### PR TITLE
fix for retina markers

### DIFF
--- a/theme/style.css
+++ b/theme/style.css
@@ -178,6 +178,11 @@ a.mapbox-icon-twitter {
     padding: 5px 8px;
 }
 
+/* Fix for retina markers */
+.leaflet-marker-icon {
+  background-size: 100%;
+}
+
 /* General Toolbar Overrides */
 
 .leaflet-bar, .leaflet-touch .leaflet-bar {


### PR DESCRIPTION
This fix forces the background image size of markers to exactly match  the size of the container. This will work as long as our marker containers match the size of the intended background image size, which they all do now.
