### PR TITLE
fix for marker image width problem

### DIFF
--- a/theme/style.css
+++ b/theme/style.css
@@ -754,6 +754,8 @@
 ------------------------------------------------------- */
 /* Map is broken in FF if you have max-width: 100% on tiles */
 .leaflet-container img.leaflet-tile { max-width:none !important; }
+/* Markers are broken in FF/IE if you have max-width: 100% on marker images */
+.leaflet-container img.leaflet-marker-icon { max-width:none !important; }
 /* Stupid Android 2 doesn't understand "max-width: none" properly */
 .leaflet-container img.leaflet-image-layer { max-width:15000px !important; }
 /* workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=888319 */

--- a/theme/style.css
+++ b/theme/style.css
@@ -755,7 +755,7 @@
 /* Map is broken in FF if you have max-width: 100% on tiles */
 .leaflet-container img.leaflet-tile { max-width:none !important; }
 /* Markers are broken in FF/IE if you have max-width: 100% on marker images */
-.leaflet-container img.leaflet-marker-icon { max-width:none !important; }
+.leaflet-container img.leaflet-marker-icon { max-width:none; }
 /* Stupid Android 2 doesn't understand "max-width: none" properly */
 .leaflet-container img.leaflet-image-layer { max-width:15000px !important; }
 /* workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=888319 */


### PR DESCRIPTION
Fixing https://github.com/mapbox/base/issues/115 here, even though it's not an issue with mapbox.js in itself, but an issue with styling done to the `img` element that might interfere with mapbox.js.
