### PR TITLE
make marker popups work better

### DIFF
--- a/theme/style.css
+++ b/theme/style.css
@@ -757,9 +757,9 @@
 /* Browser Fixes
 ------------------------------------------------------- */
 /* Map is broken in FF if you have max-width: 100% on tiles */
-.leaflet-container img.leaflet-tile { max-width:none; }
+.leaflet-container img.leaflet-tile { max-width:none !important; }
 /* Stupid Android 2 doesn't understand "max-width: none" properly */
-.leaflet-container img.leaflet-image-layer { max-width:15000px; }
+.leaflet-container img.leaflet-image-layer { max-width:15000px !important; }
 /* workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=888319 */
 .leaflet-overlay-pane svg { -moz-user-select:none; }
 /* Older IEs don't support the translateY property for display animation */

--- a/theme/style.css
+++ b/theme/style.css
@@ -1,13 +1,14 @@
 /* general typography */
 .leaflet-container {
   background:#fff;
-  font:15px/25px 'Helvetica Neue', Arial, Helvetica, sans-serif;
+  font:12px/20px 'Helvetica Neue', Arial, Helvetica, sans-serif;
   color:#404040;
   color:rgba(0,0,0,0.75);
   outline:0;
   overflow:hidden;
   -ms-touch-action:none;
   }
+
 .leaflet-container *,
 .leaflet-container *:after,
 .leaflet-container *:before {
@@ -15,6 +16,11 @@
      -moz-box-sizing:border-box;
           box-sizing:border-box;
   }
+
+.leaflet-container .marker-description {
+  max-height: 300px;
+  overflow: auto;
+}
 
 .leaflet-container h1,
 .leaflet-container h2,
@@ -24,9 +30,14 @@
 .leaflet-container h6,
 .leaflet-container p {
   font-size:15px;
-  line-height:25px;
+  line-height:20px;
   margin:0 0 10px;
   }
+
+.leaflet-container img {
+  margin-bottom: 10px;
+  }
+
 .mapbox-small,
 .leaflet-control-attribution,
 .leaflet-control-scale,
@@ -746,9 +757,9 @@
 /* Browser Fixes
 ------------------------------------------------------- */
 /* Map is broken in FF if you have max-width: 100% on tiles */
-.leaflet-container img { max-width:none!important; }
+.leaflet-container img.leaflet-tile { max-width:none; }
 /* Stupid Android 2 doesn't understand "max-width: none" properly */
-.leaflet-container img.leaflet-image-layer { max-width:15000px!important; }
+.leaflet-container img.leaflet-image-layer { max-width:15000px; }
 /* workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=888319 */
 .leaflet-overlay-pane svg { -moz-user-select:none; }
 /* Older IEs don't support the translateY property for display animation */

--- a/theme/style.css
+++ b/theme/style.css
@@ -17,11 +17,6 @@
           box-sizing:border-box;
   }
 
-.leaflet-container .marker-description {
-  max-height: 300px;
-  overflow: auto;
-}
-
 .leaflet-container h1,
 .leaflet-container h2,
 .leaflet-container h3,

--- a/theme/style.css
+++ b/theme/style.css
@@ -29,7 +29,7 @@
   margin:0 0 10px;
   }
 
-.leaflet-container img {
+.leaflet-container .marker-description img {
   margin-bottom: 10px;
   }
 


### PR DESCRIPTION
- Added overflow-auto and max height to popups
- Fixed overly broad and aggressive rule intended for tiles that was interfering with image styles in popups
- Made base type styles smaller

From:
![screen shot 2014-01-28 at 3 26 18 pm](https://f.cloud.github.com/assets/108094/2023321/9da8ac22-885a-11e3-8e26-d0e365849c5b.png)

To:
![screen shot 2014-01-28 at 3 26 02 pm](https://f.cloud.github.com/assets/108094/2023324/a28af236-885a-11e3-9e81-5c7ab49a931f.png)
