### PR TITLE
Compress CSS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 UGLIFY = node_modules/.bin/uglifyjs
+CLEANCSS = node_modules/.bin/cleancss
 BROWSERIFY = node_modules/.bin/browserify
 
 # the default rule when someone runs simply `make`
@@ -19,11 +20,14 @@ mapbox%js:
 dist:
 	mkdir -p dist
 
-dist/mapbox.css: theme/style.css
-	cat theme/style.css > dist/mapbox.css
+dist/mapbox.css: dist/mapbox.uncompressed.css
+	$(CLEANCSS) dist/mapbox.uncompressed.css -o dist/mapbox.css
+
+dist/mapbox.uncompressed.css: theme/style.css
+	cat theme/style.css > dist/mapbox.uncompressed.css
 
 dist/mapbox.standalone.css: theme/style.css
-	cat theme/style.css > dist/mapbox.standalone.css
+	cat theme/style.css | $(CLEANCSS) > dist/mapbox.standalone.css
 
 theme/images: theme/images/icons.svg
 	./theme/images/render.sh

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "mocha-phantomjs": "3.1.6",
     "happen": "0.1.3",
     "browserify": "3.23.1",
-    "jshint": "2.4.2"
+    "jshint": "2.4.2",
+    "clean-css": "~2.0.7"
   },
   "optionalDependencies": {},
   "engines": {


### PR DESCRIPTION
This reduces CSS weight from 20KB to 16KB by running clean-css over the
file. I think this is worth it, since it doesn't introduce much of a
development overhead.

As a side-effect, this would introduce mapbox.uncompressed.css, in line
with mapbox.uncompressed.js.

@tristen what do you think? CSS compression, maybe the future?
