### PR TITLE
Revised attribution

### DIFF
--- a/API.md
+++ b/API.md
@@ -11,7 +11,7 @@ interactivity.
 | ---- | ---- | ---- |
 | element (_required_) | string | Must be the id of an element, or a DOM element reference. |
 | id _or_ url _or_ tilejson | __string__ if _id_ or _url_ __object__ if _tilejson_ | url can be <ul><li>a map `id` string `examples.map-foo`</li><li> a URL to TileJSON, like `http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json`</li><li>a [TileJSON](https://www.mapbox.com/developers/tilejson/) object, from your own Javascript code</li></ul> |
-| options | object | If provided, it is the same options as provided to L.Map with the following additions: <ul><li>`tileLayer` L.TileLayer options. Options passed to a `L.mapbox.tileLayer` based on the TileJSON. Set to `false` to disable the `L.mapbox.tileLayer`.</li><li>`featureLayer` `L.mapbox.featureLayer` options. Options passed to a `L.mapbox.featureLayer` based on the TileJSON. Set to `false` to disable the `L.mapbox.featureLayer`.</li><li>`gridLayer` `L.mapbox.gridLayer`. Options passed to a `L.mapbox.gridLayer` based on the TileJSON. Set to `false` to disable the `L.mapbox.gridLayer`.</li><li>`legendControl` `L.mapbox.legendControl` options. Options passed to a `L.mapbox.legendControl` based on the TileJSON. Set to `false` to disable the `L.mapbox.legendControl`.</li><li>`shareControl`: Options passed to a `L.mapbox.shareControl`. Set to `false` to disable the `L.mapbox.shareControl`.</li><li>`infoControl`: Options passed to a `L.mapbox.infoControl`. Set to `false` to disable the `L.mapbox.infoControl`.</li> |
+| options | object | If provided, it is the same options as provided to L.Map with the following additions: <ul><li>`tileLayer` L.TileLayer options. Options passed to a `L.mapbox.tileLayer` based on the TileJSON. Set to `false` to disable the `L.mapbox.tileLayer`.</li><li>`featureLayer` `L.mapbox.featureLayer` options. Options passed to a `L.mapbox.featureLayer` based on the TileJSON. Set to `false` to disable the `L.mapbox.featureLayer`.</li><li>`gridLayer` `L.mapbox.gridLayer`. Options passed to a `L.mapbox.gridLayer` based on the TileJSON. Set to `false` to disable the `L.mapbox.gridLayer`.</li><li>`legendControl` `L.mapbox.legendControl` options. Options passed to a `L.mapbox.legendControl` based on the TileJSON. Set to `false` to disable the `L.mapbox.legendControl`.</li><li>`shareControl`: Options passed to a `L.mapbox.shareControl`. Set to `true` to enable the `L.mapbox.shareControl`.</li><li>`infoControl`: Options passed to a `L.mapbox.infoControl`. Set to `true` to enable the `L.mapbox.infoControl`.</li> |
 
 _Example_:
 
@@ -388,7 +388,7 @@ A map control that shows a toggleable info container. If set, attribution is aut
 _Example_:
 
     var map = L.mapbox.map('map').setView([38, -77], 5);
-    map.addControl(L.mapbox.infoControl());
+    map.addControl(L.mapbox.infoControl().addInfo('foo'));
 
 _Returns_: a `L.mapbox.infoControl` object.
 

--- a/API.md
+++ b/API.md
@@ -379,11 +379,11 @@ _Returns_: the geocoder object. The return value of this function is not useful 
 
 <span class='leaflet'>_Extends_: `L.Control`</span>
 
-A map control that shows a toggleable info container. This is triggered by default and attribution is auto-detected from active layers and added to the info container.
+A map control that shows a toggleable info container. If set, attribution is auto-detected from active layers and added to the info container.
 
 | Options | Value | Description |
 | ---- | ---- | ---- |
-| options _optional_ | object | An options object. Beyond the default options for map controls, this object has a two additional parameters: <ul><li>`sanitizer`: A function that accepts a string, and returns a sanitized result for HTML display. The default will remove dangerous script content, and is recommended.</li></ul> |
+| options _optional_ | object | An options object. Beyond the default options for map controls, this object has a one additional parameter: <ul><li>`sanitizer`: A function that accepts a string, and returns a sanitized result for HTML display. The default will remove dangerous script content, and is recommended.</li></ul> |
 
 _Example_:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * Exposes non-magic constructors like `L.mapbox.TileLayer`
 * No longer requires `embed` property from TileJSON
 * Fix Geocoder results position when controls are positioned to the right or bottom of a map.
+* AttributionControl is now default on the map. infoControl may be added as an option.
+* Improve this map link now updates it's coordinates on the AttributionControl.
 
 ## v1.6.2
 

--- a/src/info_control.js
+++ b/src/info_control.js
@@ -33,7 +33,6 @@ var InfoControl = L.Control.extend({
         }
 
         map
-            .on('moveend', this._editLink, this)
             .on('layeradd', this._onLayerAdd, this)
             .on('layerremove', this._onLayerRemove, this);
 
@@ -43,7 +42,6 @@ var InfoControl = L.Control.extend({
 
     onRemove: function(map) {
         map
-            .off('moveend', this._editLink, this)
             .off('layeradd', this._onLayerAdd, this)
             .off('layerremove', this._onLayerRemove, this);
     },
@@ -91,30 +89,10 @@ var InfoControl = L.Control.extend({
         }
 
         this._content.innerHTML += info.join(' | ');
-        this._editLink();
 
         // If there are no results in _info then hide this.
         this._container.style.display = hide;
         return this;
-    },
-
-    _editLink: function() {
-        if (!this._content.getElementsByClassName) {
-            return;
-        }
-        var link = this._content.getElementsByClassName('mapbox-improve-map');
-        if (link.length && this._map._loaded) {
-            var center = this._map.getCenter().wrap();
-            var tilejson = this._tilejson || this._map._tilejson || {};
-            var id = tilejson.id || '';
-
-            for (var i = 0; i < link.length; i++) {
-                link[i].href = link[i].href.split('#')[0] + '#' + id + '/' +
-                    center.lng.toFixed(3) + '/' +
-                    center.lat.toFixed(3) + '/' +
-                    this._map.getZoom();
-            }
-        }
     },
 
     _onLayerAdd: function(e) {

--- a/src/map.js
+++ b/src/map.js
@@ -132,7 +132,7 @@ var LMap = L.Map.extend({
         var link = this._controlContainer.getElementsByClassName('mapbox-improve-map');
         if (link.length && this._loaded) {
             var center = this.getCenter().wrap();
-            var tilejson = this._tilejson || this._map._tilejson || {};
+            var tilejson = this._tilejson || {};
             var id = tilejson.id || '';
 
             for (var i = 0; i < link.length; i++) {
@@ -155,7 +155,6 @@ var LMap = L.Map.extend({
             this.attributionControl.addAttribution(layer.getAttribution());
         }
 
-        this.off('moveend', this._editLink, this);
         this.on('moveend', this._editLink, this);
 
         if (!(L.stamp(layer) in this._zoomBoundLayers) &&

--- a/src/map.js
+++ b/src/map.js
@@ -128,9 +128,7 @@ var LMap = L.Map.extend({
     },
 
     _editLink: function() {
-        if (!this._controlContainer.getElementsByClassName) {
-            return;
-        }
+        if (!this._controlContainer.getElementsByClassName) return;
         var link = this._controlContainer.getElementsByClassName('mapbox-improve-map');
         if (link.length && this._loaded) {
             var center = this.getCenter().wrap();
@@ -165,6 +163,7 @@ var LMap = L.Map.extend({
             this._zoomBoundLayers[L.stamp(layer)] = layer;
         }
 
+        this._editLink();
         this._updateZoomLevels();
     }
 });

--- a/src/map.js
+++ b/src/map.js
@@ -127,6 +127,25 @@ var LMap = L.Map.extend({
         }
     },
 
+    _editLink: function() {
+        if (!this._controlContainer.getElementsByClassName) {
+            return;
+        }
+        var link = this._controlContainer.getElementsByClassName('mapbox-improve-map');
+        if (link.length && this._loaded) {
+            var center = this.getCenter().wrap();
+            var tilejson = this._tilejson || this._map._tilejson || {};
+            var id = tilejson.id || '';
+
+            for (var i = 0; i < link.length; i++) {
+                link[i].href = link[i].href.split('#')[0] + '#' + id + '/' +
+                    center.lng.toFixed(3) + '/' +
+                    center.lat.toFixed(3) + '/' +
+                    this.getZoom();
+            }
+        }
+    },
+
     _updateLayer: function(layer) {
         if (!layer.options) return;
 
@@ -137,6 +156,9 @@ var LMap = L.Map.extend({
         if (this.attributionControl && this._loaded && layer.getAttribution) {
             this.attributionControl.addAttribution(layer.getAttribution());
         }
+
+        this.off('moveend', this._editLink, this);
+        this.on('moveend', this._editLink, this);
 
         if (!(L.stamp(layer) in this._zoomBoundLayers) &&
                 (layer.options.maxZoom || layer.options.minZoom)) {

--- a/src/map.js
+++ b/src/map.js
@@ -18,8 +18,7 @@ var LMap = L.Map.extend({
         gridLayer: {},
         legendControl: {},
         gridControl: {},
-        infoControl: {},
-        attributionControl: false,
+        infoControl: false,
         shareControl: false
     },
 

--- a/test/manual/theme.html
+++ b/test/manual/theme.html
@@ -24,33 +24,41 @@
 <div id='map-dark' class='dark map'></div>
 
 <script>
-  var mapdark = L.mapbox.map('map-dark', 'examples.map-y7l23tes')
-      .addControl(L.mapbox.geocoderControl('examples.map-y7l23tes'))
-      .addControl(L.mapbox.shareControl())
-      .setView([37.9, -77], 5);
+var mapdark = L.mapbox.map('map-dark', 'examples.map-y7l23tes')
+  .addControl(L.mapbox.geocoderControl('examples.map-y7l23tes', {
+    position: 'topright'
+  }))
+  .addControl(L.mapbox.shareControl())
+  .setView([37.9, -77], 5);
 
-  var maplight = L.mapbox.map('map-light', 'examples.map-20v6611k')
-      .addControl(L.mapbox.geocoderControl('examples.map-20v6611k'))
-      .addControl(L.mapbox.shareControl())
-      .setView([37.9, -77], 5);
+var maplight = L.mapbox.map('map-light', 'examples.map-20v6611k', {
+    infoControl: true
+  })
+  .addControl(L.mapbox.geocoderControl('examples.map-y7l23tes'))
+  .addControl(L.mapbox.shareControl())
+  .setView([37.9, -77], 5);
 
-  var feature = {
-      type: 'Feature',
-      geometry: {
-          type: 'Point',
-          coordinates: [-77, 37.9]
-      },
-      properties: {
-          title: 'Example Marker',
-          description: 'This is a single marker.'
-      }
-  };
+var info = L.mapbox.infoControl({
+  position: 'bottomleft'
+}).addInfo('foo').addTo(mapdark);
 
-  maplight.legendControl.addLegend('hee haw');
-  mapdark.legendControl.addLegend('hee haw');
+var feature = {
+    type: 'Feature',
+    geometry: {
+        type: 'Point',
+        coordinates: [-77, 37.9]
+    },
+    properties: {
+        title: 'Example Marker',
+        description: 'This is a single marker.'
+    }
+};
 
-  mapdark.markerLayer.setGeoJSON(feature);
-  maplight.markerLayer.setGeoJSON(feature);
+maplight.legendControl.addLegend('hee haw');
+mapdark.legendControl.addLegend('hee haw');
+
+mapdark.markerLayer.setGeoJSON(feature);
+maplight.markerLayer.setGeoJSON(feature);
 </script>
 </body>
 </html>

--- a/test/spec/info_control.js
+++ b/test/spec/info_control.js
@@ -76,7 +76,9 @@ describe('L.mapbox.infoControl', function() {
     it('receives attribution from a layer', function(done) {
         var server = sinon.fakeServer.create();
         var element = document.createElement('div');
-        var map = L.mapbox.map(element, 'mapbox.map-0l53fhk2');
+        var map = L.mapbox.map(element, 'mapbox.map-0l53fhk2', {
+            infoControl: true
+        });
 
         map.on('ready', function() {
             expect(map.infoControl._content.innerHTML).to.eql('Data provided by NatureServe in collaboration with Robert Ridgely');
@@ -93,7 +95,9 @@ describe('L.mapbox.infoControl', function() {
     it('adds map location to improve link in attribution when .mapbox-improve-map is present', function(done) {
         var server = sinon.fakeServer.create();
         var element = document.createElement('div');
-        var map = L.mapbox.map(element, 'examples.h8e9h88l');
+        var map = L.mapbox.map(element, 'examples.h8e9h88l', {
+            infoControl: true
+        });
 
         map.on('ready', function() {
             map.setView([38.902, -77.001], 13);

--- a/test/spec/info_control.js
+++ b/test/spec/info_control.js
@@ -91,26 +91,4 @@ describe('L.mapbox.infoControl', function() {
             [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.tileJSON)]);
         server.respond();
     });
-
-    it('adds map location to improve link in attribution when .mapbox-improve-map is present', function(done) {
-        var server = sinon.fakeServer.create();
-        var element = document.createElement('div');
-        var map = L.mapbox.map(element, 'examples.h8e9h88l', {
-            infoControl: true
-        });
-
-        map.on('ready', function() {
-            map.setView([38.902, -77.001], 13);
-            expect(map.infoControl._content.innerHTML).to.eql('<a href="https://www.mapbox.com/about/maps/" target="_blank">© Mapbox © OpenStreetMap</a> <a class="mapbox-improve-map" href="https://www.mapbox.com/map-feedback/#examples.h8e9h88l/-77.001/38.902/13" target="_blank">Improve this map</a>');
-            map.setView([48.902, -77.001], 13);
-            expect(map.infoControl._content.innerHTML).to.eql('<a href="https://www.mapbox.com/about/maps/" target="_blank">© Mapbox © OpenStreetMap</a> <a class="mapbox-improve-map" href="https://www.mapbox.com/map-feedback/#examples.h8e9h88l/-77.001/48.902/13" target="_blank">Improve this map</a>');
-            map.setView([48.902, -77.001 - 360], 13);
-            expect(map.infoControl._content.innerHTML).to.eql('<a href="https://www.mapbox.com/about/maps/" target="_blank">© Mapbox © OpenStreetMap</a> <a class="mapbox-improve-map" href="https://www.mapbox.com/map-feedback/#examples.h8e9h88l/-77.001/48.902/13" target="_blank">Improve this map</a>');
-            done();
-        });
-
-        server.respondWith("GET", "http://a.tiles.mapbox.com/v3/examples.h8e9h88l.json",
-            [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.tileJSON_improvemap)]);
-        server.respond();
-    });
 });

--- a/test/spec/map.js
+++ b/test/spec/map.js
@@ -245,5 +245,35 @@ describe('L.mapbox.map', function() {
                 [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.tileJSON)]);
             server.respond();
         });
+
+        it('adds mapid and coordinates to improve link in attribution when .mapbox-improve-map is present', function(done) {
+            'use strict';
+            var server = sinon.fakeServer.create();
+            var element = document.createElement('div');
+            var map = L.mapbox.map(element, 'examples.h8e9h88l', {
+                infoControl: true
+            });
+
+            map.on('ready', function() {
+                map.setView([38.902, -77.001], 13);
+                var val = '<a href="https://www.mapbox.com/about/maps/" target="_blank">© Mapbox © OpenStreetMap</a> <a class="mapbox-improve-map" href="https://www.mapbox.com/map-feedback/#examples.h8e9h88l/-77.001/38.902/13" target="_blank">Improve this map</a>';
+                expect(map.infoControl._content.innerHTML).to.eql(val);
+                 expect(map.attributionControl._container.innerHTML).to.eql(val);
+                map.setView([48.902, -77.001], 13);
+                val = '<a href="https://www.mapbox.com/about/maps/" target="_blank">© Mapbox © OpenStreetMap</a> <a class="mapbox-improve-map" href="https://www.mapbox.com/map-feedback/#examples.h8e9h88l/-77.001/48.902/13" target="_blank">Improve this map</a>';
+                expect(map.infoControl._content.innerHTML).to.eql(val);
+                expect(map.attributionControl._container.innerHTML).to.eql(val);
+                map.setView([48.902, -77.001 - 360], 13);
+                val = '<a href="https://www.mapbox.com/about/maps/" target="_blank">© Mapbox © OpenStreetMap</a> <a class="mapbox-improve-map" href="https://www.mapbox.com/map-feedback/#examples.h8e9h88l/-77.001/48.902/13" target="_blank">Improve this map</a>';
+                expect(map.infoControl._content.innerHTML).to.eql(val);
+                expect(map.attributionControl._container.innerHTML).to.eql(val);
+                done();
+            });
+
+            server.respondWith("GET", "http://a.tiles.mapbox.com/v3/examples.h8e9h88l.json",
+                [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.tileJSON_improvemap)]);
+            server.respond();
+        });
+
     });
 });

--- a/theme/style.css
+++ b/theme/style.css
@@ -275,7 +275,8 @@
   margin:0;
   box-shadow:none;
   }
-  .leaflet-container .leaflet-control-attribution a {
+  .leaflet-container .leaflet-control-attribution a,
+  .leaflet-container .map-info-container a {
     color:#404040;
     }
     .leaflet-control-attribution a:hover,
@@ -709,7 +710,9 @@
   color:#f8f8f8;
   }
   .leaflet-container.dark .leaflet-control-attribution a,
-  .leaflet-container.dark .leaflet-control-attribution a:hover {
+  .leaflet-container.dark .leaflet-control-attribution a:hover,
+  .leaflet-container.dark .map-info-container a,
+  .leaflet-container.dark .map-info-container a:hover {
     color:#fff;
     }
 

--- a/theme/style.css
+++ b/theme/style.css
@@ -33,25 +33,14 @@
   margin-bottom: 10px;
   }
 
-.mapbox-small,
-.leaflet-control-attribution,
-.leaflet-control-scale,
-.leaflet-container input,
-.leaflet-container textarea,
-.leaflet-container label,
-.leaflet-container small {
-  font-size:12px;
-  line-height:20px;
-  }
-
-.leaflet-container a            {
+.leaflet-container a {
   color:#3887BE;
   font-weight:normal;
   text-decoration:none;
   }
-.leaflet-container a:hover      { color:#63b6e5; }
-.leaflet-container.dark a       { color:#63b6e5; }
-.leaflet-container.dark a:hover { color:#8fcaec; }
+  .leaflet-container a:hover      { color:#63b6e5; }
+  .leaflet-container.dark a       { color:#63b6e5; }
+  .leaflet-container.dark a:hover { color:#8fcaec; }
 
 .leaflet-container.dark .mapbox-button,
 .leaflet-container .mapbox-button {
@@ -282,15 +271,18 @@
   }
 
 .leaflet-container .leaflet-control-attribution {
-  background-color:rgba(255,255,255,0.25);
+  background-color:rgba(255,255,255,0.5);
   margin:0;
   box-shadow:none;
   }
-.leaflet-control-attribution a:hover,
-.map-info-container a:hover {
-  color:inherit;
-  text-decoration:underline;
-  }
+  .leaflet-container .leaflet-control-attribution a {
+    color:#404040;
+    }
+    .leaflet-control-attribution a:hover,
+    .map-info-container a:hover {
+      color:inherit;
+      text-decoration:underline;
+      }
 
 .leaflet-control-attribution,
 .leaflet-control-scale-line {
@@ -713,9 +705,14 @@
 .leaflet-container.dark .mapbox-info-toggle,
 .leaflet-container.dark .map-info-container,
 .leaflet-container.dark .leaflet-control-attribution {
-  background-color:rgba(0,0,0,0.25);
+  background-color:rgba(0,0,0,0.5);
   color:#f8f8f8;
   }
+  .leaflet-container.dark .leaflet-control-attribution a,
+  .leaflet-container.dark .leaflet-control-attribution a:hover {
+    color:#fff;
+    }
+
 .leaflet-container.dark .leaflet-control-layers-list span {
   color:#f8f8f8;
   }


### PR DESCRIPTION
Hits https://github.com/mapbox/mapbox.js/issues/744
- Attribution control is now default over of infoControl.
- infoControl is now triggered when it's set to true in the `L.mapbox.map` options param or when passed as an argument to `map.addControl()`.
- **Improve this map** link now tracks on the attribution control
### TODO
- [x] Mark change in CHANGELOG
- [x] Test coverage for **Improve this map** in L.control.attribution.

cc/ @tmcw for a review.
