### PR TITLE
Fix IE8 compatibility of util.strict_oneof

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -21,7 +21,7 @@ module.exports = {
         }
     },
     strict_oneof: function(_, values) {
-        if (values.indexOf(_) == -1) {
+        if (!contains(_, values)) {
             throw new Error('Invalid argument: ' + _ + ' given, valid values are ' +
                 values.join(', '));
         }
@@ -34,3 +34,11 @@ module.exports = {
         return new L.LatLngBounds([[_[1], _[0]], [_[3], _[2]]]);
     }
 };
+
+function contains(item, list) {
+    if (!list || !list.length) return false;
+    for (var i = 0; i < list.length; i++) {
+        if (list[i] == item) return true;
+    }
+    return false;
+}

--- a/test/spec/util.js
+++ b/test/spec/util.js
@@ -32,6 +32,21 @@ describe("util", function() {
         });
     });
 
+    describe('#strict_oneof', function() {
+        it('does not throw an error when in list', function() {
+            expect(function() {
+                private.util.strict_oneof('a', ['a']);
+            }).to.not.throwException();
+        });
+        it('throws an error when not in list', function() {
+            expect(function() {
+                private.util.strict_oneof('c', ['a']);
+            }).to.throwException(function(e) {
+                expect(e.message).to.eql('Invalid argument: c given, valid values are a');
+            });
+        });
+    });
+
     describe('#strip_tags', function() {
         it('strips a basic tag', function() {
             expect(private.util.strip_tags('<div>foo</div>')).to.eql('foo');


### PR DESCRIPTION
Do not use indexOf for argument comparisons, because it is not
supported in IE<9. Instead uses simple list iteration.

Need to test this in IE8 to be sure.
