### PR TITLE
Remove trailing comma from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,6 +12,6 @@
     "node_modules",
     "bower_components",
     "test",
-    "examples",
+    "examples"
   ]
 }


### PR DESCRIPTION
Otherwise, bower can't parse the JSON.

//cc @skalnik
