### PR TITLE
center property now actually optional in tilejson

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -120,7 +120,7 @@ var LMap = L.Map.extend({
             this.shareControl._setTileJSON(json);
         }
 
-        if (!this._loaded) {
+        if (!this._loaded && json.center) {
             var zoom = json.center[2],
                 center = L.latLng(json.center[1], json.center[0]);
 

--- a/test/spec/map.js
+++ b/test/spec/map.js
@@ -128,6 +128,12 @@ describe('L.mapbox.map', function() {
             var map = L.mapbox.map(element, 'mapbox.map-0l53fhk2', {shareControl: {position: 'bottomleft'}});
             expect(map.shareControl.options.position).to.equal('bottomleft');
         });
+
+        it('supports tilejson without a center property', function(){
+            var map = L.mapbox.map(element, helpers.tileJSON_nocenter);
+            expect(map._loaded).not.to.be.ok();
+
+        });
     });
 
     describe('layers', function() {

--- a/test/util.js
+++ b/test/util.js
@@ -93,6 +93,23 @@ helpers.tileJSON_autoscale = {
   "maxzoom": 19
 };
 
+helpers.tileJSON_nocenter = {
+    "attribution": "<a href='https://www.mapbox.com/about/maps/' target='_blank'>&copy; Mapbox &copy; OpenStreetMap</a> <a class='mapbox-improve-map' href='https://www.mapbox.com/map-feedback/' target='_blank'>Improve this map</a>",
+    "autoscale": true,
+    "bounds": [-180, -85.0511, 180, 85.0511],
+    "data": ["http://a.tiles.mapbox.com/v3/examples.h8e9h88l/markers.geojsonp"],
+    "geocoder": "http://a.tiles.mapbox.com/v3/examples.h8e9h88l/geocode/{query}.jsonp",
+    "id": "examples.h8e9h88l",
+    "maxzoom": 22,
+    "minzoom": 0,
+    "name": "My Mapbox Streets Map",
+    "private": true,
+    "scheme": "xyz",
+    "tilejson": "2.0.0",
+    "tiles": ["http://a.tiles.mapbox.com/v3/examples.h8e9h88l/{z}/{x}/{y}.png"],
+    "webpage": "http://a.tiles.mapbox.com/v3/examples.h8e9h88l/page.html"
+};
+
 helpers.geoJson = {
     type: 'FeatureCollection',
     features: [{


### PR DESCRIPTION
Fixed bug where center property wasn't optional in [tilejson](https://github.com/mapbox/tilejson-spec/tree/master/2.1.0). Maps without a center property will wait for map.setView()
