### PR TITLE
Set defaults for min/max Zoom in L.mapbox.tileLayer

### DIFF
--- a/src/tile_layer.js
+++ b/src/tile_layer.js
@@ -61,8 +61,8 @@ var TileLayer = L.TileLayer.extend({
         L.extend(this.options, {
             tiles: json.tiles,
             attribution: json.attribution,
-            minZoom: json.minzoom,
-            maxZoom: json.maxzoom,
+            minZoom: json.minzoom || 0,
+            maxZoom: json.maxzoom || 18,
             autoscale: json.autoscale || false,
             tms: json.scheme === 'tms',
             bounds: json.bounds && util.lbounds(json.bounds)


### PR DESCRIPTION
When overwriting TileLayer options from TileJSON the defaults of min/max Zoom gets overwritten with `undefined` when not set in TileJSON which causes the map to break.

This occurs when a map is initialized with the smallest possible TileJSON

``` json
{
  "tilejson": "2.0.0",
  "tiles": [ "http://a.tiles.mapbox.com/v3/examples.map-9ijuk24y/{z}/{x}/{y}.png" ]
}
```
