### PR TITLE
Improve this map

### DIFF
--- a/API.md
+++ b/API.md
@@ -333,7 +333,7 @@ A map control that shows a toggleable info container. This is triggered by defau
 
 | Options | Value | Description |
 | ---- | ---- | ---- |
-| options _optional_ | object | An options object. Beyond the default options for map controls, this object has a two additional parameters: <ul><li>`editLink`: A boolean that adds an `Improve this map` link to your map allowing users to learn more and make edits to OpenStreetMap from the current map coordinates being viewed.</li><li>`sanitizer`: A function that accepts a string, and returns a sanitized result for HTML display. The default will remove dangerous script content, and is recommended.</li><li>`open`: A boolean value that controls whether attribution should be open by default.</li></ul> |
+| options _optional_ | object | An options object. Beyond the default options for map controls, this object has a two additional parameters: <ul><li>`editLink`: A boolean that adds an `Improve this map` link to your map allowing users to learn more and make edits to OpenStreetMap from the current map coordinates being viewed.</li><li>`sanitizer`: A function that accepts a string, and returns a sanitized result for HTML display. The default will remove dangerous script content, and is recommended.</li><li>`open`: A boolean that controls whether attribution should be open by default.</li></ul> |
 
 _Example_:
 

--- a/API.md
+++ b/API.md
@@ -333,7 +333,7 @@ A map control that shows a toggleable info container. This is triggered by defau
 
 | Options | Value | Description |
 | ---- | ---- | ---- |
-| options _optional_ | object | An options object. Beyond the default options for map controls, this object has a two additional parameters: <ul><li>`editLink`: A boolean that adds an `Improve this map` link to your map allowing users to make edits to OpenStreetMap from the current map coordinates being viewed.</li><li>`sanitizer`: A function that accepts a string, and returns a sanitized result for HTML display. The default will remove dangerous script content, and is recommended.</li></ul> |
+| options _optional_ | object | An options object. Beyond the default options for map controls, this object has a two additional parameters: <ul><li>`editLink`: A boolean that adds an `Improve this map` link to your map allowing users to learn more and make edits to OpenStreetMap from the current map coordinates being viewed.</li><li>`sanitizer`: A function that accepts a string, and returns a sanitized result for HTML display. The default will remove dangerous script content, and is recommended.</li><li>`open`: A boolean value that controls whether attribution should be open by default.</li></ul> |
 
 _Example_:
 

--- a/src/info_control.js
+++ b/src/info_control.js
@@ -98,12 +98,12 @@ var InfoControl = L.Control.extend({
         this._content.innerHTML += info.join(' | ');
 
         if (this.options.editLink && !L.Browser.mobile) {
-            this._content.innerHTML += (info.length) ? ' | ' : '';
             var edit = L.DomUtil.create('a', '', this._content);
             edit.href = '#';
+            edit.className = 'mapbox-improve-link';
             edit.innerHTML = 'Improve this map';
-            edit.title = 'Edit in OpenStreetMap';
-            L.DomEvent.on(edit, 'click', L.bind(this._osmlink, this), this);
+            edit.title = 'Improve this map';
+            L.DomEvent.on(edit, 'click', L.bind(this._editlink, this), this);
         }
 
         // If there are no results in _info then hide this.
@@ -111,10 +111,10 @@ var InfoControl = L.Control.extend({
         return this;
     },
 
-    _osmlink: function() {
+    _editlink: function() {
         var center = this._map.getCenter();
         var z = this._map.getZoom();
-        window.open('http://www.openstreetmap.org/edit?' + 'zoom=' + z +
+        window.open('http://www.mapbox.com/map-feedback?' + 'zoom=' + z +
         '&lat=' + center.lat + '&lon=' + center.lng);
     },
 

--- a/src/info_control.js
+++ b/src/info_control.js
@@ -112,9 +112,11 @@ var InfoControl = L.Control.extend({
     },
 
     _editlink: function() {
+        var tilejson = this._tilejson || this._map._tilejson || {};
+        var id = tilejson.id || '';
         var center = this._map.getCenter();
         var z = this._map.getZoom();
-        var url = 'https://www.mapbox.com/map-feedback/?' + 'zoom=' + z + '&lat=' + center.lat + '&lon=' + center.lng;
+        var url = 'https://www.mapbox.com/map-feedback/?id=' + id + '&zoom=' + z + '&lat=' + center.lat + '&lon=' + center.lng;
         window.open(url);
     },
 

--- a/src/info_control.js
+++ b/src/info_control.js
@@ -116,7 +116,7 @@ var InfoControl = L.Control.extend({
         var id = tilejson.id || '';
         var center = this._map.getCenter();
         var z = this._map.getZoom();
-        var url = 'https://www.mapbox.com/map-feedback/#' + id + ',' + center.lng + ',' + center.lat + ',' + z;
+        var url = 'https://www.mapbox.com/map-feedback/#' + id + '/' + center.lng + '/' + center.lat + '/' + z;
         window.open(url);
     },
 

--- a/src/info_control.js
+++ b/src/info_control.js
@@ -116,7 +116,7 @@ var InfoControl = L.Control.extend({
         var id = tilejson.id || '';
         var center = this._map.getCenter();
         var z = this._map.getZoom();
-        var url = 'https://www.mapbox.com/map-feedback/?id=' + id + '&zoom=' + z + '&lat=' + center.lat + '&lon=' + center.lng;
+        var url = 'https://www.mapbox.com/map-feedback/#' + id + ',' + center.lng + ',' + center.lat + ',' + z;
         window.open(url);
     },
 

--- a/src/info_control.js
+++ b/src/info_control.js
@@ -4,7 +4,8 @@ var InfoControl = L.Control.extend({
     options: {
         position: 'bottomright',
         sanitizer: require('sanitize-caja'),
-        editLink: true
+        editLink: true,
+        open: false
     },
 
     initialize: function(options) {
@@ -21,10 +22,16 @@ var InfoControl = L.Control.extend({
             this._container.className += ' mapbox-control-info-right';
         }
 
+        if (this.options.open) this._showInfo();
+
         var link = L.DomUtil.create('a', 'mapbox-info-toggle mapbox-icon mapbox-icon-info', this._container);
         link.href = '#';
 
-        L.DomEvent.addListener(link, 'click', this._showInfo, this);
+        L.DomEvent.addListener(link, 'click', function(e) {
+            L.DomEvent.preventDefault(e);
+            this._showInfo();
+        }, this);
+
         L.DomEvent.disableClickPropagation(this._container);
 
         for (var i in map._layers) {
@@ -62,9 +69,7 @@ var InfoControl = L.Control.extend({
     },
 
     _showInfo: function(e) {
-        L.DomEvent.preventDefault(e);
         if (this._active === true) return this._hidecontent();
-
         L.DomUtil.addClass(this._container, 'active');
         this._active = true;
         this._update();

--- a/src/info_control.js
+++ b/src/info_control.js
@@ -114,8 +114,8 @@ var InfoControl = L.Control.extend({
     _editlink: function() {
         var center = this._map.getCenter();
         var z = this._map.getZoom();
-        window.open('http://www.mapbox.com/map-feedback?' + 'zoom=' + z +
-        '&lat=' + center.lat + '&lon=' + center.lng);
+        var url = 'https://www.mapbox.com/map-feedback/?' + 'zoom=' + z + '&lat=' + center.lat + '&lon=' + center.lng;
+        window.open(url);
     },
 
     _onLayerAdd: function(e) {

--- a/src/info_control.js
+++ b/src/info_control.js
@@ -4,7 +4,7 @@ var InfoControl = L.Control.extend({
     options: {
         position: 'bottomright',
         sanitizer: require('sanitize-caja'),
-        editLink: false
+        editLink: true
     },
 
     initialize: function(options) {

--- a/test/spec/info_control.js
+++ b/test/spec/info_control.js
@@ -1,5 +1,7 @@
 describe('L.mapbox.infoControl', function() {
     'use strict';
+    var improvelink = '<a class="mapbox-improve-link" href="#" title="Improve this map">Improve this map</a>';
+
     it('constructor', function() {
         var info = L.mapbox.infoControl();
         expect(info).to.be.ok();
@@ -17,7 +19,7 @@ describe('L.mapbox.infoControl', function() {
             var info = L.mapbox.infoControl();
             info.addTo(map);
             expect(info.addInfo('foo')).to.eql(info);
-            expect(info._content.innerHTML).to.eql('foo');
+            expect(info._content.innerHTML).to.eql('foo' + improvelink);
         });
 
         it('handles multiple infos', function() {
@@ -27,7 +29,7 @@ describe('L.mapbox.infoControl', function() {
             expect(info.addTo(map)).to.eql(info);
             expect(info.addInfo('foo')).to.eql(info);
             expect(info.addInfo('bar')).to.eql(info);
-            expect(info._content.innerHTML).to.eql('foo | bar');
+            expect(info._content.innerHTML).to.eql('foo | bar' + improvelink);
         });
     });
 
@@ -46,19 +48,10 @@ describe('L.mapbox.infoControl', function() {
             info.addTo(map);
             expect(info.addInfo('foo')).to.eql(info);
             expect(info.addInfo('bar')).to.eql(info);
-            expect(info._content.innerHTML).to.eql('foo | bar');
+            expect(info._content.innerHTML).to.eql('foo | bar' + improvelink);
             expect(info.removeInfo('bar')).to.eql(info);
-            expect(info._content.innerHTML).to.eql('foo');
+            expect(info._content.innerHTML).to.eql('foo' + improvelink);
         });
-    });
-
-    it('adds an improve this map link', function() {
-        var map = L.map(document.createElement('div'));
-        var info = L.mapbox.infoControl({
-            editLink: true
-        }).addTo(map);
-
-        expect(info._content.innerText || info._content.textContent).to.eql('Improve this map');
     });
 
     it('sanitizes its content', function() {
@@ -66,8 +59,7 @@ describe('L.mapbox.infoControl', function() {
         var info = L.mapbox.infoControl().addTo(map);
 
         info.addInfo('<script></script>');
-
-        expect(info._content.innerHTML).to.eql('');
+        expect(info._content.innerHTML).to.eql(improvelink);
     });
 
     it('supports a custom sanitizer', function() {
@@ -78,6 +70,6 @@ describe('L.mapbox.infoControl', function() {
 
         info.addInfo('<script></script>');
 
-        expect(info._content.innerHTML).to.eql('<script></script>');
+        expect(info._content.innerHTML).to.eql('<script></script>' + improvelink);
     });
 });

--- a/theme/style.css
+++ b/theme/style.css
@@ -597,6 +597,13 @@
   padding: 3px 27px 3px 5px;
   border-radius:3px 13px 13px 3px;
   }
+.leaflet-container .mapbox-improve-link {
+  font-size:15px;
+  line-height:25px;
+  font-weight:bold;
+  display:block;
+  text-align:right;
+  }
 
 /* Geocoder
 ------------------------------------------------------- */

--- a/theme/style.css
+++ b/theme/style.css
@@ -582,6 +582,7 @@
 
 .map-info-container {
   background:#fff;
+  background-color:rgba(255,255,255,0.9);
   padding:3px 5px 3px 27px;
   display:none;
   position:relative;
@@ -594,12 +595,11 @@
 .mapbox-control-info-right .map-info-container {
   left: auto;
   right: 0;
-  padding: 3px 27px 3px 5px;
+  padding:4px 30px 5px 7px;
   border-radius:3px 13px 13px 3px;
   }
 .leaflet-container .mapbox-improve-link {
   font-size:15px;
-  line-height:25px;
   font-weight:bold;
   display:block;
   text-align:right;

--- a/theme/style.css
+++ b/theme/style.css
@@ -38,7 +38,7 @@
   line-height:20px;
   }
 
-.leaflet-container a            {
+.leaflet-container a {
   color:#3887BE;
   font-weight:normal;
   text-decoration:none;
@@ -278,11 +278,17 @@
   margin:0;
   box-shadow:none;
   }
-.leaflet-control-attribution a:hover,
-.map-info-container a:hover {
-  color:inherit;
-  text-decoration:underline;
+
+.leaflet-control-attribution a,
+.map-info-container a {
+  color:#404040;
+  color:rgba(0,0,0,0.75);
   }
+  .leaflet-control-attribution a:hover,
+  .map-info-container a:hover {
+    color:inherit;
+    text-decoration:underline;
+    }
 
 .leaflet-control-attribution,
 .leaflet-control-scale-line {
@@ -706,6 +712,13 @@
   .leaflet-container.dark .leaflet-bar a:hover {
     background-color:#505050;
     }
+
+.dark .leaflet-control-attribution a,
+.dark .map-info-container a,
+.dark .leaflet-control-attribution a:hover,
+.dark .map-info-container a:hover {
+  color:#fff;
+  }
 
 .leaflet-container.dark .mapbox-info-toggle,
 .leaflet-container.dark .map-info-container,


### PR DESCRIPTION
This commit:
- Surfaces the `editlink` option in infoControl to be on by default
- Adds an `open` option to have attribution turned on by default
- Style, "Improve this map" link. Bump up font size and weight and drop to a new line.

References https://github.com/mapbox/www.mapbox.com/issues/3239
#### TODO
- [x] Finalize style
- [x] Fix tests
