### PR TITLE
Try to make autoscale=true a default

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "main": "index.js",
   "dependencies": {
-    "leaflet": "0.7.2",
+    "leaflet": "0.7.3",
     "mustache": "0.7.3",
     "corslite": "0.0.5",
     "json3": "3.3.1",

--- a/src/tile_layer.js
+++ b/src/tile_layer.js
@@ -68,9 +68,29 @@ var TileLayer = L.TileLayer.extend({
             bounds: json.bounds && util.lbounds(json.bounds)
         });
 
+        if (this.options &&
+            this.options.detectRetina === undefined &&
+            this.options.autoscale === true &&
+            L.Browser.retina) {
+            this.options.detectRetina = true;
+            this._resetRetina();
+        }
+
         this._tilejson = json;
         this.redraw();
         return this;
+    },
+
+    _resetRetina: function() {
+        // detecting retina displays, adjusting tileSize and zoom levels
+        if (this.options.detectRetina && L.Browser.retina && this.options.maxZoom > 0) {
+
+            this.options.tileSize = Math.floor(this.options.tileSize / 2);
+            this.options.zoomOffset++;
+
+            this.options.minZoom = Math.max(0, this.options.minZoom);
+            this.options.maxZoom--;
+        }
     },
 
     getTileJSON: function() {

--- a/test/manual/auto.html
+++ b/test/manual/auto.html
@@ -5,7 +5,7 @@
   <link rel="stylesheet" href="../../dist/mapbox.css"/>
   <meta name='viewport' content='initial-scale=1.0 maximum-scale=1.0'>
   <link rel="stylesheet" href="embed.css"/>
-  <script src="../../dist/mapbox.js"></script>
+  <script src="../../dist/mapbox.uncompressed.js"></script>
 </head>
 <body>
 <div id='map'></div>


### PR DESCRIPTION
This ends up being more of a quagmire than expected - we initialize
tileLayers in L.mapbox.map and L.mapbox.tileLayer, while Leaflet expects
us to know retina status right then, and doesn't seem to support
changing this value after it is set. Would love some ideas from
@mourner about how this could become less hacky.
