### PR TITLE
Fixed broken link from L.mapbox.map page to L.map

### DIFF
--- a/_posts/api/v1.6.1/0200-01-01-l-mapbox-map.html
+++ b/_posts/api/v1.6.1/0200-01-01-l-mapbox-map.html
@@ -8,7 +8,7 @@ permalink: /api/v1.6.1/l-mapbox-map
 {% raw %}<h2 id="section-l-mapbox-map">L.mapbox.map(element, id|url|tilejson, options)</h2>
 <p>Create and automatically configure a map with layers, markers, and
 interactivity.</p>
-<p><span class='leaflet'><em>Extends</em>: <code><a href="/mapbox.js/api/v1.6.1/l-map">L.Map</a></code></span></p>
+<p><span class='leaflet'><em>Extends</em>: <code><a href="/mapbox.js/api/v1.6.1/l-map-class">L.Map</a></code></span></p>
 <table>
 <thead>
 <tr>


### PR DESCRIPTION
Was linking to .../l-map, but actual page is .../l-map-class!
