### PR TITLE
Add support for MapBox hosting compositing

### DIFF
--- a/src/layer.js
+++ b/src/layer.js
@@ -205,6 +205,18 @@ mapbox.layer.prototype.composite = function(x) {
     if (x) this._composite = true;
     else this._composite = false;
     return this;
-}
+};
+
+// we need to redraw map due to compositing
+mapbox.layer.prototype.enable = function(x) {
+    MM.Layer.prototype.enable.call(this, x);
+    this.map.draw();
+};
+
+// we need to redraw map due to compositing
+mapbox.layer.prototype.disable = function(x) {
+    MM.Layer.prototype.disable.call(this, x);
+    this.map.draw();
+};
 
 MM.extend(mapbox.layer, MM.Layer);

--- a/src/layer.js
+++ b/src/layer.js
@@ -156,9 +156,12 @@ mapbox.layer.prototype.draw = function() {
         }
 
         // If layer is composited by layer below it, don't draw
-        for (var j = i - 1; j >= 0; i--) {
+        for (var j = i - 1; j >= 0; j--) {
             if (this.map.getLayerAt(j).enabled) {
-                if (this.map.getLayerAt(j)._composite) return;
+                if (this.map.getLayerAt(j)._composite) {
+                    this.parent.innerHTML = '';
+                    return this;
+                }
                 else break;
             }
         }
@@ -193,8 +196,7 @@ mapbox.layer.prototype.draw = function() {
         }
     }
 
-    MM.Layer.prototype.draw.call(this);
-    return this;
+    return MM.Layer.prototype.draw.call(this);
 };
 
 mapbox.layer.prototype.composite = function(x) {

--- a/src/layer.js
+++ b/src/layer.js
@@ -160,7 +160,7 @@ mapbox.layer.prototype.draw = function() {
             if (this.map.getLayerAt(j).enabled) {
                 if (this.map.getLayerAt(j)._composite) {
                     this.parent.innerHTML = '';
-                    this.composited = false;
+                    this.compositeLayer = false;
                     return this;
                 }
                 else break;
@@ -178,8 +178,8 @@ mapbox.layer.prototype.draw = function() {
         }
         ids = ids.join(',');
 
-        if (this.composited !== ids) {
-            this.composited = ids;
+        if (this.compositeLayer !== ids) {
+            this.compositeLayer = ids;
             var that = this;
             mapbox.load(ids, function(tiledata) {
                 that.setProvider(new mapbox.provider(tiledata));
@@ -190,8 +190,8 @@ mapbox.layer.prototype.draw = function() {
 
     } else {
         // Set back to regular provider
-        if (this.composited) {
-            this.composited = false;
+        if (this.compositeLayer) {
+            this.compositeLayer = false;
             this.tilejson(this.tilejson());
             // .draw() called by .tilejson()
         }

--- a/src/layer.js
+++ b/src/layer.js
@@ -159,7 +159,7 @@ mapbox.layer.prototype.draw = function() {
         for (var j = i - 1; j >= 0; j--) {
             if (this.map.getLayerAt(j).enabled) {
                 if (this.map.getLayerAt(j)._composite) {
-                    this.parent.innerHTML = '';
+                    this.parent.style.display = 'none';
                     this.compositeLayer = false;
                     return this;
                 }
@@ -185,10 +185,12 @@ mapbox.layer.prototype.draw = function() {
                 that.setProvider(new mapbox.provider(tiledata));
                 // setProvider calls .draw()
             });
+            this.parent.style.display = '';
             return this;
         }
 
     } else {
+        this.parent.style.display = '';
         // Set back to regular provider
         if (this.compositeLayer) {
             this.compositeLayer = false;

--- a/src/layer.js
+++ b/src/layer.js
@@ -160,6 +160,7 @@ mapbox.layer.prototype.draw = function() {
             if (this.map.getLayerAt(j).enabled) {
                 if (this.map.getLayerAt(j)._composite) {
                     this.parent.innerHTML = '';
+                    this.composited = false;
                     return this;
                 }
                 else break;
@@ -167,8 +168,8 @@ mapbox.layer.prototype.draw = function() {
         }
 
         // Get map IDs for all consecutive composited layers
-        var ids = [this.id()];
-        for (var k = i + 1; k < this.map.layers.length; k++) {
+        var ids = [];
+        for (var k = i; k < this.map.layers.length; k++) {
             var l = this.map.getLayerAt(k);
             if (l.enabled) {
                 if (l._composite) ids.push(l.id());

--- a/src/layer.js
+++ b/src/layer.js
@@ -198,9 +198,9 @@ mapbox.layer.prototype.draw = function() {
 };
 
 mapbox.layer.prototype.composite = function(x) {
-    if (!arguments.length) return this.composite;
-    if (x) this.composite = true;
-    else this.composite = false;
+    if (!arguments.length) return this._composite;
+    if (x) this._composite = true;
+    else this._composite = false;
     return this;
 }
 

--- a/src/map.js
+++ b/src/map.js
@@ -124,6 +124,20 @@ mapbox.map = function(el, layer, dimensions, eventhandlers) {
         return this.insertLayerAt(0, layer);
     };
 
+    // We need to redraw after removing due to compositing
+    m.removeLayerAt = function(index) {
+        MM.Map.prototype.removeLayerAt.call(this, index);
+        MM.getFrame(this.getRedraw());
+        return this;
+    };
+
+    // We need to redraw after removing due to compositing
+    m.swapLayersAt = function(a, b) {
+        MM.Map.prototype.swapLayersAt.call(this, a, b);
+        MM.getFrame(this.getRedraw());
+        return this;
+    };
+
     return m;
 };
 

--- a/test/spec/mapbox.layer.js
+++ b/test/spec/mapbox.layer.js
@@ -96,11 +96,11 @@ describe("mapbox.layer", function() {
           expect(m.getLayerAt(2).compositeLayer).toBeFalsy();
           expect(m.getLayerAt(3).compositeLayer).toBeTruthy();
           expect(m.getLayerAt(4).compositeLayer).toBeFalsy();
-          expect(m.getLayerAt(0).parent.innerHTML).not.toEqual('');
-          expect(m.getLayerAt(1).parent.innerHTML).toEqual('');
-          expect(m.getLayerAt(2).parent.innerHTML).not.toEqual('');
-          expect(m.getLayerAt(3).parent.innerHTML).not.toEqual('');
-          expect(m.getLayerAt(4).parent.innerHTML).toEqual('');
+          expect(m.getLayerAt(0).parent.style.display).not.toEqual('none');
+          expect(m.getLayerAt(1).parent.style.display).toEqual('none');
+          expect(m.getLayerAt(2).parent.style.display).not.toEqual('none');
+          expect(m.getLayerAt(3).parent.style.display).not.toEqual('none');
+          expect(m.getLayerAt(4).parent.style.display).toEqual('none');
       });
   });
 
@@ -123,9 +123,9 @@ describe("mapbox.layer", function() {
           expect(m.getLayerAt(2).compositeLayer).toBeFalsy();
           expect(m.getLayerAt(3).compositeLayer).toBeFalsy();
           expect(m.getLayerAt(4).compositeLayer).toBeFalsy();
-          expect(m.getLayerAt(0).parent.innerHTML).not.toEqual('');
-          expect(m.getLayerAt(1).parent.innerHTML).toEqual('');
-          expect(m.getLayerAt(4).parent.innerHTML).toEqual('');
+          expect(m.getLayerAt(0).parent.style.display).not.toEqual('none');
+          expect(m.getLayerAt(1).parent.style.display).toEqual('none');
+          expect(m.getLayerAt(4).parent.style.display).toEqual('none');
       });
   });
 
@@ -160,11 +160,11 @@ describe("mapbox.layer", function() {
           expect(m.getLayerAt(2).compositeLayer).toBeFalsy();
           expect(m.getLayerAt(3).compositeLayer).toBeFalsy();
           expect(m.getLayerAt(4).compositeLayer).toBeFalsy();
-          expect(m.getLayerAt(0).parent.innerHTML).not.toEqual('');
-          expect(m.getLayerAt(1).parent.innerHTML).toEqual('');
-          expect(m.getLayerAt(2).parent.innerHTML).toEqual('');
-          expect(m.getLayerAt(3).parent.innerHTML).toEqual('');
-          expect(m.getLayerAt(4).parent.innerHTML).toEqual('');
+          expect(m.getLayerAt(0).parent.style.display).not.toEqual('none');
+          expect(m.getLayerAt(1).parent.style.display).toEqual('none');
+          expect(m.getLayerAt(2).parent.style.display).toEqual('none');
+          expect(m.getLayerAt(3).parent.style.display).toEqual('none');
+          expect(m.getLayerAt(4).parent.style.display).toEqual('none');
       });
   });
 });

--- a/test/spec/mapbox.layer.js
+++ b/test/spec/mapbox.layer.js
@@ -91,11 +91,11 @@ describe("mapbox.layer", function() {
       });
       waits(600);
       runs(function() {
-          expect(m.getLayerAt(0).composited).toBeTruthy();
-          expect(m.getLayerAt(1).composited).toBeFalsy();
-          expect(m.getLayerAt(2).composited).toBeFalsy();
-          expect(m.getLayerAt(3).composited).toBeTruthy();
-          expect(m.getLayerAt(4).composited).toBeFalsy();
+          expect(m.getLayerAt(0).compositeLayer).toBeTruthy();
+          expect(m.getLayerAt(1).compositeLayer).toBeFalsy();
+          expect(m.getLayerAt(2).compositeLayer).toBeFalsy();
+          expect(m.getLayerAt(3).compositeLayer).toBeTruthy();
+          expect(m.getLayerAt(4).compositeLayer).toBeFalsy();
           expect(m.getLayerAt(0).parent.innerHTML).not.toEqual('');
           expect(m.getLayerAt(1).parent.innerHTML).toEqual('');
           expect(m.getLayerAt(2).parent.innerHTML).not.toEqual('');
@@ -118,11 +118,11 @@ describe("mapbox.layer", function() {
       });
       waits(600);
       runs(function() {
-          expect(m.getLayerAt(0).composited).toBeTruthy();
-          expect(m.getLayerAt(1).composited).toBeFalsy();
-          expect(m.getLayerAt(2).composited).toBeFalsy();
-          expect(m.getLayerAt(3).composited).toBeFalsy();
-          expect(m.getLayerAt(4).composited).toBeFalsy();
+          expect(m.getLayerAt(0).compositeLayer).toBeTruthy();
+          expect(m.getLayerAt(1).compositeLayer).toBeFalsy();
+          expect(m.getLayerAt(2).compositeLayer).toBeFalsy();
+          expect(m.getLayerAt(3).compositeLayer).toBeFalsy();
+          expect(m.getLayerAt(4).compositeLayer).toBeFalsy();
           expect(m.getLayerAt(0).parent.innerHTML).not.toEqual('');
           expect(m.getLayerAt(1).parent.innerHTML).toEqual('');
           expect(m.getLayerAt(4).parent.innerHTML).toEqual('');
@@ -143,11 +143,11 @@ describe("mapbox.layer", function() {
           for (var i = 0; i < 5; i++) {
               t[i].layer.draw();
           }
-          expect(m.getLayerAt(0).composited).toBeTruthy();
-          expect(m.getLayerAt(1).composited).toBeFalsy();
-          expect(m.getLayerAt(2).composited).toBeFalsy();
-          expect(m.getLayerAt(3).composited).toBeTruthy();
-          expect(m.getLayerAt(4).composited).toBeFalsy();
+          expect(m.getLayerAt(0).compositeLayer).toBeTruthy();
+          expect(m.getLayerAt(1).compositeLayer).toBeFalsy();
+          expect(m.getLayerAt(2).compositeLayer).toBeFalsy();
+          expect(m.getLayerAt(3).compositeLayer).toBeTruthy();
+          expect(m.getLayerAt(4).compositeLayer).toBeFalsy();
           m.getLayerAt(2).composite(true);
           for (var i = 0; i < 5; i++) {
               t[i].layer.draw();
@@ -155,11 +155,11 @@ describe("mapbox.layer", function() {
       });
       waits(50);
       runs(function() {
-          expect(m.getLayerAt(0).composited).toBeTruthy();
-          expect(m.getLayerAt(1).composited).toBeFalsy();
-          expect(m.getLayerAt(2).composited).toBeFalsy();
-          expect(m.getLayerAt(3).composited).toBeFalsy();
-          expect(m.getLayerAt(4).composited).toBeFalsy();
+          expect(m.getLayerAt(0).compositeLayer).toBeTruthy();
+          expect(m.getLayerAt(1).compositeLayer).toBeFalsy();
+          expect(m.getLayerAt(2).compositeLayer).toBeFalsy();
+          expect(m.getLayerAt(3).compositeLayer).toBeFalsy();
+          expect(m.getLayerAt(4).compositeLayer).toBeFalsy();
           expect(m.getLayerAt(0).parent.innerHTML).not.toEqual('');
           expect(m.getLayerAt(1).parent.innerHTML).toEqual('');
           expect(m.getLayerAt(2).parent.innerHTML).toEqual('');


### PR DESCRIPTION
Now, by default, consecutive MapBox tile layers composited together. Disabled layers do not interrupt compositing groupings.

Compositing can be disabled on a layer by calling: `layer.composite(false)`
