### PR TITLE
Update src/ui.js

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -4,6 +4,7 @@ mapbox.ui = function(map) {
     var ui = {
         zoomer: wax.mm.zoomer().map(map).smooth(true),
         pointselector: wax.mm.pointselector().map(map),
+        boxselector: wax.mm.boxselector().map(map),
         hash: wax.mm.hash().map(map),
         zoombox: wax.mm.zoombox().map(map),
         fullscreen: wax.mm.fullscreen().map(map),


### PR DESCRIPTION
boxselector is not initialized in ui therefore cannot be used from the api.
I have also sent a pull request in the wax library about a typo in wax / control / mm / boxselector.js
that did not allow boxselector callbacks to initialize properly.
