### PR TITLE
Populate attribution control with layer attribution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BROWSERIFY = node_modules/.bin/browserify
 # the default rule when someone runs simply `make`
 all: \
 	dist/mapbox.js \
-	dist/mapbox.private.js \
+	dist/mapbox.internals.js \
 	dist/mapbox.standalone.js \
 	dist/mapbox.css \
 	dist/mapbox.standalone.css \
@@ -45,8 +45,8 @@ dist/mapbox.standalone.uncompressed.js: node_modules/.install dist $(shell $(BRO
 	$(BROWSERIFY) --debug mapbox.js > $@
 
 # assemble an uncompressed but complete library for development
-dist/mapbox.private.js: node_modules/.install dist $(shell $(BROWSERIFY) --list private.js)
-	$(BROWSERIFY) --debug private.js > $@
+dist/mapbox.internals.js: node_modules/.install dist $(shell $(BROWSERIFY) --list internals.js)
+	$(BROWSERIFY) --debug internals.js > $@
 
 # compress mapbox.js with [uglify-js](https://github.com/mishoo/UglifyJS),
 # with name manging (m) and compression (c) enabled

--- a/internals.js
+++ b/internals.js
@@ -1,4 +1,4 @@
-window.private = {
+window.internals = {
     url: require('./src/url'),
     config: require('./src/config'),
     util: require('./src/util'),

--- a/src/info_control.js
+++ b/src/info_control.js
@@ -51,13 +51,13 @@ var InfoControl = L.Control.extend({
         if (!text) return this;
         if (!this._info[text]) this._info[text] = 0;
 
-        this._info[text]++;
+        this._info[text] = true;
         return this._update();
     },
 
     removeInfo: function (text) {
         if (!text) return this;
-        if (this._info[text]) this._info[text]--;
+        if (this._info[text]) this._info[text] = false;
         return this._update();
     },
 
@@ -114,11 +114,12 @@ var InfoControl = L.Control.extend({
     },
 
     _onLayerAdd: function(e) {
-        if (e.layer.getAttribution) {
+        if (e.layer.getAttribution && e.layer.getAttribution()) {
             this.addInfo(e.layer.getAttribution());
-        }
-        if ('on' in e.layer && e.layer.getAttribution) {
-            e.layer.on('ready', L.bind(function() { this.addInfo(e.layer.getAttribution()); }, this));
+        } else if ('on' in e.layer && e.layer.getAttribution) {
+            e.layer.on('ready', L.bind(function() {
+                this.addInfo(e.layer.getAttribution());
+            }, this));
         }
     },
 

--- a/src/map.js
+++ b/src/map.js
@@ -135,6 +135,10 @@ var LMap = L.Map.extend({
             this.infoControl.addInfo(layer.options.infoControl);
         }
 
+        if (this.attributionControl && this._loaded) {
+            this.attributionControl.addAttribution(layer.options.attribution);
+        }
+
         if (!(L.stamp(layer) in this._zoomBoundLayers) &&
                 (layer.options.maxZoom || layer.options.minZoom)) {
             this._zoomBoundLayers[L.stamp(layer)] = layer;

--- a/src/map.js
+++ b/src/map.js
@@ -135,8 +135,8 @@ var LMap = L.Map.extend({
             this.infoControl.addInfo(layer.options.infoControl);
         }
 
-        if (this.attributionControl && this._loaded) {
-            this.attributionControl.addAttribution(layer.options.attribution);
+        if (this.attributionControl && this._loaded && layer.getAttribution) {
+            this.attributionControl.addAttribution(layer.getAttribution());
         }
 
         if (!(L.stamp(layer) in this._zoomBoundLayers) &&

--- a/test/index.html
+++ b/test/index.html
@@ -19,7 +19,7 @@
   <script src="../node_modules/Leaflet/dist/leaflet-src.js"></script>
 
   <script src="../dist/mapbox.uncompressed.js"></script>
-  <script src="../dist/mapbox.private.js"></script>
+  <script src="../dist/mapbox.internals.js"></script>
 
   <script>
     mocha.setup('bdd');

--- a/test/spec/grid.js
+++ b/test/spec/grid.js
@@ -1,11 +1,11 @@
 describe('grid', function () {
     it('returns data for a given coordinate', function () {
-        var grid = private.grid(helpers.gridJson);
+        var grid = internals.grid(helpers.gridJson);
         expect(grid(63, 0)).to.eql({admin: "Spain"});
     });
 
     it('returns undefined where there is no data', function () {
-        var grid = private.grid(helpers.gridJson);
+        var grid = internals.grid(helpers.gridJson);
         expect(grid(0, 0)).to.be(undefined);
     });
 });

--- a/test/spec/info_control.js
+++ b/test/spec/info_control.js
@@ -80,4 +80,19 @@ describe('L.mapbox.infoControl', function() {
 
         expect(info._content.innerHTML).to.eql('<script></script>');
     });
+
+    it('receives attribution from a layer', function(done) {
+        var server = sinon.fakeServer.create();
+        var element = document.createElement('div');
+        var map = L.mapbox.map(element, 'mapbox.map-0l53fhk2');
+
+        map.on('ready', function() {
+            expect(map.infoControl._content.innerHTML).to.eql('Data provided by NatureServe in collaboration with Robert Ridgely');
+            done();
+        });
+
+        server.respondWith("GET", "http://a.tiles.mapbox.com/v3/mapbox.map-0l53fhk2.json",
+            [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.tileJSON)]);
+        server.respond();
+    });
 });

--- a/test/spec/info_control.js
+++ b/test/spec/info_control.js
@@ -88,6 +88,8 @@ describe('L.mapbox.infoControl', function() {
 
         map.on('ready', function() {
             expect(map.infoControl._content.innerHTML).to.eql('Data provided by NatureServe in collaboration with Robert Ridgely');
+            map.removeLayer(map.tileLayer);
+            expect(map.infoControl._content.innerHTML).to.eql('');
             done();
         });
 

--- a/test/spec/map.js
+++ b/test/spec/map.js
@@ -229,6 +229,8 @@ describe('L.mapbox.map', function() {
 
             map.on('ready', function() {
                 expect(map.attributionControl._container.innerHTML).to.eql('Data provided by NatureServe in collaboration with Robert Ridgely');
+                map.removeLayer(map.tileLayer);
+                expect(map.attributionControl._container.innerHTML).to.eql('');
                 done();
             });
 

--- a/test/spec/map.js
+++ b/test/spec/map.js
@@ -220,5 +220,21 @@ describe('L.mapbox.map', function() {
                 expect(e.message).to.eql('Map container is already initialized.');
             });
         });
+
+        it('attributionControl enabled', function(done) {
+            var map = L.mapbox.map(element, 'mapbox.map-0l53fhk2', {
+                infoControl: false,
+                attributionControl: true
+            });
+
+            map.on('ready', function() {
+                expect(map.attributionControl._container.innerHTML).to.eql('Data provided by NatureServe in collaboration with Robert Ridgely');
+                done();
+            });
+
+            server.respondWith("GET", "http://a.tiles.mapbox.com/v3/mapbox.map-0l53fhk2.json",
+                [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.tileJSON)]);
+            server.respond();
+        });
     });
 });

--- a/test/spec/request.js
+++ b/test/spec/request.js
@@ -15,7 +15,7 @@ describe('request', function() {
         server.respondWith("GET", "data/tilejson.json",
             [200, { "Content-Type": "application/json" }, '{"status": "success"}']);
 
-        expect(private.request('data/tilejson.json', function(err, data) {
+        expect(internals.request('data/tilejson.json', function(err, data) {
             expect(err).to.be(null);
             expect(data).to.eql({status: 'success'});
             done();
@@ -28,7 +28,7 @@ describe('request', function() {
         server.respondWith("GET", "data/tilejson.json",
             [500, { "Content-Type": "application/json" }, '{"status": "error"}']);
 
-        expect(private.request('data/tilejson.json', function(err, data) {
+        expect(internals.request('data/tilejson.json', function(err, data) {
             expect(err).to.be.ok();
             expect(data).to.be(null);
             done();

--- a/test/spec/url.js
+++ b/test/spec/url.js
@@ -1,24 +1,24 @@
 describe("url", function() {
     describe('#base', function() {
         it("returns 'http://a.tiles.mapbox.com/v3/'", function() {
-            expect(private.url.base()).to.equal('http://a.tiles.mapbox.com/v3/');
+            expect(internals.url.base()).to.equal('http://a.tiles.mapbox.com/v3/');
         });
 
         it("returns a subdomain based on the number", function() {
-            expect(private.url.base(1)).to.equal('http://b.tiles.mapbox.com/v3/');
-            expect(private.url.base(6)).to.equal('http://c.tiles.mapbox.com/v3/');
+            expect(internals.url.base(1)).to.equal('http://b.tiles.mapbox.com/v3/');
+            expect(internals.url.base(6)).to.equal('http://c.tiles.mapbox.com/v3/');
         });
     });
     describe('#secureFlag', function() {
         it('adds a json flag to urls when the page is secure', function() {
-            private.url.isSSL = function() { return true; };
-            expect(private.url.secureFlag('foo')).to.equal('foo?secure');
-            expect(private.url.secureFlag('foo?foo=bar')).to.equal('foo?foo=bar&secure');
+            internals.url.isSSL = function() { return true; };
+            expect(internals.url.secureFlag('foo')).to.equal('foo?secure');
+            expect(internals.url.secureFlag('foo?foo=bar')).to.equal('foo?foo=bar&secure');
         });
         it('does not add an ssl flag when pages are not ssl', function() {
-            private.url.isSSL = function() { return false; };
-            expect(private.url.secureFlag('foo')).to.equal('foo');
-            expect(private.url.secureFlag('foo?foo=bar')).to.equal('foo?foo=bar');
+            internals.url.isSSL = function() { return false; };
+            expect(internals.url.secureFlag('foo')).to.equal('foo');
+            expect(internals.url.secureFlag('foo?foo=bar')).to.equal('foo?foo=bar');
         });
     });
 });

--- a/test/spec/util.js
+++ b/test/spec/util.js
@@ -1,31 +1,31 @@
 describe("util", function() {
     describe('#lbounds', function() {
         it('generates a L.LLatLngBounds object', function() {
-            expect(private.util.lbounds([0, 1, 2, 3])).to.be.a(L.LatLngBounds);
+            expect(internals.util.lbounds([0, 1, 2, 3])).to.be.a(L.LatLngBounds);
         });
     });
 
     describe('#strict', function() {
         it('throws an error on object/string', function() {
             expect(function() {
-                private.util.strict({}, 'string');
+                internals.util.strict({}, 'string');
             }).to.throwException(function(e) {
                 expect(e.message).to.eql('Invalid argument: string expected');
             });
             expect(function() {
-                private.util.strict('foo', 'object');
+                internals.util.strict('foo', 'object');
             }).to.throwException(function(e) {
                 expect(e.message).to.eql('Invalid argument: object expected');
             });
         });
         it('throws an error on string/number', function() {
             expect(function() {
-                private.util.strict(5, 'string');
+                internals.util.strict(5, 'string');
             }).to.throwException(function(e) {
                 expect(e.message).to.eql('Invalid argument: string expected');
             });
             expect(function() {
-                private.util.strict('5', 'number');
+                internals.util.strict('5', 'number');
             }).to.throwException(function(e) {
                 expect(e.message).to.eql('Invalid argument: number expected');
             });
@@ -35,12 +35,12 @@ describe("util", function() {
     describe('#strict_oneof', function() {
         it('does not throw an error when in list', function() {
             expect(function() {
-                private.util.strict_oneof('a', ['a']);
+                internals.util.strict_oneof('a', ['a']);
             }).to.not.throwException();
         });
         it('throws an error when not in list', function() {
             expect(function() {
-                private.util.strict_oneof('c', ['a']);
+                internals.util.strict_oneof('c', ['a']);
             }).to.throwException(function(e) {
                 expect(e.message).to.eql('Invalid argument: c given, valid values are a');
             });
@@ -49,13 +49,13 @@ describe("util", function() {
 
     describe('#strip_tags', function() {
         it('strips a basic tag', function() {
-            expect(private.util.strip_tags('<div>foo</div>')).to.eql('foo');
+            expect(internals.util.strip_tags('<div>foo</div>')).to.eql('foo');
         });
         it('strips a self-closing tag', function() {
-            expect(private.util.strip_tags('foo <br /> bar')).to.eql('foo  bar');
+            expect(internals.util.strip_tags('foo <br /> bar')).to.eql('foo  bar');
         });
         it('does not botch non-tag input', function() {
-            expect(private.util.strip_tags('rabbit')).to.eql('rabbit');
+            expect(internals.util.strip_tags('rabbit')).to.eql('rabbit');
         });
     });
 });


### PR DESCRIPTION
Ensure that by default, attribution information is displayed when opting for attributionControl instead of infoControl.

So, in code, when creating a map like so:

```
L.mapbox.map('map', 'examples.c7d2024a', { infoControl: false, attributionControl: true })
```

In the case of the map above, attribution is displayed like so:

![screen shot 2014-02-07 at 12 05 24 pm](https://f.cloud.github.com/assets/98233/2112128/0e7583f0-901a-11e3-8c16-afa78f88378d.png)

Right now, when creating map like in the example above, nothing is displayed in the attribution field.

This patch likely needs work as I'm not sure I'm passing the correct information in the call to `addAttribution()`.
