### PR TITLE
update calculated map properties on layer change

### DIFF
--- a/src/grid_layer.js
+++ b/src/grid_layer.js
@@ -10,8 +10,6 @@ var GridLayer = L.Class.extend({
     includes: L.Mixin.Events,
 
     options: {
-        minZoom: 0,
-        maxZoom: 18,
         template: function() { return ''; }
     },
 

--- a/src/map.js
+++ b/src/map.js
@@ -99,6 +99,7 @@ var Map = L.Map.extend({
     _initialize: function(json) {
         if (this.tileLayer) {
             this.tileLayer.setTileJSON(json);
+            this._updateLayer(this.tileLayer);
         }
 
         if (this.markerLayer && json.data && json.data[0]) {
@@ -107,6 +108,7 @@ var Map = L.Map.extend({
 
         if (this.gridLayer) {
             this.gridLayer.setTileJSON(json);
+            this._updateLayer(this.gridLayer);
         }
 
         if (this.gridControl && json.template) {
@@ -123,9 +125,6 @@ var Map = L.Map.extend({
 
             this.setView(center, zoom);
         }
-
-        this._updateLayer(this.tileLayer);
-        this._updateLayer(this.gridLayer);
     },
 
     _updateLayer: function(layer) {


### PR DESCRIPTION
This recalculates zoom bounds and attribution when layers have changed (map is finished initializing, or 'ready' is called on a layer). Does this seem reasonably nice?

This would fix #308 and #317
