### PR TITLE
Standardizing tileapi URLs, moving to {{site.tileapi}} rather than hard-coded URLs

### DIFF
--- a/API.md
+++ b/API.md
@@ -10,7 +10,7 @@ interactivity.
 | Options | Value | Description |
 | ---- | ---- | ---- |
 | element (_required_) | string | Must be the id of an element, or a DOM element reference. |
-| id _or_ url _or_ tilejson | __string__ if _id_ or _url_ __object__ if _tilejson_ | url can be <ul><li>a map `id` string `examples.map-foo`</li><li> a URL to TileJSON, like `http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json`</li><li>a [TileJSON](https://www.mapbox.com/developers/tilejson/) object, from your own Javascript code</li></ul> |
+| id _or_ url _or_ tilejson | __string__ if _id_ or _url_ __object__ if _tilejson_ | url can be <ul><li>a map `id` string `examples.map-foo`</li><li> a URL to TileJSON, like `{{site.tileApi}}/v3/examples.map-0l53fhk2.json`</li><li>a [TileJSON](https://www.mapbox.com/developers/tilejson/) object, from your own Javascript code</li></ul> |
 | options | object | If provided, it is the same options as provided to L.Map with the following additions: <ul><li>`tileLayer` L.TileLayer options. Options passed to a `L.mapbox.tileLayer` based on the TileJSON. Set to `false` to disable the `L.mapbox.tileLayer`.</li><li>`featureLayer` `L.mapbox.featureLayer` options. Options passed to a `L.mapbox.featureLayer` based on the TileJSON. Set to `false` to disable the `L.mapbox.featureLayer`.</li><li>`gridLayer` `L.mapbox.gridLayer`. Options passed to a `L.mapbox.gridLayer` based on the TileJSON. Set to `false` to disable the `L.mapbox.gridLayer`.</li><li>`legendControl` `L.mapbox.legendControl` options. Options passed to a `L.mapbox.legendControl` based on the TileJSON. Set to `false` to disable the `L.mapbox.legendControl`.</li><li>`shareControl`: Options passed to a `L.mapbox.shareControl`. Set to `true` to enable the `L.mapbox.shareControl`.</li><li>`infoControl`: Options passed to a `L.mapbox.infoControl`. Set to `true` to enable the `L.mapbox.infoControl`.</li> |
 
 _Example_:
@@ -45,7 +45,7 @@ interface to layers from Mapbox and elsewhere.
 
 | Options | Value | Description |
 | ---- | ---- | ---- |
-| id _or_ url _or_ tilejson (_required_) | __string__ if _id_ or _url_ __object__ if _tilejson_ | Value must be <ul><li>An `id` string `examples.map-foo`</li><li>A URL to TileJSON, like `http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json`</li><li>A TileJSON object, from your own Javascript code</li></ul> |
+| id _or_ url _or_ tilejson (_required_) | __string__ if _id_ or _url_ __object__ if _tilejson_ | Value must be <ul><li>An `id` string `examples.map-foo`</li><li>A URL to TileJSON, like `{{site.tileApi}}/v3/examples.map-0l53fhk2.json`</li><li>A TileJSON object, from your own Javascript code</li></ul> |
 | options | object | The second argument is optional. If provided, it is the same options as provided to `L.TileLayer` with one addition: <ul><li>`retinaVersion`, if provided, is an alternative value for the first argument to `L.mapbox.tileLayer` which, if retina is detected, is used instead.</li></ul>
 
 If `detectRetina` is set to true and the map in question supports auto-scaling, then a scaled version will automatically be useful if retina is detected and you don't provide an explicit `retinaVersion` to be used.
@@ -56,7 +56,7 @@ _Example_:
     var layer = L.mapbox.tileLayer('examples.map-20v6611k');
 
     // you can also provide a full url to a TileJSON resource
-    var layer = L.mapbox.tileLayer('http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json');
+    var layer = L.mapbox.tileLayer('{{site.tileApi}}/v3/examples.map-0l53fhk2.json');
 
     // if provided, you can support retina tiles
     var layer = L.mapbox.tileLayer('examples.map-20v6611k', {
@@ -121,7 +121,7 @@ interactivity into your map, which you can easily access with `L.mapbox.gridCont
 
 | Options | Value | Description |
 | ---- | ---- | ---- |
-| id _or_ url _or_ tilejson (_required_) | __string__ if _id_ or _url_ __object__ if _tilejson_ | <ul><li>An `id` string `examples.map-foo`</li><li>A URL to TileJSON, like `http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json`</li><li>A TileJSON object, from your own Javascript code</li></ul> |
+| id _or_ url _or_ tilejson (_required_) | __string__ if _id_ or _url_ __object__ if _tilejson_ | <ul><li>An `id` string `examples.map-foo`</li><li>A URL to TileJSON, like `{{site.tileApi}}/v3/examples.map-0l53fhk2.json`</li><li>A TileJSON object, from your own Javascript code</li></ul> |
 
 _Example_:
 
@@ -205,7 +205,7 @@ from Mapbox and elsewhere into your map.
 
 | Options | Value | Description |
 | ---- | ---- | ---- |
-| id _or_ url _or_ geojson | __string__ if _id_ or _url_ __object__ if _tilejson_ | Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like `http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json`</li><li>A GeoJSON object, from your own Javascript code</li><li>`null`, if you wish to only provide `options` and not initial data.</li></ul> |
+| id _or_ url _or_ geojson | __string__ if _id_ or _url_ __object__ if _tilejson_ | Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like `{{site.tileApi}}/v3/examples.map-0l53fhk2.json`</li><li>A GeoJSON object, from your own Javascript code</li><li>`null`, if you wish to only provide `options` and not initial data.</li></ul> |
 | options | object | If provided, it is the same options as provided to `L.FeatureGroup`, as well as: <ul><li>`filter`: A function that accepts a feature object and returns `true` or `false` to indicate whether it should be displayed on the map. This can be changed later using `setFilter`.</li><li>`sanitizer`: A function that accepts a string containing tooltip data, and returns a sanitized result for HTML display. The default will remove dangerous script content, and is recommended.</li></ul> |
 
 _Example_:
@@ -333,7 +333,7 @@ A low-level interface to geocoding, useful for more complex uses and reverse-geo
 
 | Options | Value | Description |
 | ---- | ---- | ---- |
-| id _or_ url | string | Value must be <ul><li>An `id` string `examples.map-foo`</li><li>A URL to TileJSON, like `http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json`</li></ul> |
+| id _or_ url | string | Value must be <ul><li>An `id` string `examples.map-foo`</li><li>A URL to TileJSON, like `{{site.tileApi}}/v3/examples.map-0l53fhk2.json`</li></ul> |
 
 _Returns_ a `L.mapbox.geocoder` object.
 
@@ -493,7 +493,7 @@ This function is currently in private beta: [Contact Mapbox](https://mapbox.com/
 
 | Options | Value | Description |
 | ---- | ---- | ---- |
-| id _or_ url (_required_) | string | Either a <ul><li>An `id` string `examples.map-foo`</li><li>A URL to TileJSON, like `http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json`</li></ul> |
+| id _or_ url (_required_) | string | Either a <ul><li>An `id` string `examples.map-foo`</li><li>A URL to TileJSON, like `{{site.tileApi}}/v3/examples.map-0l53fhk2.json`</li></ul> |
 | options | object | An options argument with the same options as the `L.Control` class, as well as: <ul><li>`keepOpen`: a boolean for whether the control will stay open always rather than being toggled. Default `false`. See <a href='https://www.mapbox.com/mapbox.js/example/v1.0.0/geocoder-keep-open/'>live example</a>.<li></ul> |
 
 _Example_:
@@ -553,7 +553,7 @@ Adds a "Share" button to the map, which can be used to share the map to Twitter 
 
 | Options | Value | Description |
 | ---- | ---- | ---- |
-| id _or_ url _optional_ | string | Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>https://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code> If not supplied, the TileJSON from the map is used.</li></ul> |
+| id _or_ url _optional_ | string | Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code> If not supplied, the TileJSON from the map is used.</li></ul> |
 | options | object | Options for L.Control</span> Also accepts the following options:<ul><li>url: the <code>URL</code> of a page to which the share control will link instead of the URL of the current page or that specified in TileJSON data.</li></ul> |
 
 _Example_:
@@ -734,4 +734,3 @@ is available by applying `class="dark"` to the map div.
 _Example_:
 
     <div id="map" class="dark"></div>
-

--- a/API.md
+++ b/API.md
@@ -10,7 +10,7 @@ interactivity.
 | Options | Value | Description |
 | ---- | ---- | ---- |
 | element (_required_) | string | Must be the id of an element, or a DOM element reference. |
-| id _or_ url _or_ tilejson | __string__ if _id_ or _url_ __object__ if _tilejson_ | url can be <ul><li>a map `id` string `examples.map-foo`</li><li> a URL to TileJSON, like `{{site.tileApi}}/v3/examples.map-0l53fhk2.json`</li><li>a [TileJSON](https://www.mapbox.com/developers/tilejson/) object, from your own Javascript code</li></ul> |
+| id _or_ url _or_ tilejson | __string__ if _id_ or _url_ __object__ if _tilejson_ | url can be <ul><li>a map `id` string `examples.map-foo`</li><li> a URL to TileJSON, like `{{site.tileapi}}/v3/examples.map-0l53fhk2.json`</li><li>a [TileJSON](https://www.mapbox.com/developers/tilejson/) object, from your own Javascript code</li></ul> |
 | options | object | If provided, it is the same options as provided to L.Map with the following additions: <ul><li>`tileLayer` L.TileLayer options. Options passed to a `L.mapbox.tileLayer` based on the TileJSON. Set to `false` to disable the `L.mapbox.tileLayer`.</li><li>`featureLayer` `L.mapbox.featureLayer` options. Options passed to a `L.mapbox.featureLayer` based on the TileJSON. Set to `false` to disable the `L.mapbox.featureLayer`.</li><li>`gridLayer` `L.mapbox.gridLayer`. Options passed to a `L.mapbox.gridLayer` based on the TileJSON. Set to `false` to disable the `L.mapbox.gridLayer`.</li><li>`legendControl` `L.mapbox.legendControl` options. Options passed to a `L.mapbox.legendControl` based on the TileJSON. Set to `false` to disable the `L.mapbox.legendControl`.</li><li>`shareControl`: Options passed to a `L.mapbox.shareControl`. Set to `true` to enable the `L.mapbox.shareControl`.</li><li>`infoControl`: Options passed to a `L.mapbox.infoControl`. Set to `true` to enable the `L.mapbox.infoControl`.</li> |
 
 _Example_:
@@ -45,7 +45,7 @@ interface to layers from Mapbox and elsewhere.
 
 | Options | Value | Description |
 | ---- | ---- | ---- |
-| id _or_ url _or_ tilejson (_required_) | __string__ if _id_ or _url_ __object__ if _tilejson_ | Value must be <ul><li>An `id` string `examples.map-foo`</li><li>A URL to TileJSON, like `{{site.tileApi}}/v3/examples.map-0l53fhk2.json`</li><li>A TileJSON object, from your own Javascript code</li></ul> |
+| id _or_ url _or_ tilejson (_required_) | __string__ if _id_ or _url_ __object__ if _tilejson_ | Value must be <ul><li>An `id` string `examples.map-foo`</li><li>A URL to TileJSON, like `{{site.tileapi}}/v3/examples.map-0l53fhk2.json`</li><li>A TileJSON object, from your own Javascript code</li></ul> |
 | options | object | The second argument is optional. If provided, it is the same options as provided to `L.TileLayer` with one addition: <ul><li>`retinaVersion`, if provided, is an alternative value for the first argument to `L.mapbox.tileLayer` which, if retina is detected, is used instead.</li></ul>
 
 If `detectRetina` is set to true and the map in question supports auto-scaling, then a scaled version will automatically be useful if retina is detected and you don't provide an explicit `retinaVersion` to be used.
@@ -56,7 +56,7 @@ _Example_:
     var layer = L.mapbox.tileLayer('examples.map-20v6611k');
 
     // you can also provide a full url to a TileJSON resource
-    var layer = L.mapbox.tileLayer('{{site.tileApi}}/v3/examples.map-0l53fhk2.json');
+    var layer = L.mapbox.tileLayer('{{site.tileapi}}/v3/examples.map-0l53fhk2.json');
 
     // if provided, you can support retina tiles
     var layer = L.mapbox.tileLayer('examples.map-20v6611k', {
@@ -121,7 +121,7 @@ interactivity into your map, which you can easily access with `L.mapbox.gridCont
 
 | Options | Value | Description |
 | ---- | ---- | ---- |
-| id _or_ url _or_ tilejson (_required_) | __string__ if _id_ or _url_ __object__ if _tilejson_ | <ul><li>An `id` string `examples.map-foo`</li><li>A URL to TileJSON, like `{{site.tileApi}}/v3/examples.map-0l53fhk2.json`</li><li>A TileJSON object, from your own Javascript code</li></ul> |
+| id _or_ url _or_ tilejson (_required_) | __string__ if _id_ or _url_ __object__ if _tilejson_ | <ul><li>An `id` string `examples.map-foo`</li><li>A URL to TileJSON, like `{{site.tileapi}}/v3/examples.map-0l53fhk2.json`</li><li>A TileJSON object, from your own Javascript code</li></ul> |
 
 _Example_:
 
@@ -205,7 +205,7 @@ from Mapbox and elsewhere into your map.
 
 | Options | Value | Description |
 | ---- | ---- | ---- |
-| id _or_ url _or_ geojson | __string__ if _id_ or _url_ __object__ if _tilejson_ | Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like `{{site.tileApi}}/v3/examples.map-0l53fhk2.json`</li><li>A GeoJSON object, from your own Javascript code</li><li>`null`, if you wish to only provide `options` and not initial data.</li></ul> |
+| id _or_ url _or_ geojson | __string__ if _id_ or _url_ __object__ if _tilejson_ | Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like `{{site.tileapi}}/v3/examples.map-0l53fhk2.json`</li><li>A GeoJSON object, from your own Javascript code</li><li>`null`, if you wish to only provide `options` and not initial data.</li></ul> |
 | options | object | If provided, it is the same options as provided to `L.FeatureGroup`, as well as: <ul><li>`filter`: A function that accepts a feature object and returns `true` or `false` to indicate whether it should be displayed on the map. This can be changed later using `setFilter`.</li><li>`sanitizer`: A function that accepts a string containing tooltip data, and returns a sanitized result for HTML display. The default will remove dangerous script content, and is recommended.</li></ul> |
 
 _Example_:
@@ -333,7 +333,7 @@ A low-level interface to geocoding, useful for more complex uses and reverse-geo
 
 | Options | Value | Description |
 | ---- | ---- | ---- |
-| id _or_ url | string | Value must be <ul><li>An `id` string `examples.map-foo`</li><li>A URL to TileJSON, like `{{site.tileApi}}/v3/examples.map-0l53fhk2.json`</li></ul> |
+| id _or_ url | string | Value must be <ul><li>An `id` string `examples.map-foo`</li><li>A URL to TileJSON, like `{{site.tileapi}}/v3/examples.map-0l53fhk2.json`</li></ul> |
 
 _Returns_ a `L.mapbox.geocoder` object.
 
@@ -493,7 +493,7 @@ This function is currently in private beta: [Contact Mapbox](https://mapbox.com/
 
 | Options | Value | Description |
 | ---- | ---- | ---- |
-| id _or_ url (_required_) | string | Either a <ul><li>An `id` string `examples.map-foo`</li><li>A URL to TileJSON, like `{{site.tileApi}}/v3/examples.map-0l53fhk2.json`</li></ul> |
+| id _or_ url (_required_) | string | Either a <ul><li>An `id` string `examples.map-foo`</li><li>A URL to TileJSON, like `{{site.tileapi}}/v3/examples.map-0l53fhk2.json`</li></ul> |
 | options | object | An options argument with the same options as the `L.Control` class, as well as: <ul><li>`keepOpen`: a boolean for whether the control will stay open always rather than being toggled. Default `false`. See <a href='https://www.mapbox.com/mapbox.js/example/v1.0.0/geocoder-keep-open/'>live example</a>.<li></ul> |
 
 _Example_:
@@ -553,7 +553,7 @@ Adds a "Share" button to the map, which can be used to share the map to Twitter 
 
 | Options | Value | Description |
 | ---- | ---- | ---- |
-| id _or_ url _optional_ | string | Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code> If not supplied, the TileJSON from the map is used.</li></ul> |
+| id _or_ url _optional_ | string | Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code> If not supplied, the TileJSON from the map is used.</li></ul> |
 | options | object | Options for L.Control</span> Also accepts the following options:<ul><li>url: the <code>URL</code> of a page to which the share control will link instead of the URL of the current page or that specified in TileJSON data.</li></ul> |
 
 _Example_:
@@ -653,7 +653,7 @@ A [mustache](http://mustache.github.io/) template rendering function, as used by
 
 _Example_:
 
-    var output = L.mapbox.template('Name: {{name}}', {name: 'John'});
+    var output = L.mapbox.template('Name: {% raw %}{{name}}{% endraw %}', {name: 'John'});
     // output is "Name: John"
 
 # Configuration

--- a/_config.mb-pages.yml
+++ b/_config.mb-pages.yml
@@ -6,6 +6,7 @@ baseurl: /mapbox.js
 pygments: true
 mapboxjs: v1.6.4
 defaultid: 'examples.map-i86nkdio'
+tileapi: 'https://api.tiles.mapbox.com'
 rdiscount:
   extensions: [smart]
 exclude: [dist]

--- a/_config.yml
+++ b/_config.yml
@@ -7,5 +7,6 @@ pygments: true
 mapboxjs: v1.6.4
 mapboxjsbase: /mapbox.js/dist
 defaultid: 'examples.map-i86nkdio'
+tileApi: https://api.tiles.mapbox.com
 rdiscount:
   extensions: [smart]

--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,6 @@ pygments: true
 mapboxjs: v1.6.4
 mapboxjsbase: /mapbox.js/dist
 defaultid: 'examples.map-i86nkdio'
-tileApi: https://api.tiles.mapbox.com
+tileapi: 'https://api.tiles.mapbox.com'
 rdiscount:
   extensions: [smart]

--- a/_docs/generate.js
+++ b/_docs/generate.js
@@ -203,8 +203,8 @@ function readDocumentation(filename) {
                 file: argv.d + '/0200-01-01-' + escapedText + '.html',
                 contents: header.replace('All', main) +
                     'version: ' + argv.t + '\n' +
-                    'permalink: /api/' + argv.t + '/' + escapedText + '\n---\n{% raw %}' +
-                    html.replace('id="map"', '') + '{% endraw %}'
+                    'permalink: /api/' + argv.t + '/' + escapedText + '\n---\n' +
+                    html.replace('id="map"', '')
             });
         });
 
@@ -219,11 +219,8 @@ landOutput.write('---\n');
 landOutput.write('{% include api.introduction.html %}\n');
 
 output.write("---\n");
-output.write("{% raw %}\n");
 output.write(all + '\n');
-output.write("{% endraw %}");
 
 writes.forEach(function(w) {
     fs.writeFileSync(w.file, w.contents);
 });
-

--- a/docs/_includes/site.introduction.html
+++ b/docs/_includes/site.introduction.html
@@ -53,8 +53,8 @@ L.mapbox.map('map', 'username.mapid');
   </div>
   <div class='pad1'>
     <div class='space-bottom1'>{% highlight html %}
-<script src='https://api.tiles.mapbox.com/mapbox.js/{{site.mapboxjs}}/mapbox.js'></script>
-<link href='https://api.tiles.mapbox.com/mapbox.js/{{site.mapboxjs}}/mapbox.css' rel='stylesheet' />{% endhighlight html %}
+<script src='{{site.tileapi}}/mapbox.js/{{site.mapboxjs}}/mapbox.js'></script>
+<link href='{{site.tileapi}}/mapbox.js/{{site.mapboxjs}}/mapbox.css' rel='stylesheet' />{% endhighlight html %}
     </div>
     <div class='pad1x small quiet'>
     Include mapbox.js and CSS in your HTML header and call <code>L.mapbox.map('map', '{{site.defaultid}}')</code> to load your first map. <a class='truncate rcon next' href='{{site.baseurl}}/example/v1.0.0/'>View simple example</a>
@@ -107,4 +107,3 @@ $(function load() {
 #example-snippet .highlight { width:200%; }
 .highlight pre { background-color:#f8f8f8; }
 </style>
-

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -79,7 +79,7 @@ footer:
   <!--[if IE 9]><link href='{{site.url}}/css/site-ie9.css' rel='stylesheet' /><![endif]-->
   <link rel='shortcut icon' href='{{site.url}}/img/favicon.ico' type='image/x-icon' />
   <link rel='alternate' type='application/rss+xml' title='RSS' href='{{site.url}}/blog/blog.rss' />
-  <link href='{% if site.mapboxjsbase %}{{site.mapboxjsbase}}{% else %}https://api.tiles.mapbox.com/mapbox.js/{% if site.mapboxjs %}{{site.mapboxjs}}{% else %}v1.6.1{% endif %}{% endif %}/mapbox.css' rel='stylesheet' />
+  <link href='{% if site.mapboxjsbase %}{{site.mapboxjsbase}}{% else %}{{site.tileapi}}/mapbox.js/{% if site.mapboxjs %}{{site.mapboxjs}}{% else %}v1.6.1{% endif %}{% endif %}/mapbox.css' rel='stylesheet' />
 
   <!--[if lt IE 9 ]><script src='{{site.url}}/js/redirect-ie.js'></script><![endif]-->
   <script src='{{site.api}}/api/session.js'></script>
@@ -92,7 +92,7 @@ footer:
   Stripe.setPublishableKey(window.location.hostname.indexOf('mapbox.com') !== -1 ?
     'pk_live_hI6mmOTIg7KkywK6vo3vJvpk' : 'pk_test_gmIyREg3sKzAiyMkAEeCsxUG');
   </script>
-  <script src='{% if site.mapboxjsbase %}{{site.mapboxjsbase}}{% else %}https://api.tiles.mapbox.com/mapbox.js/{% if site.mapboxjs %}{{site.mapboxjs}}{% else %}v1.6.1{% endif %}{% endif %}/mapbox.js'></script>
+  <script src='{% if site.mapboxjsbase %}{{site.mapboxjsbase}}{% else %}{{site.tileapi}}/mapbox.js/{% if site.mapboxjs %}{{site.mapboxjs}}{% else %}v1.6.1{% endif %}{% endif %}/mapbox.js'></script>
   <script src='{{site.url}}/js/api.js'></script>
   <script src='{{site.url}}/js/libs.js'></script>
   <script src='{{site.url}}/js/site.js'></script>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -79,7 +79,7 @@ footer:
   <!--[if IE 9]><link href='{{site.url}}/css/site-ie9.css' rel='stylesheet' /><![endif]-->
   <link rel='shortcut icon' href='{{site.url}}/img/favicon.ico' type='image/x-icon' />
   <link rel='alternate' type='application/rss+xml' title='RSS' href='{{site.url}}/blog/blog.rss' />
-  <link href='{% if site.mapboxjsbase %}{{site.mapboxjsbase}}{% else %}{{site.tileapi}}/mapbox.js/{% if site.mapboxjs %}{{site.mapboxjs}}{% else %}v1.6.1{% endif %}{% endif %}/mapbox.css' rel='stylesheet' />
+  <link href='{% if site.mapboxjsbase %}{{site.mapboxjsbase}}{% else %}https://api.tiles.mapbox.com/mapbox.js/{% if site.mapboxjs %}{{site.mapboxjs}}{% else %}v1.6.1{% endif %}{% endif %}/mapbox.css' rel='stylesheet' />
 
   <!--[if lt IE 9 ]><script src='{{site.url}}/js/redirect-ie.js'></script><![endif]-->
   <script src='{{site.api}}/api/session.js'></script>
@@ -92,7 +92,7 @@ footer:
   Stripe.setPublishableKey(window.location.hostname.indexOf('mapbox.com') !== -1 ?
     'pk_live_hI6mmOTIg7KkywK6vo3vJvpk' : 'pk_test_gmIyREg3sKzAiyMkAEeCsxUG');
   </script>
-  <script src='{% if site.mapboxjsbase %}{{site.mapboxjsbase}}{% else %}{{site.tileapi}}/mapbox.js/{% if site.mapboxjs %}{{site.mapboxjs}}{% else %}v1.6.1{% endif %}{% endif %}/mapbox.js'></script>
+  <script src='{% if site.mapboxjsbase %}{{site.mapboxjsbase}}{% else %}https://api.tiles.mapbox.com/mapbox.js/{% if site.mapboxjs %}{{site.mapboxjs}}{% else %}v1.6.1{% endif %}{% endif %}/mapbox.js'></script>
   <script src='{{site.url}}/js/api.js'></script>
   <script src='{{site.url}}/js/libs.js'></script>
   <script src='{{site.url}}/js/site.js'></script>

--- a/docs/_layouts/example.html
+++ b/docs/_layouts/example.html
@@ -26,8 +26,8 @@ version: latest
 <meta charset=utf-8 />
 <title>{{page.title}}</title>
 <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
-<script src='https://api.tiles.mapbox.com/mapbox.js/{{site.mapboxjs}}/mapbox.js'></script>
-<link href='https://api.tiles.mapbox.com/mapbox.js/{{site.mapboxjs}}/mapbox.css' rel='stylesheet' />
+<script src='{{site.tileapi}}/mapbox.js/{{site.mapboxjs}}/mapbox.js'></script>
+<link href='{{site.tileapi}}/mapbox.js/{{site.mapboxjs}}/mapbox.css' rel='stylesheet' />
 <style>
   body { margin:0; padding:0; }
   #map { position:absolute; top:0; bottom:0; width:100%; }

--- a/docs/_posts/api/0200-01-01-v0.6.0-dev.html
+++ b/docs/_posts/api/0200-01-01-v0.6.0-dev.html
@@ -205,7 +205,7 @@ auto-instantiate many of its features.
 
 </p>
 </div><h2 id="mapbox.load"><span class="object">mapbox</span>.<span class="name">load</span><span class="bracket">(</span><span class="args">url, callback</span><span class="bracket">)</span></h2>
-<div class="depth-2"><p>This loads the information about a map on <a href="http://mapbox.com/tour/">MapBox Hosting</a>. The first argument can either be a full URL to a TileJSON file, like <code>{{site.tileApi}}/v3/tmcw.map-hehqnmda.jsonp</code>, or a bare id, like <code>tmcw.map-hehqnmda</code>, which will get expanded to the former.
+<div class="depth-2"><p>This loads the information about a map on <a href="http://mapbox.com/tour/">MapBox Hosting</a>. The first argument can either be a full URL to a TileJSON file, like <code>{{site.tileapi}}/v3/tmcw.map-hehqnmda.jsonp</code>, or a bare id, like <code>tmcw.map-hehqnmda</code>, which will get expanded to the former.
 
 </p>
 <p>After pulling the information from MapBox, it calls the function specified at the second argument with an object with map parts you can combine for yourself:
@@ -241,7 +241,7 @@ auto-instantiate many of its features.
 </p>
 <pre><code>&lt;div id=&#39;map&#39; style=&#39;width:500px;height:400px;&#39;&gt;&lt;/div&gt;
 &lt;script&gt;
-mapbox.auto(&#39;map&#39;, &#39;{{site.tileApi}}/v3/tmcw.map-hehqnmda.jsonp&#39;);
+mapbox.auto(&#39;map&#39;, &#39;{{site.tileapi}}/v3/tmcw.map-hehqnmda.jsonp&#39;);
 &lt;/script&gt;</code></pre>
 </div><h1>MapBox Layer</h1>
 <div class="depth-1"><p><code>mapbox.layer</code> is a fast way to add layers to your map without having to deal with complex configuration.
@@ -309,7 +309,7 @@ TileJSON information has been asynchronously loaded.</li>
 <p><strong>Example:</strong>
 
 </p>
-<pre><code>var layer = mapbox.layer().url(&#39;{{site.tileApi}}/v3/tmcw.map-hehqnmda.jsonp&#39;);</code></pre>
+<pre><code>var layer = mapbox.layer().url(&#39;{{site.tileapi}}/v3/tmcw.map-hehqnmda.jsonp&#39;);</code></pre>
 </div><h3 id="layer.tilejson"><span class="object">layer</span>.<span class="name">tilejson</span><span class="bracket">(</span><span class="args">[tilejson]</span><span class="bracket">)</span></h3>
 <div class="depth-3"><p>Set layer options directly from a TileJSON object.
 

--- a/docs/_posts/api/0200-01-01-v0.6.0-dev.html
+++ b/docs/_posts/api/0200-01-01-v0.6.0-dev.html
@@ -205,7 +205,7 @@ auto-instantiate many of its features.
 
 </p>
 </div><h2 id="mapbox.load"><span class="object">mapbox</span>.<span class="name">load</span><span class="bracket">(</span><span class="args">url, callback</span><span class="bracket">)</span></h2>
-<div class="depth-2"><p>This loads the information about a map on <a href="http://mapbox.com/tour/">MapBox Hosting</a>. The first argument can either be a full URL to a TileJSON file, like <code>http://a.tiles.mapbox.com/v3/tmcw.map-hehqnmda.jsonp</code>, or a bare id, like <code>tmcw.map-hehqnmda</code>, which will get expanded to the former.
+<div class="depth-2"><p>This loads the information about a map on <a href="http://mapbox.com/tour/">MapBox Hosting</a>. The first argument can either be a full URL to a TileJSON file, like <code>{{site.tileApi}}/v3/tmcw.map-hehqnmda.jsonp</code>, or a bare id, like <code>tmcw.map-hehqnmda</code>, which will get expanded to the former.
 
 </p>
 <p>After pulling the information from MapBox, it calls the function specified at the second argument with an object with map parts you can combine for yourself:
@@ -241,7 +241,7 @@ auto-instantiate many of its features.
 </p>
 <pre><code>&lt;div id=&#39;map&#39; style=&#39;width:500px;height:400px;&#39;&gt;&lt;/div&gt;
 &lt;script&gt;
-mapbox.auto(&#39;map&#39;, &#39;http://a.tiles.mapbox.com/v3/tmcw.map-hehqnmda.jsonp&#39;);
+mapbox.auto(&#39;map&#39;, &#39;{{site.tileApi}}/v3/tmcw.map-hehqnmda.jsonp&#39;);
 &lt;/script&gt;</code></pre>
 </div><h1>MapBox Layer</h1>
 <div class="depth-1"><p><code>mapbox.layer</code> is a fast way to add layers to your map without having to deal with complex configuration.
@@ -309,7 +309,7 @@ TileJSON information has been asynchronously loaded.</li>
 <p><strong>Example:</strong>
 
 </p>
-<pre><code>var layer = mapbox.layer().url(&#39;http://a.tiles.mapbox.com/v3/tmcw.map-hehqnmda.jsonp&#39;);</code></pre>
+<pre><code>var layer = mapbox.layer().url(&#39;{{site.tileApi}}/v3/tmcw.map-hehqnmda.jsonp&#39;);</code></pre>
 </div><h3 id="layer.tilejson"><span class="object">layer</span>.<span class="name">tilejson</span><span class="bracket">(</span><span class="args">[tilejson]</span><span class="bracket">)</span></h3>
 <div class="depth-3"><p>Set layer options directly from a TileJSON object.
 

--- a/docs/_posts/api/0200-01-01-v0.6.3.html
+++ b/docs/_posts/api/0200-01-01-v0.6.3.html
@@ -210,7 +210,7 @@ auto-instantiate many of its features.
 
 </p>
 </div><h2 id="mapbox.load"><span class="object">mapbox</span>.<span class="name">load</span><span class="bracket">(</span><span class="args">url, callback</span><span class="bracket">)</span></h2>
-<div class="depth-2"><p>This loads the information about a map on <a href="http://mapbox.com/tour/">MapBox Hosting</a>. The first argument can either be a full URL to a TileJSON file, like <code>http://a.tiles.mapbox.com/v3/tmcw.map-hehqnmda.jsonp</code>, or a bare id, like <code>tmcw.map-hehqnmda</code>, which will get expanded to the former.
+<div class="depth-2"><p>This loads the information about a map on <a href="http://mapbox.com/tour/">MapBox Hosting</a>. The first argument can either be a full URL to a TileJSON file, like <code>{{site.tileApi}}/v3/tmcw.map-hehqnmda.jsonp</code>, or a bare id, like <code>tmcw.map-hehqnmda</code>, which will get expanded to the former.
 
 </p>
 <p>After pulling the information from MapBox, it calls the function specified at the second argument with an object with map parts you can combine for yourself:
@@ -246,7 +246,7 @@ auto-instantiate many of its features.
 </p>
 <pre><code>&lt;div id=&#39;map&#39; style=&#39;width:500px;height:400px;&#39;&gt;&lt;/div&gt;
 &lt;script&gt;
-mapbox.auto(&#39;map&#39;, &#39;http://a.tiles.mapbox.com/v3/tmcw.map-hehqnmda.jsonp&#39;);
+mapbox.auto(&#39;map&#39;, &#39;{{site.tileApi}}/v3/tmcw.map-hehqnmda.jsonp&#39;);
 &lt;/script&gt;</code></pre>
 </div><h1>MapBox Layer</h1>
 <div class="depth-1"><p><code>mapbox.layer</code> is a fast way to add layers to your map without having to deal with complex configuration.
@@ -314,7 +314,7 @@ TileJSON information has been asynchronously loaded.</li>
 <p><strong>Example:</strong>
 
 </p>
-<pre><code>var layer = mapbox.layer().url(&#39;http://a.tiles.mapbox.com/v3/tmcw.map-hehqnmda.jsonp&#39;);</code></pre>
+<pre><code>var layer = mapbox.layer().url(&#39;{{site.tileApi}}/v3/tmcw.map-hehqnmda.jsonp&#39;);</code></pre>
 </div><h3 id="layer.tilejson"><span class="object">layer</span>.<span class="name">tilejson</span><span class="bracket">(</span><span class="args">[tilejson]</span><span class="bracket">)</span></h3>
 <div class="depth-3"><p>Set layer options directly from a TileJSON object.
 

--- a/docs/_posts/api/0200-01-01-v0.6.3.html
+++ b/docs/_posts/api/0200-01-01-v0.6.3.html
@@ -210,7 +210,7 @@ auto-instantiate many of its features.
 
 </p>
 </div><h2 id="mapbox.load"><span class="object">mapbox</span>.<span class="name">load</span><span class="bracket">(</span><span class="args">url, callback</span><span class="bracket">)</span></h2>
-<div class="depth-2"><p>This loads the information about a map on <a href="http://mapbox.com/tour/">MapBox Hosting</a>. The first argument can either be a full URL to a TileJSON file, like <code>{{site.tileApi}}/v3/tmcw.map-hehqnmda.jsonp</code>, or a bare id, like <code>tmcw.map-hehqnmda</code>, which will get expanded to the former.
+<div class="depth-2"><p>This loads the information about a map on <a href="http://mapbox.com/tour/">MapBox Hosting</a>. The first argument can either be a full URL to a TileJSON file, like <code>{{site.tileapi}}/v3/tmcw.map-hehqnmda.jsonp</code>, or a bare id, like <code>tmcw.map-hehqnmda</code>, which will get expanded to the former.
 
 </p>
 <p>After pulling the information from MapBox, it calls the function specified at the second argument with an object with map parts you can combine for yourself:
@@ -246,7 +246,7 @@ auto-instantiate many of its features.
 </p>
 <pre><code>&lt;div id=&#39;map&#39; style=&#39;width:500px;height:400px;&#39;&gt;&lt;/div&gt;
 &lt;script&gt;
-mapbox.auto(&#39;map&#39;, &#39;{{site.tileApi}}/v3/tmcw.map-hehqnmda.jsonp&#39;);
+mapbox.auto(&#39;map&#39;, &#39;{{site.tileapi}}/v3/tmcw.map-hehqnmda.jsonp&#39;);
 &lt;/script&gt;</code></pre>
 </div><h1>MapBox Layer</h1>
 <div class="depth-1"><p><code>mapbox.layer</code> is a fast way to add layers to your map without having to deal with complex configuration.
@@ -314,7 +314,7 @@ TileJSON information has been asynchronously loaded.</li>
 <p><strong>Example:</strong>
 
 </p>
-<pre><code>var layer = mapbox.layer().url(&#39;{{site.tileApi}}/v3/tmcw.map-hehqnmda.jsonp&#39;);</code></pre>
+<pre><code>var layer = mapbox.layer().url(&#39;{{site.tileapi}}/v3/tmcw.map-hehqnmda.jsonp&#39;);</code></pre>
 </div><h3 id="layer.tilejson"><span class="object">layer</span>.<span class="name">tilejson</span><span class="bracket">(</span><span class="args">[tilejson]</span><span class="bracket">)</span></h3>
 <div class="depth-3"><p>Set layer options directly from a TileJSON object.
 

--- a/docs/_posts/api/0200-01-01-v0.6.4.html
+++ b/docs/_posts/api/0200-01-01-v0.6.4.html
@@ -939,7 +939,7 @@ auto-instantiate many of its features.
 </p>
 <ul>
 <li><code>url</code> can be either be a full URL to a TileJSON file, like
-<code>http://a.tiles.mapbox.com/v3/tmcw.map-hehqnmda.jsonp</code>, or a bare id, like
+<code>{{site.tileApi}}/v3/tmcw.map-hehqnmda.jsonp</code>, or a bare id, like
 <code>tmcw.map-hehqnmda</code>, which will get expanded to the former. This can also
 accept an array of urls in the same format.</li>
 <li><p><code>callback</code> must be a function that receives either a single object with details
@@ -986,7 +986,7 @@ mapbox.load(&#39;tmcw.map-hehqnmda&#39;, function(o) {
 </p>
 <pre><code>&lt;div id=&#39;map&#39; style=&#39;width:500px;height:400px;&#39;&gt;&lt;/div&gt;
 &lt;script&gt;
-mapbox.auto(&#39;map&#39;, &#39;http://a.tiles.mapbox.com/v3/tmcw.map-hehqnmda.jsonp&#39;);
+mapbox.auto(&#39;map&#39;, &#39;{{site.tileApi}}/v3/tmcw.map-hehqnmda.jsonp&#39;);
 &lt;/script&gt;</code></pre>
 </div><h1>Layer</h1>
 <div id="content-mapbox.auto"class="depth-1"><p><code>mapbox.layer</code> is a fast way to add layers to your map without having to deal with complex configuration.
@@ -1055,7 +1055,7 @@ TileJSON information has been asynchronously loaded.</li>
 <p><strong>Example:</strong>
 
 </p>
-<pre><code>var layer = mapbox.layer().url(&#39;http://a.tiles.mapbox.com/v3/tmcw.map-hehqnmda.jsonp&#39;);</code></pre>
+<pre><code>var layer = mapbox.layer().url(&#39;{{site.tileApi}}/v3/tmcw.map-hehqnmda.jsonp&#39;);</code></pre>
 </div><h3 id="layer.tilejson">layer.tilejson<span class="bracket">(</span><span class="args">[tilejson]</span><span class="bracket">)</span></h3>
 <div id="content-layer.tilejson"class="depth-3"><p>Set layer options directly from a <a href="https://github.com/mapbox/tilejson-spec">TileJSON</a> object.
 

--- a/docs/_posts/api/0200-01-01-v0.6.4.html
+++ b/docs/_posts/api/0200-01-01-v0.6.4.html
@@ -939,7 +939,7 @@ auto-instantiate many of its features.
 </p>
 <ul>
 <li><code>url</code> can be either be a full URL to a TileJSON file, like
-<code>{{site.tileApi}}/v3/tmcw.map-hehqnmda.jsonp</code>, or a bare id, like
+<code>{{site.tileapi}}/v3/tmcw.map-hehqnmda.jsonp</code>, or a bare id, like
 <code>tmcw.map-hehqnmda</code>, which will get expanded to the former. This can also
 accept an array of urls in the same format.</li>
 <li><p><code>callback</code> must be a function that receives either a single object with details
@@ -986,7 +986,7 @@ mapbox.load(&#39;tmcw.map-hehqnmda&#39;, function(o) {
 </p>
 <pre><code>&lt;div id=&#39;map&#39; style=&#39;width:500px;height:400px;&#39;&gt;&lt;/div&gt;
 &lt;script&gt;
-mapbox.auto(&#39;map&#39;, &#39;{{site.tileApi}}/v3/tmcw.map-hehqnmda.jsonp&#39;);
+mapbox.auto(&#39;map&#39;, &#39;{{site.tileapi}}/v3/tmcw.map-hehqnmda.jsonp&#39;);
 &lt;/script&gt;</code></pre>
 </div><h1>Layer</h1>
 <div id="content-mapbox.auto"class="depth-1"><p><code>mapbox.layer</code> is a fast way to add layers to your map without having to deal with complex configuration.
@@ -1055,7 +1055,7 @@ TileJSON information has been asynchronously loaded.</li>
 <p><strong>Example:</strong>
 
 </p>
-<pre><code>var layer = mapbox.layer().url(&#39;{{site.tileApi}}/v3/tmcw.map-hehqnmda.jsonp&#39;);</code></pre>
+<pre><code>var layer = mapbox.layer().url(&#39;{{site.tileapi}}/v3/tmcw.map-hehqnmda.jsonp&#39;);</code></pre>
 </div><h3 id="layer.tilejson">layer.tilejson<span class="bracket">(</span><span class="args">[tilejson]</span><span class="bracket">)</span></h3>
 <div id="content-layer.tilejson"class="depth-3"><p>Set layer options directly from a <a href="https://github.com/mapbox/tilejson-spec">TileJSON</a> object.
 

--- a/docs/_posts/api/0200-01-01-v0.6.5.html
+++ b/docs/_posts/api/0200-01-01-v0.6.5.html
@@ -970,7 +970,7 @@ auto-instantiate many of its features.
 </p>
 <ul>
 <li><code>url</code> can be either be a full URL to a TileJSON file, like
-<code>http://a.tiles.mapbox.com/v3/tmcw.map-hehqnmda.jsonp</code>, or a bare id, like
+<code>{{site.tileApi}}/v3/tmcw.map-hehqnmda.jsonp</code>, or a bare id, like
 <code>tmcw.map-hehqnmda</code>, which will get expanded to the former. This can also
 accept an array of urls in the same format.</li>
 <li><p><code>callback</code> must be a function that receives either a single object with details
@@ -1017,7 +1017,7 @@ mapbox.load(&#39;tmcw.map-hehqnmda&#39;, function(o) {
 </p>
 <pre><code>&lt;div id=&#39;map&#39; style=&#39;width:500px;height:400px;&#39;&gt;&lt;/div&gt;
 &lt;script&gt;
-mapbox.auto(&#39;map&#39;, &#39;http://a.tiles.mapbox.com/v3/tmcw.map-hehqnmda.jsonp&#39;);
+mapbox.auto(&#39;map&#39;, &#39;{{site.tileApi}}/v3/tmcw.map-hehqnmda.jsonp&#39;);
 &lt;/script&gt;</code></pre>
 </div><h1>Layer</h1>
 <div id="content-mapbox.auto"class="depth-1"><p><code>mapbox.layer</code> is a fast way to add layers to your map without having to deal with complex configuration.
@@ -1086,7 +1086,7 @@ TileJSON information has been asynchronously loaded.</li>
 <p><strong>Example:</strong>
 
 </p>
-<pre><code>var layer = mapbox.layer().url(&#39;http://a.tiles.mapbox.com/v3/tmcw.map-hehqnmda.jsonp&#39;);</code></pre>
+<pre><code>var layer = mapbox.layer().url(&#39;{{site.tileApi}}/v3/tmcw.map-hehqnmda.jsonp&#39;);</code></pre>
 </div><h3 id="layer.tilejson">layer.tilejson<span class="bracket">(</span><span class="args">[tilejson]</span><span class="bracket">)</span></h3>
 <div id="content-layer.tilejson"class="depth-3"><p>Set layer options directly from a <a href="https://github.com/mapbox/tilejson-spec">TileJSON</a> object.
 

--- a/docs/_posts/api/0200-01-01-v0.6.5.html
+++ b/docs/_posts/api/0200-01-01-v0.6.5.html
@@ -970,7 +970,7 @@ auto-instantiate many of its features.
 </p>
 <ul>
 <li><code>url</code> can be either be a full URL to a TileJSON file, like
-<code>{{site.tileApi}}/v3/tmcw.map-hehqnmda.jsonp</code>, or a bare id, like
+<code>{{site.tileapi}}/v3/tmcw.map-hehqnmda.jsonp</code>, or a bare id, like
 <code>tmcw.map-hehqnmda</code>, which will get expanded to the former. This can also
 accept an array of urls in the same format.</li>
 <li><p><code>callback</code> must be a function that receives either a single object with details
@@ -1017,7 +1017,7 @@ mapbox.load(&#39;tmcw.map-hehqnmda&#39;, function(o) {
 </p>
 <pre><code>&lt;div id=&#39;map&#39; style=&#39;width:500px;height:400px;&#39;&gt;&lt;/div&gt;
 &lt;script&gt;
-mapbox.auto(&#39;map&#39;, &#39;{{site.tileApi}}/v3/tmcw.map-hehqnmda.jsonp&#39;);
+mapbox.auto(&#39;map&#39;, &#39;{{site.tileapi}}/v3/tmcw.map-hehqnmda.jsonp&#39;);
 &lt;/script&gt;</code></pre>
 </div><h1>Layer</h1>
 <div id="content-mapbox.auto"class="depth-1"><p><code>mapbox.layer</code> is a fast way to add layers to your map without having to deal with complex configuration.
@@ -1086,7 +1086,7 @@ TileJSON information has been asynchronously loaded.</li>
 <p><strong>Example:</strong>
 
 </p>
-<pre><code>var layer = mapbox.layer().url(&#39;{{site.tileApi}}/v3/tmcw.map-hehqnmda.jsonp&#39;);</code></pre>
+<pre><code>var layer = mapbox.layer().url(&#39;{{site.tileapi}}/v3/tmcw.map-hehqnmda.jsonp&#39;);</code></pre>
 </div><h3 id="layer.tilejson">layer.tilejson<span class="bracket">(</span><span class="args">[tilejson]</span><span class="bracket">)</span></h3>
 <div id="content-layer.tilejson"class="depth-3"><p>Set layer options directly from a <a href="https://github.com/mapbox/tilejson-spec">TileJSON</a> object.
 

--- a/docs/_posts/api/0200-01-01-v0.6.6.html
+++ b/docs/_posts/api/0200-01-01-v0.6.6.html
@@ -970,7 +970,7 @@ auto-instantiate many of its features.
 </p>
 <ul>
 <li><code>url</code> can be either be a full URL to a TileJSON file, like
-<code>http://a.tiles.mapbox.com/v3/tmcw.map-hehqnmda.jsonp</code>, or a bare id, like
+<code>{{site.tileApi}}/v3/tmcw.map-hehqnmda.jsonp</code>, or a bare id, like
 <code>tmcw.map-hehqnmda</code>, which will get expanded to the former. This can also
 accept an array of urls in the same format.</li>
 <li><p><code>callback</code> must be a function that receives either a single object with details
@@ -1017,7 +1017,7 @@ mapbox.load(&#39;tmcw.map-hehqnmda&#39;, function(o) {
 </p>
 <pre><code>&lt;div id=&#39;map&#39; style=&#39;width:500px;height:400px;&#39;&gt;&lt;/div&gt;
 &lt;script&gt;
-mapbox.auto(&#39;map&#39;, &#39;http://a.tiles.mapbox.com/v3/tmcw.map-hehqnmda.jsonp&#39;);
+mapbox.auto(&#39;map&#39;, &#39;{{site.tileApi}}/v3/tmcw.map-hehqnmda.jsonp&#39;);
 &lt;/script&gt;</code></pre>
 </div><h1>Layer</h1>
 <div id="content-mapbox.auto"class="depth-1"><p><code>mapbox.layer</code> is a fast way to add layers to your map without having to deal with complex configuration.
@@ -1086,7 +1086,7 @@ TileJSON information has been asynchronously loaded.</li>
 <p><strong>Example:</strong>
 
 </p>
-<pre><code>var layer = mapbox.layer().url(&#39;http://a.tiles.mapbox.com/v3/tmcw.map-hehqnmda.jsonp&#39;);</code></pre>
+<pre><code>var layer = mapbox.layer().url(&#39;{{site.tileApi}}/v3/tmcw.map-hehqnmda.jsonp&#39;);</code></pre>
 </div><h3 id="layer.tilejson">layer.tilejson<span class="bracket">(</span><span class="args">[tilejson]</span><span class="bracket">)</span></h3>
 <div id="content-layer.tilejson"class="depth-3"><p>Set layer options directly from a <a href="https://github.com/mapbox/tilejson-spec">TileJSON</a> object.
 

--- a/docs/_posts/api/0200-01-01-v0.6.6.html
+++ b/docs/_posts/api/0200-01-01-v0.6.6.html
@@ -970,7 +970,7 @@ auto-instantiate many of its features.
 </p>
 <ul>
 <li><code>url</code> can be either be a full URL to a TileJSON file, like
-<code>{{site.tileApi}}/v3/tmcw.map-hehqnmda.jsonp</code>, or a bare id, like
+<code>{{site.tileapi}}/v3/tmcw.map-hehqnmda.jsonp</code>, or a bare id, like
 <code>tmcw.map-hehqnmda</code>, which will get expanded to the former. This can also
 accept an array of urls in the same format.</li>
 <li><p><code>callback</code> must be a function that receives either a single object with details
@@ -1017,7 +1017,7 @@ mapbox.load(&#39;tmcw.map-hehqnmda&#39;, function(o) {
 </p>
 <pre><code>&lt;div id=&#39;map&#39; style=&#39;width:500px;height:400px;&#39;&gt;&lt;/div&gt;
 &lt;script&gt;
-mapbox.auto(&#39;map&#39;, &#39;{{site.tileApi}}/v3/tmcw.map-hehqnmda.jsonp&#39;);
+mapbox.auto(&#39;map&#39;, &#39;{{site.tileapi}}/v3/tmcw.map-hehqnmda.jsonp&#39;);
 &lt;/script&gt;</code></pre>
 </div><h1>Layer</h1>
 <div id="content-mapbox.auto"class="depth-1"><p><code>mapbox.layer</code> is a fast way to add layers to your map without having to deal with complex configuration.
@@ -1086,7 +1086,7 @@ TileJSON information has been asynchronously loaded.</li>
 <p><strong>Example:</strong>
 
 </p>
-<pre><code>var layer = mapbox.layer().url(&#39;{{site.tileApi}}/v3/tmcw.map-hehqnmda.jsonp&#39;);</code></pre>
+<pre><code>var layer = mapbox.layer().url(&#39;{{site.tileapi}}/v3/tmcw.map-hehqnmda.jsonp&#39;);</code></pre>
 </div><h3 id="layer.tilejson">layer.tilejson<span class="bracket">(</span><span class="args">[tilejson]</span><span class="bracket">)</span></h3>
 <div id="content-layer.tilejson"class="depth-3"><p>Set layer options directly from a <a href="https://github.com/mapbox/tilejson-spec">TileJSON</a> object.
 

--- a/docs/_posts/api/0200-01-01-v0.6.7.html
+++ b/docs/_posts/api/0200-01-01-v0.6.7.html
@@ -970,7 +970,7 @@ auto-instantiate many of its features.
 </p>
 <ul>
 <li><code>url</code> can be either be a full URL to a TileJSON file, like
-<code>http://a.tiles.mapbox.com/v3/tmcw.map-hehqnmda.jsonp</code>, or a bare id, like
+<code>{{site.tileApi}}/v3/tmcw.map-hehqnmda.jsonp</code>, or a bare id, like
 <code>tmcw.map-hehqnmda</code>, which will get expanded to the former. This can also
 accept an array of urls in the same format.</li>
 <li><p><code>callback</code> must be a function that receives either a single object with details
@@ -1017,7 +1017,7 @@ mapbox.load(&#39;tmcw.map-hehqnmda&#39;, function(o) {
 </p>
 <pre><code>&lt;div id=&#39;map&#39; style=&#39;width:500px;height:400px;&#39;&gt;&lt;/div&gt;
 &lt;script&gt;
-mapbox.auto(&#39;map&#39;, &#39;http://a.tiles.mapbox.com/v3/tmcw.map-hehqnmda.jsonp&#39;);
+mapbox.auto(&#39;map&#39;, &#39;{{site.tileApi}}/v3/tmcw.map-hehqnmda.jsonp&#39;);
 &lt;/script&gt;</code></pre>
 </div><h1>Layer</h1>
 <div id="content-mapbox.auto"class="depth-1"><p><code>mapbox.layer</code> is a fast way to add layers to your map without having to deal with complex configuration.
@@ -1086,7 +1086,7 @@ TileJSON information has been asynchronously loaded.</li>
 <p><strong>Example:</strong>
 
 </p>
-<pre><code>var layer = mapbox.layer().url(&#39;http://a.tiles.mapbox.com/v3/tmcw.map-hehqnmda.jsonp&#39;);</code></pre>
+<pre><code>var layer = mapbox.layer().url(&#39;{{site.tileApi}}/v3/tmcw.map-hehqnmda.jsonp&#39;);</code></pre>
 </div><h3 id="layer.tilejson">layer.tilejson<span class="bracket">(</span><span class="args">[tilejson]</span><span class="bracket">)</span></h3>
 <div id="content-layer.tilejson"class="depth-3"><p>Set layer options directly from a <a href="https://github.com/mapbox/tilejson-spec">TileJSON</a> object.
 

--- a/docs/_posts/api/0200-01-01-v0.6.7.html
+++ b/docs/_posts/api/0200-01-01-v0.6.7.html
@@ -970,7 +970,7 @@ auto-instantiate many of its features.
 </p>
 <ul>
 <li><code>url</code> can be either be a full URL to a TileJSON file, like
-<code>{{site.tileApi}}/v3/tmcw.map-hehqnmda.jsonp</code>, or a bare id, like
+<code>{{site.tileapi}}/v3/tmcw.map-hehqnmda.jsonp</code>, or a bare id, like
 <code>tmcw.map-hehqnmda</code>, which will get expanded to the former. This can also
 accept an array of urls in the same format.</li>
 <li><p><code>callback</code> must be a function that receives either a single object with details
@@ -1017,7 +1017,7 @@ mapbox.load(&#39;tmcw.map-hehqnmda&#39;, function(o) {
 </p>
 <pre><code>&lt;div id=&#39;map&#39; style=&#39;width:500px;height:400px;&#39;&gt;&lt;/div&gt;
 &lt;script&gt;
-mapbox.auto(&#39;map&#39;, &#39;{{site.tileApi}}/v3/tmcw.map-hehqnmda.jsonp&#39;);
+mapbox.auto(&#39;map&#39;, &#39;{{site.tileapi}}/v3/tmcw.map-hehqnmda.jsonp&#39;);
 &lt;/script&gt;</code></pre>
 </div><h1>Layer</h1>
 <div id="content-mapbox.auto"class="depth-1"><p><code>mapbox.layer</code> is a fast way to add layers to your map without having to deal with complex configuration.
@@ -1086,7 +1086,7 @@ TileJSON information has been asynchronously loaded.</li>
 <p><strong>Example:</strong>
 
 </p>
-<pre><code>var layer = mapbox.layer().url(&#39;{{site.tileApi}}/v3/tmcw.map-hehqnmda.jsonp&#39;);</code></pre>
+<pre><code>var layer = mapbox.layer().url(&#39;{{site.tileapi}}/v3/tmcw.map-hehqnmda.jsonp&#39;);</code></pre>
 </div><h3 id="layer.tilejson">layer.tilejson<span class="bracket">(</span><span class="args">[tilejson]</span><span class="bracket">)</span></h3>
 <div id="content-layer.tilejson"class="depth-3"><p>Set layer options directly from a <a href="https://github.com/mapbox/tilejson-spec">TileJSON</a> object.
 

--- a/docs/_posts/api/0200-01-01-v1.0.0.html
+++ b/docs/_posts/api/0200-01-01-v1.0.0.html
@@ -47,7 +47,7 @@ navigation:
   items:
 
 ---
-{% raw %}
+
 <div></div><h1>Map</h1>
 <div id="content-undefined"class="space-bottom depth-1"></div><h2 id="L.mapbox.map">L.mapbox.map<span class="bracket">(</span><span class="args">element: Element, id: string | url: string | tilejson: object, [options: object]</span><span class="bracket">)</span></h2>
 <div id="content-L.mapbox.map"class="space-bottom depth-2"><p>Create and automatically configure a map with layers, markers, and
@@ -66,7 +66,7 @@ reference.
 </p>
 <ul>
 <li>A map <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li>
 </ul>
 <p>The third argument is optional. If provided, it is the same options
@@ -122,7 +122,7 @@ interface to layers from MapBox and elsewhere.
 </p>
 <ul>
 <li>An <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A TileJSON object, from your own Javascript code</li>
 </ul>
 <p>The second argument is optional. If provided, it is the same options
@@ -141,7 +141,7 @@ to <code>L.mapbox.tileLayer</code> which, if retina is detected, is used instead
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a tilejson resource
-var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileapi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided,you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -209,7 +209,7 @@ interactivity into your map, which you can easily access with <code>L.mapbox.gri
 </p>
 <ul>
 <li>An <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A TileJSON object, from your own Javascript code</li>
 </ul>
 <p><em>Example</em>:
@@ -271,7 +271,7 @@ from MapBox and elsewhere into your map.
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A GeoJSON object, from your own Javascript code</li>
 </ol>
 <p>The second argument is optional. If provided, it is the same options
@@ -425,7 +425,7 @@ markerLayer.setGeoJSON({
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 </ol>
 <p><em>Returns</em> a <code>L.mapbox.geocoder</code> object.
 
@@ -568,7 +568,7 @@ the <a href="http://mapbox.com/developers/api/#geocoding">MapBox Geocoding API</
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 </ol>
 <p><em>Example</em>
 
@@ -697,4 +697,4 @@ is available by applying <code>class=&quot;dark&quot;</code> to the map div.
 </p>
 <pre><code>&lt;div id=&quot;map&quot; class=&quot;dark&quot;&gt;&lt;/div&gt;</code></pre>
 </div>
-{% endraw %}
+

--- a/docs/_posts/api/0200-01-01-v1.0.0.html
+++ b/docs/_posts/api/0200-01-01-v1.0.0.html
@@ -66,7 +66,7 @@ reference.
 </p>
 <ul>
 <li>A map <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li>
 </ul>
 <p>The third argument is optional. If provided, it is the same options
@@ -122,7 +122,7 @@ interface to layers from MapBox and elsewhere.
 </p>
 <ul>
 <li>An <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A TileJSON object, from your own Javascript code</li>
 </ul>
 <p>The second argument is optional. If provided, it is the same options
@@ -141,7 +141,7 @@ to <code>L.mapbox.tileLayer</code> which, if retina is detected, is used instead
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a tilejson resource
-var layer = L.mapbox.tileLayer(&#39;http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided,you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -209,7 +209,7 @@ interactivity into your map, which you can easily access with <code>L.mapbox.gri
 </p>
 <ul>
 <li>An <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A TileJSON object, from your own Javascript code</li>
 </ul>
 <p><em>Example</em>:
@@ -271,7 +271,7 @@ from MapBox and elsewhere into your map.
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A GeoJSON object, from your own Javascript code</li>
 </ol>
 <p>The second argument is optional. If provided, it is the same options
@@ -425,7 +425,7 @@ markerLayer.setGeoJSON({
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 </ol>
 <p><em>Returns</em> a <code>L.mapbox.geocoder</code> object.
 
@@ -568,7 +568,7 @@ the <a href="http://mapbox.com/developers/api/#geocoding">MapBox Geocoding API</
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 </ol>
 <p><em>Example</em>
 

--- a/docs/_posts/api/0200-01-01-v1.0.1.html
+++ b/docs/_posts/api/0200-01-01-v1.0.1.html
@@ -68,11 +68,11 @@ maps and services.</p>
 <div id="content-MapBox.js & Leaflet"class="depth-2"><p>Here&#39;s a simple page that you can set up with MapBox.js:</p>
 <pre><code>&lt;html&gt;
 &lt;head&gt;
-  &lt;link href=&#39;{{site.tileApi}}/mapbox.js/v1.0.0/mapbox.css&#39; rel=&#39;stylesheet&#39; /&gt;
+  &lt;link href=&#39;{{site.tileapi}}/mapbox.js/v1.0.0/mapbox.css&#39; rel=&#39;stylesheet&#39; /&gt;
   &lt;!--[if lte IE 8]&gt;
-    &lt;link href=&#39;{{site.tileApi}}/mapbox.js/v1.0.0/mapbox.ie.css&#39; rel=&#39;stylesheet&#39; /&gt;
+    &lt;link href=&#39;{{site.tileapi}}/mapbox.js/v1.0.0/mapbox.ie.css&#39; rel=&#39;stylesheet&#39; /&gt;
   &lt;![endif]--&gt;
-  &lt;script src=&#39;{{site.tileApi}}/mapbox.js/v1.0.0/mapbox.js&#39;&gt;&lt;/script&gt;
+  &lt;script src=&#39;{{site.tileapi}}/mapbox.js/v1.0.0/mapbox.js&#39;&gt;&lt;/script&gt;
 &lt;/head&gt;
 &lt;body&gt;
   &lt;div id=&#39;map&#39; class=&#39;dark&#39;&gt;&lt;/div&gt;
@@ -146,7 +146,7 @@ reference.</p>
 <p>The second argument is optional and can be:</p>
 <ul>
 <li>A map <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li>
 </ul>
 <p>The third argument is optional. If provided, it is the same options
@@ -184,7 +184,7 @@ interface to layers from MapBox and elsewhere.</p>
 <p>The first argument is required and must be:</p>
 <ul>
 <li>An <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A TileJSON object, from your own Javascript code</li>
 </ul>
 <p>The second argument is optional. If provided, it is the same options
@@ -199,7 +199,7 @@ to <code>L.mapbox.tileLayer</code> which, if retina is detected, is used instead
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a tilejson resource
-var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileapi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided,you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -243,7 +243,7 @@ interactivity into your map, which you can easily access with <code>L.mapbox.gri
 <p>The first argument is required and must be:</p>
 <ul>
 <li>An <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A TileJSON object, from your own Javascript code</li>
 </ul>
 <p><em>Example</em>:</p>
@@ -282,7 +282,7 @@ from MapBox and elsewhere into your map.</p>
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A GeoJSON object, from your own Javascript code</li>
 </ol>
 <p>The second argument is optional. If provided, it is the same options
@@ -382,7 +382,7 @@ reverse geocoding.</p>
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL <code>string</code> that points to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL <code>string</code> that points to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 </ol>
 <p><em>Returns</em> a <code>L.mapbox.geocoder</code> object.</p>
 </div><h3 id="geocoder.query">geocoder.query<span class="bracket">(</span><span class="args">queryString: string, callback: function</span><span class="bracket">)</span></h3>
@@ -483,7 +483,7 @@ the <a href="http://mapbox.com/developers/api/#geocoding">MapBox Geocoding API</
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 </ol>
 <p><em>Example</em></p>
 <pre><code>var map = L.map(&#39;map&#39;)

--- a/docs/_posts/api/0200-01-01-v1.0.1.html
+++ b/docs/_posts/api/0200-01-01-v1.0.1.html
@@ -68,11 +68,11 @@ maps and services.</p>
 <div id="content-MapBox.js & Leaflet"class="depth-2"><p>Here&#39;s a simple page that you can set up with MapBox.js:</p>
 <pre><code>&lt;html&gt;
 &lt;head&gt;
-  &lt;link href=&#39;http://api.tiles.mapbox.com/mapbox.js/v1.0.0/mapbox.css&#39; rel=&#39;stylesheet&#39; /&gt;
+  &lt;link href=&#39;{{site.tileApi}}/mapbox.js/v1.0.0/mapbox.css&#39; rel=&#39;stylesheet&#39; /&gt;
   &lt;!--[if lte IE 8]&gt;
-    &lt;link href=&#39;http://api.tiles.mapbox.com/mapbox.js/v1.0.0/mapbox.ie.css&#39; rel=&#39;stylesheet&#39; /&gt;
+    &lt;link href=&#39;{{site.tileApi}}/mapbox.js/v1.0.0/mapbox.ie.css&#39; rel=&#39;stylesheet&#39; /&gt;
   &lt;![endif]--&gt;
-  &lt;script src=&#39;http://api.tiles.mapbox.com/mapbox.js/v1.0.0/mapbox.js&#39;&gt;&lt;/script&gt;
+  &lt;script src=&#39;{{site.tileApi}}/mapbox.js/v1.0.0/mapbox.js&#39;&gt;&lt;/script&gt;
 &lt;/head&gt;
 &lt;body&gt;
   &lt;div id=&#39;map&#39; class=&#39;dark&#39;&gt;&lt;/div&gt;
@@ -146,7 +146,7 @@ reference.</p>
 <p>The second argument is optional and can be:</p>
 <ul>
 <li>A map <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li>
 </ul>
 <p>The third argument is optional. If provided, it is the same options
@@ -184,7 +184,7 @@ interface to layers from MapBox and elsewhere.</p>
 <p>The first argument is required and must be:</p>
 <ul>
 <li>An <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A TileJSON object, from your own Javascript code</li>
 </ul>
 <p>The second argument is optional. If provided, it is the same options
@@ -199,7 +199,7 @@ to <code>L.mapbox.tileLayer</code> which, if retina is detected, is used instead
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a tilejson resource
-var layer = L.mapbox.tileLayer(&#39;http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided,you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -243,7 +243,7 @@ interactivity into your map, which you can easily access with <code>L.mapbox.gri
 <p>The first argument is required and must be:</p>
 <ul>
 <li>An <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A TileJSON object, from your own Javascript code</li>
 </ul>
 <p><em>Example</em>:</p>
@@ -282,7 +282,7 @@ from MapBox and elsewhere into your map.</p>
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A GeoJSON object, from your own Javascript code</li>
 </ol>
 <p>The second argument is optional. If provided, it is the same options
@@ -382,7 +382,7 @@ reverse geocoding.</p>
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL <code>string</code> that points to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL <code>string</code> that points to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 </ol>
 <p><em>Returns</em> a <code>L.mapbox.geocoder</code> object.</p>
 </div><h3 id="geocoder.query">geocoder.query<span class="bracket">(</span><span class="args">queryString: string, callback: function</span><span class="bracket">)</span></h3>
@@ -483,7 +483,7 @@ the <a href="http://mapbox.com/developers/api/#geocoding">MapBox Geocoding API</
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 </ol>
 <p><em>Example</em></p>
 <pre><code>var map = L.map(&#39;map&#39;)

--- a/docs/_posts/api/0200-01-01-v1.0.2.html
+++ b/docs/_posts/api/0200-01-01-v1.0.2.html
@@ -68,11 +68,11 @@ maps and services.</p>
 <div id="content-MapBox.js & Leaflet"class="depth-2"><p>Here&#39;s a simple page that you can set up with MapBox.js:</p>
 <pre><code>&lt;html&gt;
 &lt;head&gt;
-  &lt;link href=&#39;{{site.tileApi}}/mapbox.js/v1.0.0/mapbox.css&#39; rel=&#39;stylesheet&#39; /&gt;
+  &lt;link href=&#39;{{site.tileapi}}/mapbox.js/v1.0.0/mapbox.css&#39; rel=&#39;stylesheet&#39; /&gt;
   &lt;!--[if lte IE 8]&gt;
-    &lt;link href=&#39;{{site.tileApi}}/mapbox.js/v1.0.0/mapbox.ie.css&#39; rel=&#39;stylesheet&#39; /&gt;
+    &lt;link href=&#39;{{site.tileapi}}/mapbox.js/v1.0.0/mapbox.ie.css&#39; rel=&#39;stylesheet&#39; /&gt;
   &lt;![endif]--&gt;
-  &lt;script src=&#39;{{site.tileApi}}/mapbox.js/v1.0.0/mapbox.js&#39;&gt;&lt;/script&gt;
+  &lt;script src=&#39;{{site.tileapi}}/mapbox.js/v1.0.0/mapbox.js&#39;&gt;&lt;/script&gt;
 &lt;/head&gt;
 &lt;body&gt;
   &lt;div id=&#39;map&#39; class=&#39;dark&#39;&gt;&lt;/div&gt;
@@ -146,7 +146,7 @@ reference.</p>
 <p>The second argument is optional and can be:</p>
 <ul>
 <li>A map <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li>
 </ul>
 <p>The third argument is optional. If provided, it is the same options
@@ -184,7 +184,7 @@ interface to layers from MapBox and elsewhere.</p>
 <p>The first argument is required and must be:</p>
 <ul>
 <li>An <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A TileJSON object, from your own Javascript code</li>
 </ul>
 <p>The second argument is optional. If provided, it is the same options
@@ -199,7 +199,7 @@ to <code>L.mapbox.tileLayer</code> which, if retina is detected, is used instead
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a tilejson resource
-var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileapi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided,you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -243,7 +243,7 @@ interactivity into your map, which you can easily access with <code>L.mapbox.gri
 <p>The first argument is required and must be:</p>
 <ul>
 <li>An <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A TileJSON object, from your own Javascript code</li>
 </ul>
 <p><em>Example</em>:</p>
@@ -282,7 +282,7 @@ from MapBox and elsewhere into your map.</p>
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A GeoJSON object, from your own Javascript code</li>
 </ol>
 <p>The second argument is optional. If provided, it is the same options
@@ -382,7 +382,7 @@ reverse geocoding.</p>
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL <code>string</code> that points to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL <code>string</code> that points to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 </ol>
 <p><em>Returns</em> a <code>L.mapbox.geocoder</code> object.</p>
 </div><h3 id="geocoder.query">geocoder.query<span class="bracket">(</span><span class="args">queryString: string, callback: function</span><span class="bracket">)</span></h3>
@@ -483,7 +483,7 @@ the <a href="http://mapbox.com/developers/api/#geocoding">MapBox Geocoding API</
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 </ol>
 <p><em>Example</em></p>
 <pre><code>var map = L.map(&#39;map&#39;)

--- a/docs/_posts/api/0200-01-01-v1.0.2.html
+++ b/docs/_posts/api/0200-01-01-v1.0.2.html
@@ -68,11 +68,11 @@ maps and services.</p>
 <div id="content-MapBox.js & Leaflet"class="depth-2"><p>Here&#39;s a simple page that you can set up with MapBox.js:</p>
 <pre><code>&lt;html&gt;
 &lt;head&gt;
-  &lt;link href=&#39;http://api.tiles.mapbox.com/mapbox.js/v1.0.0/mapbox.css&#39; rel=&#39;stylesheet&#39; /&gt;
+  &lt;link href=&#39;{{site.tileApi}}/mapbox.js/v1.0.0/mapbox.css&#39; rel=&#39;stylesheet&#39; /&gt;
   &lt;!--[if lte IE 8]&gt;
-    &lt;link href=&#39;http://api.tiles.mapbox.com/mapbox.js/v1.0.0/mapbox.ie.css&#39; rel=&#39;stylesheet&#39; /&gt;
+    &lt;link href=&#39;{{site.tileApi}}/mapbox.js/v1.0.0/mapbox.ie.css&#39; rel=&#39;stylesheet&#39; /&gt;
   &lt;![endif]--&gt;
-  &lt;script src=&#39;http://api.tiles.mapbox.com/mapbox.js/v1.0.0/mapbox.js&#39;&gt;&lt;/script&gt;
+  &lt;script src=&#39;{{site.tileApi}}/mapbox.js/v1.0.0/mapbox.js&#39;&gt;&lt;/script&gt;
 &lt;/head&gt;
 &lt;body&gt;
   &lt;div id=&#39;map&#39; class=&#39;dark&#39;&gt;&lt;/div&gt;
@@ -146,7 +146,7 @@ reference.</p>
 <p>The second argument is optional and can be:</p>
 <ul>
 <li>A map <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li>
 </ul>
 <p>The third argument is optional. If provided, it is the same options
@@ -184,7 +184,7 @@ interface to layers from MapBox and elsewhere.</p>
 <p>The first argument is required and must be:</p>
 <ul>
 <li>An <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A TileJSON object, from your own Javascript code</li>
 </ul>
 <p>The second argument is optional. If provided, it is the same options
@@ -199,7 +199,7 @@ to <code>L.mapbox.tileLayer</code> which, if retina is detected, is used instead
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a tilejson resource
-var layer = L.mapbox.tileLayer(&#39;http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided,you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -243,7 +243,7 @@ interactivity into your map, which you can easily access with <code>L.mapbox.gri
 <p>The first argument is required and must be:</p>
 <ul>
 <li>An <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A TileJSON object, from your own Javascript code</li>
 </ul>
 <p><em>Example</em>:</p>
@@ -282,7 +282,7 @@ from MapBox and elsewhere into your map.</p>
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A GeoJSON object, from your own Javascript code</li>
 </ol>
 <p>The second argument is optional. If provided, it is the same options
@@ -382,7 +382,7 @@ reverse geocoding.</p>
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL <code>string</code> that points to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL <code>string</code> that points to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 </ol>
 <p><em>Returns</em> a <code>L.mapbox.geocoder</code> object.</p>
 </div><h3 id="geocoder.query">geocoder.query<span class="bracket">(</span><span class="args">queryString: string, callback: function</span><span class="bracket">)</span></h3>
@@ -483,7 +483,7 @@ the <a href="http://mapbox.com/developers/api/#geocoding">MapBox Geocoding API</
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 </ol>
 <p><em>Example</em></p>
 <pre><code>var map = L.map(&#39;map&#39;)

--- a/docs/_posts/api/0200-01-01-v1.0.3.html
+++ b/docs/_posts/api/0200-01-01-v1.0.3.html
@@ -68,11 +68,11 @@ maps and services.</p>
 <div id="content-MapBox.js & Leaflet"class="depth-2"><p>Here&#39;s a simple page that you can set up with MapBox.js:</p>
 <pre><code>&lt;html&gt;
 &lt;head&gt;
-  &lt;link href=&#39;{{site.tileApi}}/mapbox.js/v1.0.0/mapbox.css&#39; rel=&#39;stylesheet&#39; /&gt;
+  &lt;link href=&#39;{{site.tileapi}}/mapbox.js/v1.0.0/mapbox.css&#39; rel=&#39;stylesheet&#39; /&gt;
   &lt;!--[if lte IE 8]&gt;
-    &lt;link href=&#39;{{site.tileApi}}/mapbox.js/v1.0.0/mapbox.ie.css&#39; rel=&#39;stylesheet&#39; /&gt;
+    &lt;link href=&#39;{{site.tileapi}}/mapbox.js/v1.0.0/mapbox.ie.css&#39; rel=&#39;stylesheet&#39; /&gt;
   &lt;![endif]--&gt;
-  &lt;script src=&#39;{{site.tileApi}}/mapbox.js/v1.0.0/mapbox.js&#39;&gt;&lt;/script&gt;
+  &lt;script src=&#39;{{site.tileapi}}/mapbox.js/v1.0.0/mapbox.js&#39;&gt;&lt;/script&gt;
 &lt;/head&gt;
 &lt;body&gt;
   &lt;div id=&#39;map&#39; class=&#39;dark&#39;&gt;&lt;/div&gt;
@@ -160,7 +160,7 @@ reference.</p>
 <p>The second argument is optional and can be:</p>
 <ul>
 <li>A map <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li>
 </ul>
 <p>The third argument is optional. If provided, it is the same options
@@ -198,7 +198,7 @@ interface to layers from MapBox and elsewhere.</p>
 <p>The first argument is required and must be:</p>
 <ul>
 <li>An <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A TileJSON object, from your own Javascript code</li>
 </ul>
 <p>The second argument is optional. If provided, it is the same options
@@ -213,7 +213,7 @@ to <code>L.mapbox.tileLayer</code> which, if retina is detected, is used instead
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a tilejson resource
-var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileapi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided,you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -257,7 +257,7 @@ interactivity into your map, which you can easily access with <code>L.mapbox.gri
 <p>The first argument is required and must be:</p>
 <ul>
 <li>An <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A TileJSON object, from your own Javascript code</li>
 </ul>
 <p><em>Example</em>:</p>
@@ -296,7 +296,7 @@ from MapBox and elsewhere into your map.</p>
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A GeoJSON object, from your own Javascript code</li>
 </ol>
 <p>The second argument is optional. If provided, it is the same options
@@ -396,7 +396,7 @@ reverse geocoding.</p>
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL <code>string</code> that points to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL <code>string</code> that points to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 </ol>
 <p><em>Returns</em> a <code>L.mapbox.geocoder</code> object.</p>
 </div><h3 id="geocoder.query">geocoder.query<span class="bracket">(</span><span class="args">queryString: string, callback: function</span><span class="bracket">)</span></h3>
@@ -497,7 +497,7 @@ the <a href="http://mapbox.com/developers/api/#geocoding">MapBox Geocoding API</
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 </ol>
 <p><em>Example</em></p>
 <pre><code>var map = L.map(&#39;map&#39;)

--- a/docs/_posts/api/0200-01-01-v1.0.3.html
+++ b/docs/_posts/api/0200-01-01-v1.0.3.html
@@ -68,11 +68,11 @@ maps and services.</p>
 <div id="content-MapBox.js & Leaflet"class="depth-2"><p>Here&#39;s a simple page that you can set up with MapBox.js:</p>
 <pre><code>&lt;html&gt;
 &lt;head&gt;
-  &lt;link href=&#39;http://api.tiles.mapbox.com/mapbox.js/v1.0.0/mapbox.css&#39; rel=&#39;stylesheet&#39; /&gt;
+  &lt;link href=&#39;{{site.tileApi}}/mapbox.js/v1.0.0/mapbox.css&#39; rel=&#39;stylesheet&#39; /&gt;
   &lt;!--[if lte IE 8]&gt;
-    &lt;link href=&#39;http://api.tiles.mapbox.com/mapbox.js/v1.0.0/mapbox.ie.css&#39; rel=&#39;stylesheet&#39; /&gt;
+    &lt;link href=&#39;{{site.tileApi}}/mapbox.js/v1.0.0/mapbox.ie.css&#39; rel=&#39;stylesheet&#39; /&gt;
   &lt;![endif]--&gt;
-  &lt;script src=&#39;http://api.tiles.mapbox.com/mapbox.js/v1.0.0/mapbox.js&#39;&gt;&lt;/script&gt;
+  &lt;script src=&#39;{{site.tileApi}}/mapbox.js/v1.0.0/mapbox.js&#39;&gt;&lt;/script&gt;
 &lt;/head&gt;
 &lt;body&gt;
   &lt;div id=&#39;map&#39; class=&#39;dark&#39;&gt;&lt;/div&gt;
@@ -160,7 +160,7 @@ reference.</p>
 <p>The second argument is optional and can be:</p>
 <ul>
 <li>A map <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li>
 </ul>
 <p>The third argument is optional. If provided, it is the same options
@@ -198,7 +198,7 @@ interface to layers from MapBox and elsewhere.</p>
 <p>The first argument is required and must be:</p>
 <ul>
 <li>An <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A TileJSON object, from your own Javascript code</li>
 </ul>
 <p>The second argument is optional. If provided, it is the same options
@@ -213,7 +213,7 @@ to <code>L.mapbox.tileLayer</code> which, if retina is detected, is used instead
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a tilejson resource
-var layer = L.mapbox.tileLayer(&#39;http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided,you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -257,7 +257,7 @@ interactivity into your map, which you can easily access with <code>L.mapbox.gri
 <p>The first argument is required and must be:</p>
 <ul>
 <li>An <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A TileJSON object, from your own Javascript code</li>
 </ul>
 <p><em>Example</em>:</p>
@@ -296,7 +296,7 @@ from MapBox and elsewhere into your map.</p>
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A GeoJSON object, from your own Javascript code</li>
 </ol>
 <p>The second argument is optional. If provided, it is the same options
@@ -396,7 +396,7 @@ reverse geocoding.</p>
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL <code>string</code> that points to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL <code>string</code> that points to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 </ol>
 <p><em>Returns</em> a <code>L.mapbox.geocoder</code> object.</p>
 </div><h3 id="geocoder.query">geocoder.query<span class="bracket">(</span><span class="args">queryString: string, callback: function</span><span class="bracket">)</span></h3>
@@ -497,7 +497,7 @@ the <a href="http://mapbox.com/developers/api/#geocoding">MapBox Geocoding API</
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 </ol>
 <p><em>Example</em></p>
 <pre><code>var map = L.map(&#39;map&#39;)

--- a/docs/_posts/api/0200-01-01-v1.0.4.html
+++ b/docs/_posts/api/0200-01-01-v1.0.4.html
@@ -68,11 +68,11 @@ maps and services.</p>
 <div id="content-MapBox.js & Leaflet"class="depth-2"><p>Here&#39;s a simple page that you can set up with MapBox.js:</p>
 <pre><code>&lt;html&gt;
 &lt;head&gt;
-  &lt;link href=&#39;http://api.tiles.mapbox.com/mapbox.js/v1.0.4/mapbox.css&#39; rel=&#39;stylesheet&#39; /&gt;
+  &lt;link href=&#39;{{site.tileApi}}/mapbox.js/v1.0.4/mapbox.css&#39; rel=&#39;stylesheet&#39; /&gt;
   &lt;!--[if lte IE 8]&gt;
-    &lt;link href=&#39;http://api.tiles.mapbox.com/mapbox.js/v1.0.4/mapbox.ie.css&#39; rel=&#39;stylesheet&#39; /&gt;
+    &lt;link href=&#39;{{site.tileApi}}/mapbox.js/v1.0.4/mapbox.ie.css&#39; rel=&#39;stylesheet&#39; /&gt;
   &lt;![endif]--&gt;
-  &lt;script src=&#39;http://api.tiles.mapbox.com/mapbox.js/v1.0.4/mapbox.js&#39;&gt;&lt;/script&gt;
+  &lt;script src=&#39;{{site.tileApi}}/mapbox.js/v1.0.4/mapbox.js&#39;&gt;&lt;/script&gt;
   &lt;style&gt;
     body { margin:0; padding:0; }
     #map { position:absolute; top:0; bottom:0; width:100%; }
@@ -164,7 +164,7 @@ reference.</p>
 <p>The second argument is optional and can be:</p>
 <ul>
 <li>A map <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li>
 </ul>
 <p>The third argument is optional. If provided, it is the same options
@@ -202,7 +202,7 @@ interface to layers from MapBox and elsewhere.</p>
 <p>The first argument is required and must be:</p>
 <ul>
 <li>An <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A TileJSON object, from your own Javascript code</li>
 </ul>
 <p>The second argument is optional. If provided, it is the same options
@@ -217,7 +217,7 @@ to <code>L.mapbox.tileLayer</code> which, if retina is detected, is used instead
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a tilejson resource
-var layer = L.mapbox.tileLayer(&#39;http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided,you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -261,7 +261,7 @@ interactivity into your map, which you can easily access with <code>L.mapbox.gri
 <p>The first argument is required and must be:</p>
 <ul>
 <li>An <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A TileJSON object, from your own Javascript code</li>
 </ul>
 <p><em>Example</em>:</p>
@@ -300,7 +300,7 @@ from MapBox and elsewhere into your map.</p>
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A GeoJSON object, from your own Javascript code</li>
 </ol>
 <p>The second argument is optional. If provided, it is the same options
@@ -409,7 +409,7 @@ reverse geocoding.</p>
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL <code>string</code> that points to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL <code>string</code> that points to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 </ol>
 <p><em>Returns</em> a <code>L.mapbox.geocoder</code> object.</p>
 </div><h3 id="geocoder.query">geocoder.query<span class="bracket">(</span><span class="args">queryString: string, callback: function</span><span class="bracket">)</span></h3>
@@ -510,7 +510,7 @@ the <a href="http://mapbox.com/developers/api/#geocoding">MapBox Geocoding API</
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 </ol>
 <p><em>Example</em></p>
 <pre><code>var map = L.map(&#39;map&#39;)

--- a/docs/_posts/api/0200-01-01-v1.0.4.html
+++ b/docs/_posts/api/0200-01-01-v1.0.4.html
@@ -68,11 +68,11 @@ maps and services.</p>
 <div id="content-MapBox.js & Leaflet"class="depth-2"><p>Here&#39;s a simple page that you can set up with MapBox.js:</p>
 <pre><code>&lt;html&gt;
 &lt;head&gt;
-  &lt;link href=&#39;{{site.tileApi}}/mapbox.js/v1.0.4/mapbox.css&#39; rel=&#39;stylesheet&#39; /&gt;
+  &lt;link href=&#39;{{site.tileapi}}/mapbox.js/v1.0.4/mapbox.css&#39; rel=&#39;stylesheet&#39; /&gt;
   &lt;!--[if lte IE 8]&gt;
-    &lt;link href=&#39;{{site.tileApi}}/mapbox.js/v1.0.4/mapbox.ie.css&#39; rel=&#39;stylesheet&#39; /&gt;
+    &lt;link href=&#39;{{site.tileapi}}/mapbox.js/v1.0.4/mapbox.ie.css&#39; rel=&#39;stylesheet&#39; /&gt;
   &lt;![endif]--&gt;
-  &lt;script src=&#39;{{site.tileApi}}/mapbox.js/v1.0.4/mapbox.js&#39;&gt;&lt;/script&gt;
+  &lt;script src=&#39;{{site.tileapi}}/mapbox.js/v1.0.4/mapbox.js&#39;&gt;&lt;/script&gt;
   &lt;style&gt;
     body { margin:0; padding:0; }
     #map { position:absolute; top:0; bottom:0; width:100%; }
@@ -164,7 +164,7 @@ reference.</p>
 <p>The second argument is optional and can be:</p>
 <ul>
 <li>A map <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li>
 </ul>
 <p>The third argument is optional. If provided, it is the same options
@@ -202,7 +202,7 @@ interface to layers from MapBox and elsewhere.</p>
 <p>The first argument is required and must be:</p>
 <ul>
 <li>An <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A TileJSON object, from your own Javascript code</li>
 </ul>
 <p>The second argument is optional. If provided, it is the same options
@@ -217,7 +217,7 @@ to <code>L.mapbox.tileLayer</code> which, if retina is detected, is used instead
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a tilejson resource
-var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileapi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided,you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -261,7 +261,7 @@ interactivity into your map, which you can easily access with <code>L.mapbox.gri
 <p>The first argument is required and must be:</p>
 <ul>
 <li>An <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A TileJSON object, from your own Javascript code</li>
 </ul>
 <p><em>Example</em>:</p>
@@ -300,7 +300,7 @@ from MapBox and elsewhere into your map.</p>
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A GeoJSON object, from your own Javascript code</li>
 </ol>
 <p>The second argument is optional. If provided, it is the same options
@@ -409,7 +409,7 @@ reverse geocoding.</p>
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL <code>string</code> that points to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL <code>string</code> that points to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 </ol>
 <p><em>Returns</em> a <code>L.mapbox.geocoder</code> object.</p>
 </div><h3 id="geocoder.query">geocoder.query<span class="bracket">(</span><span class="args">queryString: string, callback: function</span><span class="bracket">)</span></h3>
@@ -510,7 +510,7 @@ the <a href="http://mapbox.com/developers/api/#geocoding">MapBox Geocoding API</
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 </ol>
 <p><em>Example</em></p>
 <pre><code>var map = L.map(&#39;map&#39;)

--- a/docs/_posts/api/0200-01-01-v1.1.0.html
+++ b/docs/_posts/api/0200-01-01-v1.1.0.html
@@ -249,7 +249,7 @@ reference.
 </p>
 <ul>
 <li>A map <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li>
 </ul>
 <p>The third argument is optional. If provided, it is the same options
@@ -309,7 +309,7 @@ interface to layers from MapBox and elsewhere.
 </p>
 <ul>
 <li>An <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A TileJSON object, from your own Javascript code</li>
 </ul>
 <p>The second argument is optional. If provided, it is the same options
@@ -328,7 +328,7 @@ to <code>L.mapbox.tileLayer</code> which, if retina is detected, is used instead
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a tilejson resource
-var layer = L.mapbox.tileLayer(&#39;http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided,you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -396,7 +396,7 @@ interactivity into your map, which you can easily access with <code>L.mapbox.gri
 </p>
 <ul>
 <li>An <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A TileJSON object, from your own Javascript code</li>
 </ul>
 <p><em>Example</em>:
@@ -458,7 +458,7 @@ from MapBox and elsewhere into your map.
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A GeoJSON object, from your own Javascript code</li>
 </ol>
 <p>The second argument is optional. If provided, it is the same options
@@ -621,7 +621,7 @@ reverse geocoding.
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL <code>string</code> that points to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL <code>string</code> that points to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 </ol>
 <p><em>Returns</em> a <code>L.mapbox.geocoder</code> object.
 
@@ -764,7 +764,7 @@ the <a href="http://mapbox.com/developers/api/#geocoding">MapBox Geocoding API</
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 </ol>
 <p><em>Example</em>
 

--- a/docs/_posts/api/0200-01-01-v1.1.0.html
+++ b/docs/_posts/api/0200-01-01-v1.1.0.html
@@ -249,7 +249,7 @@ reference.
 </p>
 <ul>
 <li>A map <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li>
 </ul>
 <p>The third argument is optional. If provided, it is the same options
@@ -309,7 +309,7 @@ interface to layers from MapBox and elsewhere.
 </p>
 <ul>
 <li>An <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A TileJSON object, from your own Javascript code</li>
 </ul>
 <p>The second argument is optional. If provided, it is the same options
@@ -328,7 +328,7 @@ to <code>L.mapbox.tileLayer</code> which, if retina is detected, is used instead
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a tilejson resource
-var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileapi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided,you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -396,7 +396,7 @@ interactivity into your map, which you can easily access with <code>L.mapbox.gri
 </p>
 <ul>
 <li>An <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A TileJSON object, from your own Javascript code</li>
 </ul>
 <p><em>Example</em>:
@@ -458,7 +458,7 @@ from MapBox and elsewhere into your map.
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A GeoJSON object, from your own Javascript code</li>
 </ol>
 <p>The second argument is optional. If provided, it is the same options
@@ -621,7 +621,7 @@ reverse geocoding.
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL <code>string</code> that points to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL <code>string</code> that points to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 </ol>
 <p><em>Returns</em> a <code>L.mapbox.geocoder</code> object.
 
@@ -764,7 +764,7 @@ the <a href="http://mapbox.com/developers/api/#geocoding">MapBox Geocoding API</
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 </ol>
 <p><em>Example</em>
 

--- a/docs/_posts/api/0200-01-01-v1.2.0.html
+++ b/docs/_posts/api/0200-01-01-v1.2.0.html
@@ -206,7 +206,7 @@ reference.</p>
 <p>The second argument is optional and can be:</p>
 <ul>
 <li>A map <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li>
 </ul>
 <p>The third argument is optional. If provided, it is the same options
@@ -248,7 +248,7 @@ interface to layers from MapBox and elsewhere.</p>
 <p>The first argument is required and must be:</p>
 <ul>
 <li>An <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A TileJSON object, from your own Javascript code</li>
 </ul>
 <p>The second argument is optional. If provided, it is the same options
@@ -263,7 +263,7 @@ to <code>L.mapbox.tileLayer</code> which, if retina is detected, is used instead
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a tilejson resource
-var layer = L.mapbox.tileLayer(&#39;http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided,you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -307,7 +307,7 @@ interactivity into your map, which you can easily access with <code>L.mapbox.gri
 <p>The first argument is required and must be:</p>
 <ul>
 <li>An <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A TileJSON object, from your own Javascript code</li>
 </ul>
 <p><em>Example</em>:</p>
@@ -346,7 +346,7 @@ from MapBox and elsewhere into your map.</p>
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A GeoJSON object, from your own Javascript code</li>
 </ol>
 <p>The second argument is optional. If provided, it is the same options
@@ -455,7 +455,7 @@ reverse geocoding.</p>
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL <code>string</code> that points to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL <code>string</code> that points to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 </ol>
 <p><em>Returns</em> a <code>L.mapbox.geocoder</code> object.</p>
 </div><h3 id="geocoder.query">geocoder.query<span class="bracket">(</span><span class="args">queryString: string, callback: function</span><span class="bracket">)</span></h3>
@@ -556,7 +556,7 @@ the <a href="http://mapbox.com/developers/api/#geocoding">MapBox Geocoding API</
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 </ol>
 <p><em>Example</em></p>
 <pre><code>var map = L.map(&#39;map&#39;)
@@ -605,7 +605,7 @@ or Facebook, or generate HTML for a map embed.</p>
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li><p>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></p>
+<li><p>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></p>
 <p>If not supplied, the TileJSON from the map is used.</p>
 </li>
 <li><p>(optional) Options for <a href="http://leafletjs.com/reference.html#control">L.Control</a>.</p>

--- a/docs/_posts/api/0200-01-01-v1.2.0.html
+++ b/docs/_posts/api/0200-01-01-v1.2.0.html
@@ -55,7 +55,7 @@ navigation:
   items:
 
 ---
-{% raw %}
+
 <div></div><h1>Getting Started</h1>
 <div id="content-undefined"class="depth-1"><p>This API documentation covers the MapBox Javascript API, an API for adding
 MapBox maps to webpages.</p>
@@ -206,7 +206,7 @@ reference.</p>
 <p>The second argument is optional and can be:</p>
 <ul>
 <li>A map <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li>
 </ul>
 <p>The third argument is optional. If provided, it is the same options
@@ -248,7 +248,7 @@ interface to layers from MapBox and elsewhere.</p>
 <p>The first argument is required and must be:</p>
 <ul>
 <li>An <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A TileJSON object, from your own Javascript code</li>
 </ul>
 <p>The second argument is optional. If provided, it is the same options
@@ -263,7 +263,7 @@ to <code>L.mapbox.tileLayer</code> which, if retina is detected, is used instead
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a tilejson resource
-var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileapi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided,you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -307,7 +307,7 @@ interactivity into your map, which you can easily access with <code>L.mapbox.gri
 <p>The first argument is required and must be:</p>
 <ul>
 <li>An <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A TileJSON object, from your own Javascript code</li>
 </ul>
 <p><em>Example</em>:</p>
@@ -346,7 +346,7 @@ from MapBox and elsewhere into your map.</p>
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A GeoJSON object, from your own Javascript code</li>
 </ol>
 <p>The second argument is optional. If provided, it is the same options
@@ -455,7 +455,7 @@ reverse geocoding.</p>
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL <code>string</code> that points to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL <code>string</code> that points to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 </ol>
 <p><em>Returns</em> a <code>L.mapbox.geocoder</code> object.</p>
 </div><h3 id="geocoder.query">geocoder.query<span class="bracket">(</span><span class="args">queryString: string, callback: function</span><span class="bracket">)</span></h3>
@@ -556,7 +556,7 @@ the <a href="http://mapbox.com/developers/api/#geocoding">MapBox Geocoding API</
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 </ol>
 <p><em>Example</em></p>
 <pre><code>var map = L.map(&#39;map&#39;)
@@ -605,7 +605,7 @@ or Facebook, or generate HTML for a map embed.</p>
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li><p>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></p>
+<li><p>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></p>
 <p>If not supplied, the TileJSON from the map is used.</p>
 </li>
 <li><p>(optional) Options for <a href="http://leafletjs.com/reference.html#control">L.Control</a>.</p>
@@ -651,7 +651,7 @@ and <code>L.mapbox.legendControl</code>.</p>
 <div id="content-L.mapbox.template"class="depth-2"><p>A <a href="http://mustache.github.io/">mustache</a> template rendering function, as used
 by the templating feature provided by <code>L.mapbox.gridControl</code>.</p>
 <p><em>Example</em>:</p>
-<pre><code>var output = L.mapbox.template(&#39;Name: {{name}}&#39;, {name: &#39;John&#39;});
+<pre><code>var output = L.mapbox.template(&#39;Name: {% raw %}{{name}}{% endraw %}&#39;, {name: &#39;John&#39;});
 // output is &quot;Name: John&quot;</code></pre>
 </div><h1>Theming</h1>
 <div id="content-L.mapbox.template"class="depth-1"></div><h2>Dark theme</h2>
@@ -660,4 +660,4 @@ is available by applying <code>class=&quot;dark&quot;</code> to the map div.</p>
 <p><em>Example</em>:</p>
 <pre><code>&lt;div id=&quot;map&quot; class=&quot;dark&quot;&gt;&lt;/div&gt;</code></pre>
 </div>
-{% endraw %}
+

--- a/docs/_posts/api/0200-01-01-v1.3.0.html
+++ b/docs/_posts/api/0200-01-01-v1.3.0.html
@@ -255,7 +255,7 @@ reference.
 </p>
 <ul>
 <li>A map <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li>
 </ul>
 <p>The third argument is optional. If provided, it is the same options
@@ -315,7 +315,7 @@ interface to layers from MapBox and elsewhere.
 </p>
 <ul>
 <li>An <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A TileJSON object, from your own Javascript code</li>
 </ul>
 <p>The second argument is optional. If provided, it is the same options
@@ -334,7 +334,7 @@ to <code>L.mapbox.tileLayer</code> which, if retina is detected, is used instead
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a tilejson resource
-var layer = L.mapbox.tileLayer(&#39;http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided,you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -402,7 +402,7 @@ interactivity into your map, which you can easily access with <code>L.mapbox.gri
 </p>
 <ul>
 <li>An <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A TileJSON object, from your own Javascript code</li>
 </ul>
 <p><em>Example</em>:
@@ -464,7 +464,7 @@ from MapBox and elsewhere into your map.
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A GeoJSON object, from your own Javascript code</li>
 </ol>
 <p>The second argument is optional. If provided, it is the same options
@@ -627,7 +627,7 @@ reverse geocoding.
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL <code>string</code> that points to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL <code>string</code> that points to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 </ol>
 <p><em>Returns</em> a <code>L.mapbox.geocoder</code> object.
 
@@ -774,7 +774,7 @@ the <a href="http://mapbox.com/developers/api/#geocoding">MapBox Geocoding API</
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 </ol>
 <p><em>Example</em>
 
@@ -848,7 +848,7 @@ or Facebook, or generate HTML for a map embed.
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li><p>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></p>
+<li><p>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></p>
 <p>If not supplied, the TileJSON from the map is used.</p>
 </li>
 <li><p>(optional) Options for <a href="http://leafletjs.com/reference.html#control">L.Control</a>.</p>

--- a/docs/_posts/api/0200-01-01-v1.3.0.html
+++ b/docs/_posts/api/0200-01-01-v1.3.0.html
@@ -54,7 +54,7 @@ navigation:
   items:
 
 ---
-{% raw %}
+
 <div></div><h1>Getting Started</h1>
 <div id="content-undefined"class="depth-1"><p>This API documentation covers the MapBox Javascript API, an API for adding
 MapBox maps to webpages.
@@ -255,7 +255,7 @@ reference.
 </p>
 <ul>
 <li>A map <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li>
 </ul>
 <p>The third argument is optional. If provided, it is the same options
@@ -315,7 +315,7 @@ interface to layers from MapBox and elsewhere.
 </p>
 <ul>
 <li>An <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A TileJSON object, from your own Javascript code</li>
 </ul>
 <p>The second argument is optional. If provided, it is the same options
@@ -334,7 +334,7 @@ to <code>L.mapbox.tileLayer</code> which, if retina is detected, is used instead
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a tilejson resource
-var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileapi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided,you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -402,7 +402,7 @@ interactivity into your map, which you can easily access with <code>L.mapbox.gri
 </p>
 <ul>
 <li>An <code>id</code> string <code>examples.map-foo</code></li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A TileJSON object, from your own Javascript code</li>
 </ul>
 <p><em>Example</em>:
@@ -464,7 +464,7 @@ from MapBox and elsewhere into your map.
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 <li>A GeoJSON object, from your own Javascript code</li>
 </ol>
 <p>The second argument is optional. If provided, it is the same options
@@ -627,7 +627,7 @@ reverse geocoding.
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL <code>string</code> that points to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL <code>string</code> that points to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 </ol>
 <p><em>Returns</em> a <code>L.mapbox.geocoder</code> object.
 
@@ -774,7 +774,7 @@ the <a href="http://mapbox.com/developers/api/#geocoding">MapBox Geocoding API</
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 </ol>
 <p><em>Example</em>
 
@@ -848,7 +848,7 @@ or Facebook, or generate HTML for a map embed.
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li><p>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></p>
+<li><p>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></p>
 <p>If not supplied, the TileJSON from the map is used.</p>
 </li>
 <li><p>(optional) Options for <a href="http://leafletjs.com/reference.html#control">L.Control</a>.</p>
@@ -929,7 +929,7 @@ by the templating feature provided by <code>L.mapbox.gridControl</code>.
 <p><em>Example</em>:
 
 </p>
-<pre><code>var output = L.mapbox.template(&#39;Name: {{name}}&#39;, {name: &#39;John&#39;});
+<pre><code>var output = L.mapbox.template(&#39;Name: {% raw %}{{name}}{% endraw %}&#39;, {name: &#39;John&#39;});
 // output is &quot;Name: John&quot;</code></pre>
 </div><h1>Theming</h1>
 <div id="content-L.mapbox.template"class="depth-1"></div><h2>Dark theme</h2>
@@ -942,4 +942,4 @@ is available by applying <code>class=&quot;dark&quot;</code> to the map div.
 </p>
 <pre><code>&lt;div id=&quot;map&quot; class=&quot;dark&quot;&gt;&lt;/div&gt;</code></pre>
 </div>
-{% endraw %}
+

--- a/docs/_posts/api/0200-01-01-v1.3.1.html
+++ b/docs/_posts/api/0200-01-01-v1.3.1.html
@@ -57,7 +57,7 @@ navigation:
     nav:
 
 ---
-{% raw %}
+
 <div></div><h1 id="section-map">Map</h1>
 <div class="space-bottom api-group-content depth-1"></div><h2 id="L.mapbox.map">L.mapbox.map<span class="bracket">(</span><span class="args">element, id|url|tilejson, options</span><span class="bracket">)</span></h2>
 <div class="space-bottom api-group-content depth-2"><p>Create and automatically configure a map with layers, markers, and
@@ -80,7 +80,7 @@ interactivity.</p>
 <tr>
 <td>url</td>
 <td>string</td>
-<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
+<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -119,7 +119,7 @@ interface to layers from MapBox and elsewhere.</p>
 <tr>
 <td>id <em>required</em></td>
 <td>string</td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -133,7 +133,7 @@ interface to layers from MapBox and elsewhere.</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a tilejson resource
-var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileapi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided,you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -196,7 +196,7 @@ interactivity into your map, which you can easily access with <code>L.mapbox.gri
 <tr>
 <td>id <em>required</em></td>
 <td>string</td>
-<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -257,7 +257,7 @@ from MapBox and elsewhere into your map.</p>
 <tr>
 <td>id, url, tilejson</td>
 <td>string</td>
-<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
+<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -404,7 +404,7 @@ markerLayer.setGeoJSON({
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 </ol>
 <p><em>Returns</em> a <code>L.mapbox.geocoder</code> object.</p>
 </div><h3 id="geocoder.query">geocoder.query<span class="bracket">(</span><span class="args">queryString: string, callback: function</span><span class="bracket">)</span></h3>
@@ -505,7 +505,7 @@ the <a href="http://mapbox.com/developers/api/#geocoding">MapBox Geocoding API</
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li>
 </ol>
 <p><em>Example</em></p>
 <pre><code>var map = L.map(&#39;map&#39;)
@@ -578,4 +578,4 @@ is available by applying <code>class=&quot;dark&quot;</code> to the map div.</p>
 <p><em>Example</em>:</p>
 <pre><code>&lt;div id=&quot;map&quot; class=&quot;dark&quot;&gt;&lt;/div&gt;</code></pre>
 </div>
-{% endraw %}
+

--- a/docs/_posts/api/0200-01-01-v1.3.1.html
+++ b/docs/_posts/api/0200-01-01-v1.3.1.html
@@ -80,7 +80,7 @@ interactivity.</p>
 <tr>
 <td>url</td>
 <td>string</td>
-<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
+<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -119,7 +119,7 @@ interface to layers from MapBox and elsewhere.</p>
 <tr>
 <td>id <em>required</em></td>
 <td>string</td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -133,7 +133,7 @@ interface to layers from MapBox and elsewhere.</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a tilejson resource
-var layer = L.mapbox.tileLayer(&#39;http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided,you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -196,7 +196,7 @@ interactivity into your map, which you can easily access with <code>L.mapbox.gri
 <tr>
 <td>id <em>required</em></td>
 <td>string</td>
-<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -257,7 +257,7 @@ from MapBox and elsewhere into your map.</p>
 <tr>
 <td>id, url, tilejson</td>
 <td>string</td>
-<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
+<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -404,7 +404,7 @@ markerLayer.setGeoJSON({
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 </ol>
 <p><em>Returns</em> a <code>L.mapbox.geocoder</code> object.</p>
 </div><h3 id="geocoder.query">geocoder.query<span class="bracket">(</span><span class="args">queryString: string, callback: function</span><span class="bracket">)</span></h3>
@@ -505,7 +505,7 @@ the <a href="http://mapbox.com/developers/api/#geocoding">MapBox Geocoding API</
 </li>
 <li><p>An <code>id</code> string <code>examples.map-foo</code></p>
 </li>
-<li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li>
+<li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li>
 </ol>
 <p><em>Example</em></p>
 <pre><code>var map = L.map(&#39;map&#39;)

--- a/docs/_posts/api/0200-01-01-v1.4.0.html
+++ b/docs/_posts/api/0200-01-01-v1.4.0.html
@@ -66,7 +66,7 @@ navigation:
     nav:
 
 ---
-{% raw %}
+
 <div></div><h1 id="section-map">Map</h1>
 <div class="space-bottom api-group-content depth-1"></div><h2 id="L.mapbox.map">L.mapbox.map<span class="bracket">(</span><span class="args">element, id | url | tilejson, options</span><span class="bracket">)</span></h2>
 <div class="space-bottom api-group-content depth-2"><p>Create and automatically configure a map with layers, markers, and
@@ -89,7 +89,7 @@ interactivity.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><ul><li><code>string</code> if <em>id</em> or <em>url</em></li><li><code>object</code> if <em>tilejson</em></li></ul></td>
-<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
+<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -128,7 +128,7 @@ interface to layers from MapBox and elsewhere.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><ul><li><code>string</code> if <em>id</em> or <em>url</em></li><li><code>object</code> if <em>tilejson</em></li></ul></td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -143,7 +143,7 @@ interface to layers from MapBox and elsewhere.</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a tilejson resource
-var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileapi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided,you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -212,7 +212,7 @@ interactivity into your map, which you can easily access with <code>L.mapbox.gri
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><ul><li><code>string</code> if <em>id</em> or <em>url</em></li><li><code>object</code> if <em>tilejson</em></li></ul></td>
-<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -273,7 +273,7 @@ from MapBox and elsewhere into your map.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><ul><li><code>string</code> if <em>id</em> or <em>url</em></li><li><code>object</code> if <em>tilejson</em></li></ul></td>
-<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
+<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -427,7 +427,7 @@ markerLayer.setGeoJSON({
 <tr>
 <td>id <em>or</em> url</td>
 <td>string</td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -600,7 +600,7 @@ This function is currently in private beta: <a href'http://mapbox.com/about/cont
 <tr>
 <td>id <em>or</em> url (<em>required</em>)</td>
 <td>string</td>
-<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -704,7 +704,7 @@ This function is currently in private beta: <a href'http://mapbox.com/about/cont
 <tr>
 <td>id <em>or</em> url <em>optional</em></td>
 <td>string</td>
-<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileApi}}/v3/examples.map-0l53fhk2.json">{{site.tileApi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
+<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileapi}}/v3/examples.map-0l53fhk2.json">{{site.tileapi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -816,7 +816,7 @@ features.</p>
 </tbody>
 </table>
 <p><em>Example</em>:</p>
-<pre><code>var output = L.mapbox.template(&#39;Name: {{name}}&#39;, {name: &#39;John&#39;});
+<pre><code>var output = L.mapbox.template(&#39;Name: {% raw %}{{name}}{% endraw %}&#39;, {name: &#39;John&#39;});
 // output is &quot;Name: John&quot;</code></pre>
 </div><h1 id="section-theming">Theming</h1>
 <div class="space-bottom api-group-content depth-1"></div><h2>Dark theme</h2>
@@ -825,4 +825,4 @@ is available by applying <code>class=&quot;dark&quot;</code> to the map div.</p>
 <p><em>Example</em>:</p>
 <pre><code>&lt;div id=&quot;map&quot; class=&quot;dark&quot;&gt;&lt;/div&gt;</code></pre>
 </div>
-{% endraw %}
+

--- a/docs/_posts/api/0200-01-01-v1.4.0.html
+++ b/docs/_posts/api/0200-01-01-v1.4.0.html
@@ -89,7 +89,7 @@ interactivity.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><ul><li><code>string</code> if <em>id</em> or <em>url</em></li><li><code>object</code> if <em>tilejson</em></li></ul></td>
-<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
+<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -128,7 +128,7 @@ interface to layers from MapBox and elsewhere.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><ul><li><code>string</code> if <em>id</em> or <em>url</em></li><li><code>object</code> if <em>tilejson</em></li></ul></td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -143,7 +143,7 @@ interface to layers from MapBox and elsewhere.</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a tilejson resource
-var layer = L.mapbox.tileLayer(&#39;http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided,you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -212,7 +212,7 @@ interactivity into your map, which you can easily access with <code>L.mapbox.gri
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><ul><li><code>string</code> if <em>id</em> or <em>url</em></li><li><code>object</code> if <em>tilejson</em></li></ul></td>
-<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -273,7 +273,7 @@ from MapBox and elsewhere into your map.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><ul><li><code>string</code> if <em>id</em> or <em>url</em></li><li><code>object</code> if <em>tilejson</em></li></ul></td>
-<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
+<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -427,7 +427,7 @@ markerLayer.setGeoJSON({
 <tr>
 <td>id <em>or</em> url</td>
 <td>string</td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -600,7 +600,7 @@ This function is currently in private beta: <a href'http://mapbox.com/about/cont
 <tr>
 <td>id <em>or</em> url (<em>required</em>)</td>
 <td>string</td>
-<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -704,7 +704,7 @@ This function is currently in private beta: <a href'http://mapbox.com/about/cont
 <tr>
 <td>id <em>or</em> url <em>optional</em></td>
 <td>string</td>
-<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="https://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json">https://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
+<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileApi}}/v3/examples.map-0l53fhk2.json">{{site.tileApi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>

--- a/docs/_posts/api/0200-01-01-v1.4.2.html
+++ b/docs/_posts/api/0200-01-01-v1.4.2.html
@@ -66,7 +66,7 @@ navigation:
     nav:
 
 ---
-{% raw %}
+
 <div></div><h1 id="section-map">Map</h1>
 <div class="space-bottom api-group-content depth-1"></div><h2 id="L.mapbox.map">L.mapbox.map<span class="bracket">(</span><span class="args">element, id | url | tilejson, options</span><span class="bracket">)</span></h2>
 <div class="space-bottom api-group-content depth-2"><p>Create and automatically configure a map with layers, markers, and
@@ -89,7 +89,7 @@ interactivity.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
+<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -128,7 +128,7 @@ interface to layers from MapBox and elsewhere.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -143,7 +143,7 @@ interface to layers from MapBox and elsewhere.</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a tilejson resource
-var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileapi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided,you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -212,7 +212,7 @@ interactivity into your map, which you can easily access with <code>L.mapbox.gri
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -273,7 +273,7 @@ from MapBox and elsewhere into your map.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
+<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -427,7 +427,7 @@ markerLayer.setGeoJSON({
 <tr>
 <td>id <em>or</em> url</td>
 <td>string</td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -600,7 +600,7 @@ This function is currently in private beta: <a href'http://mapbox.com/about/cont
 <tr>
 <td>id <em>or</em> url (<em>required</em>)</td>
 <td>string</td>
-<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -704,7 +704,7 @@ This function is currently in private beta: <a href'http://mapbox.com/about/cont
 <tr>
 <td>id <em>or</em> url <em>optional</em></td>
 <td>string</td>
-<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileApi}}/v3/examples.map-0l53fhk2.json">{{site.tileApi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
+<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileapi}}/v3/examples.map-0l53fhk2.json">{{site.tileapi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -816,7 +816,7 @@ features.</p>
 </tbody>
 </table>
 <p><em>Example</em>:</p>
-<pre><code>var output = L.mapbox.template(&#39;Name: {{name}}&#39;, {name: &#39;John&#39;});
+<pre><code>var output = L.mapbox.template(&#39;Name: {% raw %}{{name}}{% endraw %}&#39;, {name: &#39;John&#39;});
 // output is &quot;Name: John&quot;</code></pre>
 </div><h1 id="section-theming">Theming</h1>
 <div class="space-bottom api-group-content depth-1"></div><h2>Dark theme</h2>
@@ -825,4 +825,4 @@ is available by applying <code>class=&quot;dark&quot;</code> to the map div.</p>
 <p><em>Example</em>:</p>
 <pre><code>&lt;div id=&quot;map&quot; class=&quot;dark&quot;&gt;&lt;/div&gt;</code></pre>
 </div>
-{% endraw %}
+

--- a/docs/_posts/api/0200-01-01-v1.4.2.html
+++ b/docs/_posts/api/0200-01-01-v1.4.2.html
@@ -89,7 +89,7 @@ interactivity.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
+<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -128,7 +128,7 @@ interface to layers from MapBox and elsewhere.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -143,7 +143,7 @@ interface to layers from MapBox and elsewhere.</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a tilejson resource
-var layer = L.mapbox.tileLayer(&#39;http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided,you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -212,7 +212,7 @@ interactivity into your map, which you can easily access with <code>L.mapbox.gri
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -273,7 +273,7 @@ from MapBox and elsewhere into your map.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
+<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -427,7 +427,7 @@ markerLayer.setGeoJSON({
 <tr>
 <td>id <em>or</em> url</td>
 <td>string</td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -600,7 +600,7 @@ This function is currently in private beta: <a href'http://mapbox.com/about/cont
 <tr>
 <td>id <em>or</em> url (<em>required</em>)</td>
 <td>string</td>
-<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -704,7 +704,7 @@ This function is currently in private beta: <a href'http://mapbox.com/about/cont
 <tr>
 <td>id <em>or</em> url <em>optional</em></td>
 <td>string</td>
-<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="https://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json">https://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
+<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileApi}}/v3/examples.map-0l53fhk2.json">{{site.tileApi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>

--- a/docs/_posts/api/0200-01-01-v1.5.0.html
+++ b/docs/_posts/api/0200-01-01-v1.5.0.html
@@ -97,7 +97,7 @@ interactivity.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
+<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -136,7 +136,7 @@ interface to layers from MapBox and elsewhere.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -151,7 +151,7 @@ interface to layers from MapBox and elsewhere.</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a TileJSON resource
-var layer = L.mapbox.tileLayer(&#39;http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided, you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -224,7 +224,7 @@ interactivity into your map, which you can easily access with <code>L.mapbox.gri
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -285,7 +285,7 @@ from MapBox and elsewhere into your map.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
+<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -439,7 +439,7 @@ markerLayer.setGeoJSON({
 <tr>
 <td>id <em>or</em> url</td>
 <td>string</td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -693,7 +693,7 @@ This function is currently in private beta: <a href'http://mapbox.com/about/cont
 <tr>
 <td>id <em>or</em> url (<em>required</em>)</td>
 <td>string</td>
-<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -797,7 +797,7 @@ This function is currently in private beta: <a href'http://mapbox.com/about/cont
 <tr>
 <td>id <em>or</em> url <em>optional</em></td>
 <td>string</td>
-<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="https://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json">https://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
+<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileApi}}/v3/examples.map-0l53fhk2.json">{{site.tileApi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>

--- a/docs/_posts/api/0200-01-01-v1.5.0.html
+++ b/docs/_posts/api/0200-01-01-v1.5.0.html
@@ -74,7 +74,7 @@ navigation:
     nav:
 
 ---
-{% raw %}
+
 <div></div><h1 id="section-map">Map</h1>
 <div class="space-bottom api-group-content depth-1"></div><h2 id="L.mapbox.map">L.mapbox.map<span class="bracket">(</span><span class="args">element, id|url|tilejson, options</span><span class="bracket">)</span></h2>
 <div class="space-bottom api-group-content depth-2"><p>Create and automatically configure a map with layers, markers, and
@@ -97,7 +97,7 @@ interactivity.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
+<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -136,7 +136,7 @@ interface to layers from MapBox and elsewhere.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -151,7 +151,7 @@ interface to layers from MapBox and elsewhere.</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a TileJSON resource
-var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileapi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided, you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -224,7 +224,7 @@ interactivity into your map, which you can easily access with <code>L.mapbox.gri
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -285,7 +285,7 @@ from MapBox and elsewhere into your map.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
+<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -439,7 +439,7 @@ markerLayer.setGeoJSON({
 <tr>
 <td>id <em>or</em> url</td>
 <td>string</td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -693,7 +693,7 @@ This function is currently in private beta: <a href'http://mapbox.com/about/cont
 <tr>
 <td>id <em>or</em> url (<em>required</em>)</td>
 <td>string</td>
-<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -797,7 +797,7 @@ This function is currently in private beta: <a href'http://mapbox.com/about/cont
 <tr>
 <td>id <em>or</em> url <em>optional</em></td>
 <td>string</td>
-<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileApi}}/v3/examples.map-0l53fhk2.json">{{site.tileApi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
+<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileapi}}/v3/examples.map-0l53fhk2.json">{{site.tileapi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -909,7 +909,7 @@ features.</p>
 </tbody>
 </table>
 <p><em>Example</em>:</p>
-<pre><code>var output = L.mapbox.template(&#39;Name: {{name}}&#39;, {name: &#39;John&#39;});
+<pre><code>var output = L.mapbox.template(&#39;Name: {% raw %}{{name}}{% endraw %}&#39;, {name: &#39;John&#39;});
 // output is &quot;Name: John&quot;</code></pre>
 </div><h1 id="section-mobile">Mobile</h1>
 <div class="space-bottom api-group-content depth-1"><p>MapBox.js is optimized for mobile devices and small screens by default.
@@ -945,4 +945,4 @@ is available by applying <code>class=&quot;dark&quot;</code> to the map div.</p>
 <p><em>Example</em>:</p>
 <pre><code>&lt;div id=&quot;map&quot; class=&quot;dark&quot;&gt;&lt;/div&gt;</code></pre>
 </div>
-{% endraw %}
+

--- a/docs/_posts/api/0200-01-01-v1.5.1.html
+++ b/docs/_posts/api/0200-01-01-v1.5.1.html
@@ -74,7 +74,7 @@ navigation:
     nav:
 
 ---
-{% raw %}
+
 <div></div><h1 id="section-map">Map</h1>
 <div class="space-bottom api-group-content depth-1"></div><h2 id="L.mapbox.map">L.mapbox.map<span class="bracket">(</span><span class="args">element, id|url|tilejson, options</span><span class="bracket">)</span></h2>
 <div class="space-bottom api-group-content depth-2"><p>Create and automatically configure a map with layers, markers, and
@@ -97,7 +97,7 @@ interactivity.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
+<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -136,7 +136,7 @@ interface to layers from MapBox and elsewhere.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -151,7 +151,7 @@ interface to layers from MapBox and elsewhere.</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a TileJSON resource
-var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileapi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided, you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -224,7 +224,7 @@ interactivity into your map, which you can easily access with <code>L.mapbox.gri
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -285,7 +285,7 @@ from MapBox and elsewhere into your map.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
+<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -439,7 +439,7 @@ markerLayer.setGeoJSON({
 <tr>
 <td>id <em>or</em> url</td>
 <td>string</td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -693,7 +693,7 @@ This function is currently in private beta: <a href='http://mapbox.com/about/con
 <tr>
 <td>id <em>or</em> url (<em>required</em>)</td>
 <td>string</td>
-<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -797,7 +797,7 @@ This function is currently in private beta: <a href='http://mapbox.com/about/con
 <tr>
 <td>id <em>or</em> url <em>optional</em></td>
 <td>string</td>
-<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileApi}}/v3/examples.map-0l53fhk2.json">{{site.tileApi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
+<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileapi}}/v3/examples.map-0l53fhk2.json">{{site.tileapi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -909,7 +909,7 @@ features.</p>
 </tbody>
 </table>
 <p><em>Example</em>:</p>
-<pre><code>var output = L.mapbox.template(&#39;Name: {{name}}&#39;, {name: &#39;John&#39;});
+<pre><code>var output = L.mapbox.template(&#39;Name: {% raw %}{{name}}{% endraw %}&#39;, {name: &#39;John&#39;});
 // output is &quot;Name: John&quot;</code></pre>
 </div><h1 id="section-mobile">Mobile</h1>
 <div class="space-bottom api-group-content depth-1"><p>MapBox.js is optimized for mobile devices and small screens by default.
@@ -949,4 +949,4 @@ is available by applying <code>class=&quot;dark&quot;</code> to the map div.</p>
 <p><em>Example</em>:</p>
 <pre><code>&lt;div id=&quot;map&quot; class=&quot;dark&quot;&gt;&lt;/div&gt;</code></pre>
 </div>
-{% endraw %}
+

--- a/docs/_posts/api/0200-01-01-v1.5.1.html
+++ b/docs/_posts/api/0200-01-01-v1.5.1.html
@@ -97,7 +97,7 @@ interactivity.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
+<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -136,7 +136,7 @@ interface to layers from MapBox and elsewhere.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -151,7 +151,7 @@ interface to layers from MapBox and elsewhere.</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a TileJSON resource
-var layer = L.mapbox.tileLayer(&#39;http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided, you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -224,7 +224,7 @@ interactivity into your map, which you can easily access with <code>L.mapbox.gri
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -285,7 +285,7 @@ from MapBox and elsewhere into your map.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
+<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -439,7 +439,7 @@ markerLayer.setGeoJSON({
 <tr>
 <td>id <em>or</em> url</td>
 <td>string</td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -693,7 +693,7 @@ This function is currently in private beta: <a href='http://mapbox.com/about/con
 <tr>
 <td>id <em>or</em> url (<em>required</em>)</td>
 <td>string</td>
-<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -797,7 +797,7 @@ This function is currently in private beta: <a href='http://mapbox.com/about/con
 <tr>
 <td>id <em>or</em> url <em>optional</em></td>
 <td>string</td>
-<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="https://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json">https://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
+<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileApi}}/v3/examples.map-0l53fhk2.json">{{site.tileApi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>

--- a/docs/_posts/api/0200-01-01-v1.5.2.html
+++ b/docs/_posts/api/0200-01-01-v1.5.2.html
@@ -74,7 +74,7 @@ navigation:
     nav:
 
 ---
-{% raw %}
+
 <div></div><h1 id="section-map">Map</h1>
 <div class="space-bottom api-group-content depth-1"></div><h2 id="L.mapbox.map">L.mapbox.map<span class="bracket">(</span><span class="args">element, id|url|tilejson, options</span><span class="bracket">)</span></h2>
 <div class="space-bottom api-group-content depth-2"><p>Create and automatically configure a map with layers, markers, and
@@ -97,7 +97,7 @@ interactivity.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
+<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -136,7 +136,7 @@ interface to layers from Mapbox and elsewhere.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -151,7 +151,7 @@ interface to layers from Mapbox and elsewhere.</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a TileJSON resource
-var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileapi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided, you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -224,7 +224,7 @@ interactivity into your map, which you can easily access with <code>L.mapbox.gri
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -285,7 +285,7 @@ from Mapbox and elsewhere into your map.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
+<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -439,7 +439,7 @@ markerLayer.setGeoJSON({
 <tr>
 <td>id <em>or</em> url</td>
 <td>string</td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -693,7 +693,7 @@ This function is currently in private beta: <a href='http://mapbox.com/about/con
 <tr>
 <td>id <em>or</em> url (<em>required</em>)</td>
 <td>string</td>
-<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -797,7 +797,7 @@ This function is currently in private beta: <a href='http://mapbox.com/about/con
 <tr>
 <td>id <em>or</em> url <em>optional</em></td>
 <td>string</td>
-<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileApi}}/v3/examples.map-0l53fhk2.json">{{site.tileApi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
+<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileapi}}/v3/examples.map-0l53fhk2.json">{{site.tileapi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -909,7 +909,7 @@ features.</p>
 </tbody>
 </table>
 <p><em>Example</em>:</p>
-<pre><code>var output = L.mapbox.template(&#39;Name: {{name}}&#39;, {name: &#39;John&#39;});
+<pre><code>var output = L.mapbox.template(&#39;Name: {% raw %}{{name}}{% endraw %}&#39;, {name: &#39;John&#39;});
 // output is &quot;Name: John&quot;</code></pre>
 </div><h1 id="section-mobile">Mobile</h1>
 <div class="space-bottom api-group-content depth-1"><p>Mapbox.js is optimized for mobile devices and small screens by default.
@@ -949,4 +949,4 @@ is available by applying <code>class=&quot;dark&quot;</code> to the map div.</p>
 <p><em>Example</em>:</p>
 <pre><code>&lt;div id=&quot;map&quot; class=&quot;dark&quot;&gt;&lt;/div&gt;</code></pre>
 </div>
-{% endraw %}
+

--- a/docs/_posts/api/0200-01-01-v1.5.2.html
+++ b/docs/_posts/api/0200-01-01-v1.5.2.html
@@ -97,7 +97,7 @@ interactivity.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
+<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -136,7 +136,7 @@ interface to layers from Mapbox and elsewhere.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -151,7 +151,7 @@ interface to layers from Mapbox and elsewhere.</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a TileJSON resource
-var layer = L.mapbox.tileLayer(&#39;http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided, you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -224,7 +224,7 @@ interactivity into your map, which you can easily access with <code>L.mapbox.gri
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -285,7 +285,7 @@ from Mapbox and elsewhere into your map.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
+<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -439,7 +439,7 @@ markerLayer.setGeoJSON({
 <tr>
 <td>id <em>or</em> url</td>
 <td>string</td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -693,7 +693,7 @@ This function is currently in private beta: <a href='http://mapbox.com/about/con
 <tr>
 <td>id <em>or</em> url (<em>required</em>)</td>
 <td>string</td>
-<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -797,7 +797,7 @@ This function is currently in private beta: <a href='http://mapbox.com/about/con
 <tr>
 <td>id <em>or</em> url <em>optional</em></td>
 <td>string</td>
-<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="https://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json">https://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
+<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileApi}}/v3/examples.map-0l53fhk2.json">{{site.tileApi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>

--- a/docs/_posts/api/0200-01-01-v1.6.0-all.html
+++ b/docs/_posts/api/0200-01-01-v1.6.0-all.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.0
 permalink: /api/v1.6.0/all/
 ---
-{% raw %}
+
 <h1 id="map">Map</h1>
 <h2 id="l-mapbox-map">L.mapbox.map(element, id|url|tilejson, options)</h2>
 <p>Create and automatically configure a map with layers, markers, and
@@ -28,7 +28,7 @@ interactivity.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
+<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -67,7 +67,7 @@ interface to layers from Mapbox and elsewhere.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -82,7 +82,7 @@ interface to layers from Mapbox and elsewhere.</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a TileJSON resource
-var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileapi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided, you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -155,7 +155,7 @@ interactivity into your map, which you can easily access with <code><a href="#l-
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -219,7 +219,7 @@ from Mapbox and elsewhere into your map.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
+<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -373,7 +373,7 @@ featureLayer.setGeoJSON({
 <tr>
 <td>id <em>or</em> url</td>
 <td>string</td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -627,7 +627,7 @@ This function is currently in private beta: <a href='http://mapbox.com/about/con
 <tr>
 <td>id <em>or</em> url (<em>required</em>)</td>
 <td>string</td>
-<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -731,7 +731,7 @@ This function is currently in private beta: <a href='http://mapbox.com/about/con
 <tr>
 <td>id <em>or</em> url <em>optional</em></td>
 <td>string</td>
-<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileApi}}/v3/examples.map-0l53fhk2.json">{{site.tileApi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
+<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileapi}}/v3/examples.map-0l53fhk2.json">{{site.tileapi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -871,7 +871,7 @@ options object formatted to be used as <a href="http://leafletjs.com/reference.h
 </tbody>
 </table>
 <p><em>Example</em>:</p>
-<pre><code>var output = L.mapbox.template(&#39;Name: {{name}}&#39;, {name: &#39;John&#39;});
+<pre><code>var output = L.mapbox.template(&#39;Name: {% raw %}{{name}}{% endraw %}&#39;, {name: &#39;John&#39;});
 // output is &quot;Name: John&quot;
 </code></pre><h1 id="mobile">Mobile</h1>
 <p>Mapbox.js is optimized for mobile devices and small screens by default.
@@ -7115,4 +7115,4 @@ var Leaflet = L.noConflict();
 
 <pre><code>L.version // returns "0.5" (or whatever version is currently in use)</code></pre>
 
-{% endraw %}
+

--- a/docs/_posts/api/0200-01-01-v1.6.0-all.html
+++ b/docs/_posts/api/0200-01-01-v1.6.0-all.html
@@ -28,7 +28,7 @@ interactivity.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
+<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -67,7 +67,7 @@ interface to layers from Mapbox and elsewhere.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -82,7 +82,7 @@ interface to layers from Mapbox and elsewhere.</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a TileJSON resource
-var layer = L.mapbox.tileLayer(&#39;http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided, you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -155,7 +155,7 @@ interactivity into your map, which you can easily access with <code><a href="#l-
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -219,7 +219,7 @@ from Mapbox and elsewhere into your map.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
+<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -373,7 +373,7 @@ featureLayer.setGeoJSON({
 <tr>
 <td>id <em>or</em> url</td>
 <td>string</td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -627,7 +627,7 @@ This function is currently in private beta: <a href='http://mapbox.com/about/con
 <tr>
 <td>id <em>or</em> url (<em>required</em>)</td>
 <td>string</td>
-<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -731,7 +731,7 @@ This function is currently in private beta: <a href='http://mapbox.com/about/con
 <tr>
 <td>id <em>or</em> url <em>optional</em></td>
 <td>string</td>
-<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="https://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json">https://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
+<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileApi}}/v3/examples.map-0l53fhk2.json">{{site.tileApi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>

--- a/docs/_posts/api/0200-01-01-v1.6.1-all.html
+++ b/docs/_posts/api/0200-01-01-v1.6.1-all.html
@@ -28,7 +28,7 @@ interactivity.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
+<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -67,7 +67,7 @@ interface to layers from Mapbox and elsewhere.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -82,7 +82,7 @@ interface to layers from Mapbox and elsewhere.</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a TileJSON resource
-var layer = L.mapbox.tileLayer(&#39;http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided, you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -151,7 +151,7 @@ interactivity into your map, which you can easily access with <code><a href="#l-
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -215,7 +215,7 @@ from Mapbox and elsewhere into your map.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
+<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -369,7 +369,7 @@ featureLayer.setGeoJSON({
 <tr>
 <td>id <em>or</em> url</td>
 <td>string</td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -623,7 +623,7 @@ This function is currently in private beta: <a href="https://mapbox.com/contact/
 <tr>
 <td>id <em>or</em> url (<em>required</em>)</td>
 <td>string</td>
-<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -737,7 +737,7 @@ This function is currently in private beta: <a href="https://mapbox.com/contact/
 <tr>
 <td>id <em>or</em> url <em>optional</em></td>
 <td>string</td>
-<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="https://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json">https://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
+<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileApi}}/v3/examples.map-0l53fhk2.json">{{site.tileApi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>

--- a/docs/_posts/api/0200-01-01-v1.6.1-all.html
+++ b/docs/_posts/api/0200-01-01-v1.6.1-all.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.1
 permalink: /api/v1.6.1/all/
 ---
-{% raw %}
+
 <h1 id="map-object">Map Object</h1>
 <h2 id="l-mapbox-map">L.mapbox.map(element, id|url|tilejson, options)</h2>
 <p>Create and automatically configure a map with layers, markers, and
@@ -28,7 +28,7 @@ interactivity.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
+<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -67,7 +67,7 @@ interface to layers from Mapbox and elsewhere.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -82,7 +82,7 @@ interface to layers from Mapbox and elsewhere.</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a TileJSON resource
-var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileapi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided, you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -151,7 +151,7 @@ interactivity into your map, which you can easily access with <code><a href="#l-
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -215,7 +215,7 @@ from Mapbox and elsewhere into your map.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
+<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -369,7 +369,7 @@ featureLayer.setGeoJSON({
 <tr>
 <td>id <em>or</em> url</td>
 <td>string</td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -623,7 +623,7 @@ This function is currently in private beta: <a href="https://mapbox.com/contact/
 <tr>
 <td>id <em>or</em> url (<em>required</em>)</td>
 <td>string</td>
-<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -737,7 +737,7 @@ This function is currently in private beta: <a href="https://mapbox.com/contact/
 <tr>
 <td>id <em>or</em> url <em>optional</em></td>
 <td>string</td>
-<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileApi}}/v3/examples.map-0l53fhk2.json">{{site.tileApi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
+<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileapi}}/v3/examples.map-0l53fhk2.json">{{site.tileapi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -877,7 +877,7 @@ options object formatted to be used as <a href="http://leafletjs.com/reference.h
 </tbody>
 </table>
 <p><em>Example</em>:</p>
-<pre><code>var output = L.mapbox.template(&#39;Name: {{name}}&#39;, {name: &#39;John&#39;});
+<pre><code>var output = L.mapbox.template(&#39;Name: {% raw %}{{name}}{% endraw %}&#39;, {name: &#39;John&#39;});
 // output is &quot;Name: John&quot;
 </code></pre><h1 id="guides">Guides</h1>
 <h2 id="mobile">Mobile</h2>
@@ -7122,4 +7122,4 @@ var Leaflet = L.noConflict();
 
 <pre><code>L.version // returns "0.5" (or whatever version is currently in use)</code></pre>
 
-{% endraw %}
+

--- a/docs/_posts/api/0200-01-01-v1.6.2-all.html
+++ b/docs/_posts/api/0200-01-01-v1.6.2-all.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.2
 permalink: /api/v1.6.2/all/
 ---
-{% raw %}
+
 <h1 id="map-object">Map Object</h1>
 <h2 id="l-mapbox-map">L.mapbox.map(element, id|url|tilejson, options)</h2>
 <p>Create and automatically configure a map with layers, markers, and
@@ -28,7 +28,7 @@ interactivity.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="https://www.mapbox.com/developers/tilejson/">TileJSON</a> object, from your own Javascript code</li></ul></td>
+<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="https://www.mapbox.com/developers/tilejson/">TileJSON</a> object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -67,7 +67,7 @@ interface to layers from Mapbox and elsewhere.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -82,7 +82,7 @@ interface to layers from Mapbox and elsewhere.</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a TileJSON resource
-var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileapi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided, you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -151,7 +151,7 @@ interactivity into your map, which you can easily access with <code><a href="#l-
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -261,7 +261,7 @@ from Mapbox and elsewhere into your map.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> geojson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
+<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -415,7 +415,7 @@ featureLayer.setGeoJSON({
 <tr>
 <td>id <em>or</em> url</td>
 <td>string</td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -672,7 +672,7 @@ This function is currently in private beta: <a href="https://mapbox.com/contact/
 <tr>
 <td>id <em>or</em> url (<em>required</em>)</td>
 <td>string</td>
-<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -786,7 +786,7 @@ This function is currently in private beta: <a href="https://mapbox.com/contact/
 <tr>
 <td>id <em>or</em> url <em>optional</em></td>
 <td>string</td>
-<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileApi}}/v3/examples.map-0l53fhk2.json">{{site.tileApi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
+<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileapi}}/v3/examples.map-0l53fhk2.json">{{site.tileapi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -926,7 +926,7 @@ options object formatted to be used as <a href="http://leafletjs.com/reference.h
 </tbody>
 </table>
 <p><em>Example</em>:</p>
-<pre><code>var output = L.mapbox.template(&#39;Name: {{name}}&#39;, {name: &#39;John&#39;});
+<pre><code>var output = L.mapbox.template(&#39;Name: {% raw %}{{name}}{% endraw %}&#39;, {name: &#39;John&#39;});
 // output is &quot;Name: John&quot;
 </code></pre><h1 id="configuration">Configuration</h1>
 <h2 id="l-mapbox-config-force_https">L.mapbox.config.FORCE_HTTPS</h2>
@@ -7187,4 +7187,4 @@ var Leaflet = L.noConflict();
 
 <pre><code>L.version // returns "0.5" (or whatever version is currently in use)</code></pre>
 
-{% endraw %}
+

--- a/docs/_posts/api/0200-01-01-v1.6.2-all.html
+++ b/docs/_posts/api/0200-01-01-v1.6.2-all.html
@@ -28,7 +28,7 @@ interactivity.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="https://www.mapbox.com/developers/tilejson/">TileJSON</a> object, from your own Javascript code</li></ul></td>
+<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="https://www.mapbox.com/developers/tilejson/">TileJSON</a> object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -67,7 +67,7 @@ interface to layers from Mapbox and elsewhere.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -82,7 +82,7 @@ interface to layers from Mapbox and elsewhere.</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a TileJSON resource
-var layer = L.mapbox.tileLayer(&#39;http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided, you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -151,7 +151,7 @@ interactivity into your map, which you can easily access with <code><a href="#l-
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -261,7 +261,7 @@ from Mapbox and elsewhere into your map.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> geojson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
+<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -415,7 +415,7 @@ featureLayer.setGeoJSON({
 <tr>
 <td>id <em>or</em> url</td>
 <td>string</td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -672,7 +672,7 @@ This function is currently in private beta: <a href="https://mapbox.com/contact/
 <tr>
 <td>id <em>or</em> url (<em>required</em>)</td>
 <td>string</td>
-<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -786,7 +786,7 @@ This function is currently in private beta: <a href="https://mapbox.com/contact/
 <tr>
 <td>id <em>or</em> url <em>optional</em></td>
 <td>string</td>
-<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="https://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json">https://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
+<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileApi}}/v3/examples.map-0l53fhk2.json">{{site.tileApi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>

--- a/docs/_posts/api/0200-01-01-v1.6.3-all.html
+++ b/docs/_posts/api/0200-01-01-v1.6.3-all.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.3
 permalink: /api/v1.6.3/all/
 ---
-{% raw %}
+
 <h1 id="map-object">Map Object</h1>
 <h2 id="l-mapbox-map">L.mapbox.map(element, id|url|tilejson, options)</h2>
 <p>Create and automatically configure a map with layers, markers, and
@@ -28,7 +28,7 @@ interactivity.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="https://www.mapbox.com/developers/tilejson/">TileJSON</a> object, from your own Javascript code</li></ul></td>
+<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="https://www.mapbox.com/developers/tilejson/">TileJSON</a> object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -68,7 +68,7 @@ interface to layers from Mapbox and elsewhere.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -83,7 +83,7 @@ interface to layers from Mapbox and elsewhere.</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a TileJSON resource
-var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileapi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided, you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -154,7 +154,7 @@ interactivity into your map, which you can easily access with <code><a href="#l-
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -265,7 +265,7 @@ from Mapbox and elsewhere into your map.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> geojson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
+<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -421,7 +421,7 @@ featureLayer.setGeoJSON({
 <tr>
 <td>id <em>or</em> url</td>
 <td>string</td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -682,7 +682,7 @@ This function is currently in private beta: <a href="https://mapbox.com/contact/
 <tr>
 <td>id <em>or</em> url (<em>required</em>)</td>
 <td>string</td>
-<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -797,7 +797,7 @@ This function is currently in private beta: <a href="https://mapbox.com/contact/
 <tr>
 <td>id <em>or</em> url <em>optional</em></td>
 <td>string</td>
-<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileApi}}/v3/examples.map-0l53fhk2.json">{{site.tileApi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
+<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileapi}}/v3/examples.map-0l53fhk2.json">{{site.tileapi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -939,7 +939,7 @@ options object formatted to be used as <a href="http://leafletjs.com/reference.h
 </tbody>
 </table>
 <p><em>Example</em>:</p>
-<pre><code>var output = L.mapbox.template(&#39;Name: {{name}}&#39;, {name: &#39;John&#39;});
+<pre><code>var output = L.mapbox.template(&#39;Name: {% raw %}{{name}}{% endraw %}&#39;, {name: &#39;John&#39;});
 // output is &quot;Name: John&quot;
 </code></pre><h1 id="configuration">Configuration</h1>
 <h2 id="l-mapbox-config-force_https">L.mapbox.config.FORCE_HTTPS</h2>
@@ -7200,4 +7200,4 @@ var Leaflet = L.noConflict();
 
 <pre><code>L.version // returns "0.5" (or whatever version is currently in use)</code></pre>
 
-{% endraw %}
+

--- a/docs/_posts/api/0200-01-01-v1.6.3-all.html
+++ b/docs/_posts/api/0200-01-01-v1.6.3-all.html
@@ -28,7 +28,7 @@ interactivity.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="https://www.mapbox.com/developers/tilejson/">TileJSON</a> object, from your own Javascript code</li></ul></td>
+<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="https://www.mapbox.com/developers/tilejson/">TileJSON</a> object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -68,7 +68,7 @@ interface to layers from Mapbox and elsewhere.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -83,7 +83,7 @@ interface to layers from Mapbox and elsewhere.</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a TileJSON resource
-var layer = L.mapbox.tileLayer(&#39;http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided, you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -154,7 +154,7 @@ interactivity into your map, which you can easily access with <code><a href="#l-
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -265,7 +265,7 @@ from Mapbox and elsewhere into your map.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> geojson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
+<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -421,7 +421,7 @@ featureLayer.setGeoJSON({
 <tr>
 <td>id <em>or</em> url</td>
 <td>string</td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -682,7 +682,7 @@ This function is currently in private beta: <a href="https://mapbox.com/contact/
 <tr>
 <td>id <em>or</em> url (<em>required</em>)</td>
 <td>string</td>
-<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -797,7 +797,7 @@ This function is currently in private beta: <a href="https://mapbox.com/contact/
 <tr>
 <td>id <em>or</em> url <em>optional</em></td>
 <td>string</td>
-<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="https://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json">https://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
+<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileApi}}/v3/examples.map-0l53fhk2.json">{{site.tileApi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>

--- a/docs/_posts/api/0200-01-01-v1.6.4-all.html
+++ b/docs/_posts/api/0200-01-01-v1.6.4-all.html
@@ -29,7 +29,7 @@ interactivity.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="https://www.mapbox.com/developers/tilejson/">TileJSON</a> object, from your own Javascript code</li></ul></td>
+<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="https://www.mapbox.com/developers/tilejson/">TileJSON</a> object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -69,7 +69,7 @@ interface to layers from Mapbox and elsewhere.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -84,7 +84,7 @@ interface to layers from Mapbox and elsewhere.</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a TileJSON resource
-var layer = L.mapbox.tileLayer(&#39;http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided, you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -155,7 +155,7 @@ interactivity into your map, which you can easily access with <code><a href="#l-
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -266,7 +266,7 @@ from Mapbox and elsewhere into your map.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> geojson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
+<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -422,7 +422,7 @@ featureLayer.setGeoJSON({
 <tr>
 <td>id <em>or</em> url</td>
 <td>string</td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -683,7 +683,7 @@ This function is currently in private beta: <a href="https://mapbox.com/contact/
 <tr>
 <td>id <em>or</em> url (<em>required</em>)</td>
 <td>string</td>
-<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -798,7 +798,7 @@ This function is currently in private beta: <a href="https://mapbox.com/contact/
 <tr>
 <td>id <em>or</em> url <em>optional</em></td>
 <td>string</td>
-<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="https://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json">https://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
+<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code> If not supplied, the TileJSON from the map is used.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>

--- a/docs/_posts/api/0200-01-01-v1.6.4-all.html
+++ b/docs/_posts/api/0200-01-01-v1.6.4-all.html
@@ -6,7 +6,6 @@ version: v1.6.4
 description: Build anything with Mapbox.js, a library for fast & interactive maps.
 permalink: /api/v1.6.4/all/
 ---
-{% raw %}
 <h1 id="map-object">Map Object</h1>
 <h2 id="l-mapbox-map">L.mapbox.map(element, id|url|tilejson, options)</h2>
 <p>Create and automatically configure a map with layers, markers, and
@@ -29,7 +28,7 @@ interactivity.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="https://www.mapbox.com/developers/tilejson/">TileJSON</a> object, from your own Javascript code</li></ul></td>
+<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="https://www.mapbox.com/developers/tilejson/">TileJSON</a> object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -69,7 +68,7 @@ interface to layers from Mapbox and elsewhere.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -84,7 +83,7 @@ interface to layers from Mapbox and elsewhere.</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a TileJSON resource
-var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileapi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided, you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -155,7 +154,7 @@ interactivity into your map, which you can easily access with <code><a href="#l-
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -266,7 +265,7 @@ from Mapbox and elsewhere into your map.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> geojson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
+<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -422,7 +421,7 @@ featureLayer.setGeoJSON({
 <tr>
 <td>id <em>or</em> url</td>
 <td>string</td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -683,7 +682,7 @@ This function is currently in private beta: <a href="https://mapbox.com/contact/
 <tr>
 <td>id <em>or</em> url (<em>required</em>)</td>
 <td>string</td>
-<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -798,7 +797,7 @@ This function is currently in private beta: <a href="https://mapbox.com/contact/
 <tr>
 <td>id <em>or</em> url <em>optional</em></td>
 <td>string</td>
-<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code> If not supplied, the TileJSON from the map is used.</li></ul></td>
+<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code> If not supplied, the TileJSON from the map is used.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -940,7 +939,7 @@ options object formatted to be used as <a href="http://leafletjs.com/reference.h
 </tbody>
 </table>
 <p><em>Example</em>:</p>
-<pre><code>var output = L.mapbox.template(&#39;Name: {{name}}&#39;, {name: &#39;John&#39;});
+<pre><code>var output = L.mapbox.template(&#39;Name: {% raw %}{{name}}{% endraw %}&#39;, {name: &#39;John&#39;});
 // output is &quot;Name: John&quot;
 </code></pre><h1 id="configuration">Configuration</h1>
 <h2 id="l-mapbox-config-force_https">L.mapbox.config.FORCE_HTTPS</h2>
@@ -7201,4 +7200,3 @@ var Leaflet = L.noConflict();
 
 <pre><code>L.version // returns "0.5" (or whatever version is currently in use)</code></pre>
 
-{% endraw %}

--- a/docs/_posts/api/v1.6.0/0200-01-01-.html
+++ b/docs/_posts/api/v1.6.0/0200-01-01-.html
@@ -5,4 +5,4 @@ categories: api
 version: v1.6.0
 permalink: /api/v1.6.0/
 ---
-{% raw %}{% endraw %}
+

--- a/docs/_posts/api/v1.6.0/0200-01-01-dark-theme.html
+++ b/docs/_posts/api/v1.6.0/0200-01-01-dark-theme.html
@@ -5,9 +5,9 @@ categories: api
 version: v1.6.0
 permalink: /api/v1.6.0/dark-theme
 ---
-{% raw %}<h2 id="section-dark-theme">Dark theme</h2>
+<h2 id="section-dark-theme">Dark theme</h2>
 <p>Mapbox.js implements a simple, light style on all interaction elements. A dark theme
 is available by applying <code>class=&quot;dark&quot;</code> to the map div.</p>
 <p><em>Example</em>:</p>
 <pre><code>&lt;div id=&quot;map&quot; class=&quot;dark&quot;&gt;&lt;/div&gt;
-</code></pre>{% endraw %}
+</code></pre>

--- a/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-featurelayer.html
+++ b/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-featurelayer.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.0
 permalink: /api/v1.6.0/l-mapbox-featurelayer
 ---
-{% raw %}<h2 id="section-l-mapbox-featurelayer">L.mapbox.featureLayer(id|url|tilejson, options)</h2>
+<h2 id="section-l-mapbox-featurelayer">L.mapbox.featureLayer(id|url|tilejson, options)</h2>
 <p><strong>NOTE: in version 1.6.0, <code><a href="/mapbox.js/api/v1.6.0/l-mapbox-markerlayer">L.mapbox.markerLayer</a></code> was renamed to <code><a href="/mapbox.js/api/v1.6.0/l-mapbox-featurelayer">L.mapbox.featureLayer</a></code>
 to signal the addition of support for lines and polygons. The <code><a href="/mapbox.js/api/v1.6.0/l-mapbox-markerlayer">L.mapbox.markerLayer</a></code>
 alias will be removed in Mapbox.js 2.0.0</strong></p>
@@ -23,7 +23,7 @@ from Mapbox and elsewhere into your map.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
+<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -162,4 +162,4 @@ featureLayer.setGeoJSON({
 <h3 id="section-featurelayer-getgeojson">featureLayer.getGeoJSON()</h3>
 <p>Get the contents of this layer as GeoJSON data.</p>
 <p><em>Returns</em> the GeoJSON represented by this layer</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-featurelayer.html
+++ b/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-featurelayer.html
@@ -23,7 +23,7 @@ from Mapbox and elsewhere into your map.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
+<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>

--- a/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-geocoder.html
+++ b/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-geocoder.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.0
 permalink: /api/v1.6.0/l-mapbox-geocoder
 ---
-{% raw %}<h2 id="section-l-mapbox-geocoder">L.mapbox.geocoder(id|url)</h2>
+<h2 id="section-l-mapbox-geocoder">L.mapbox.geocoder(id|url)</h2>
 <p>A low-level interface to geocoding, useful for more complex uses and reverse-geocoding.</p>
 <table>
 <thead>
@@ -19,7 +19,7 @@ permalink: /api/v1.6.0/l-mapbox-geocoder
 <tr>
 <td>id <em>or</em> url</td>
 <td>string</td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -84,4 +84,4 @@ permalink: /api/v1.6.0/l-mapbox-geocoder
 </tbody>
 </table>
 <p><em>Returns</em>: the geocoder object. The return value of this function is not useful - you must use a callback to get results.</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-geocoder.html
+++ b/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-geocoder.html
@@ -19,7 +19,7 @@ permalink: /api/v1.6.0/l-mapbox-geocoder
 <tr>
 <td>id <em>or</em> url</td>
 <td>string</td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 </tbody>
 </table>

--- a/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-geocodercontrol.html
+++ b/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-geocodercontrol.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.0
 permalink: /api/v1.6.0/l-mapbox-geocodercontrol
 ---
-{% raw %}<h2 id="section-l-mapbox-geocodercontrol">L.mapbox.geocoderControl(id|url, options)</h2>
+<h2 id="section-l-mapbox-geocodercontrol">L.mapbox.geocoderControl(id|url, options)</h2>
 <p>Adds geocoder functionality as well as a UI element to a map. This uses
 the <a href="http://mapbox.com/developers/api/#geocoding">Mapbox Geocoding API</a>.</p>
 <div class='note warning'>
@@ -24,7 +24,7 @@ This function is currently in private beta: <a href='http://mapbox.com/about/con
 <tr>
 <td>id <em>or</em> url (<em>required</em>)</td>
 <td>string</td>
-<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -113,4 +113,4 @@ This function is currently in private beta: <a href='http://mapbox.com/about/con
 </tr>
 </tbody>
 </table>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-geocodercontrol.html
+++ b/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-geocodercontrol.html
@@ -24,7 +24,7 @@ This function is currently in private beta: <a href='http://mapbox.com/about/con
 <tr>
 <td>id <em>or</em> url (<em>required</em>)</td>
 <td>string</td>
-<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 <tr>
 <td>options</td>

--- a/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-gridcontrol.html
+++ b/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-gridcontrol.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.0
 permalink: /api/v1.6.0/l-mapbox-gridcontrol
 ---
-{% raw %}<h2 id="section-l-mapbox-gridcontrol">L.mapbox.gridControl(layer, options)</h2>
+<h2 id="section-l-mapbox-gridcontrol">L.mapbox.gridControl(layer, options)</h2>
 <p>Interaction is what we call interactive parts of maps that are created with the powerful <a href="http://mapbox.com/tilemill/docs/crashcourse/tooltips/">tooltips &amp; regions</a> system in <a href="http://mapbox.com/tilemill/">TileMill</a>. Under the hood, it&#39;s powered by the open <a href="https://github.com/mapbox/utfgrid-spec/">UTFGrid specification</a>.</p>
 <table>
 <thead>
@@ -58,4 +58,4 @@ the UTFGrid data in the map&#39;s interactivity into HTML for display.</p>
 </tbody>
 </table>
 <p><em>Returns</em>: the <code><a href="/mapbox.js/api/v1.6.0/l-mapbox-gridcontrol">L.mapbox.gridControl</a></code> object.</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-gridlayer.html
+++ b/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-gridlayer.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.0
 permalink: /api/v1.6.0/l-mapbox-gridlayer
 ---
-{% raw %}<h2 id="section-l-mapbox-gridlayer">L.mapbox.gridLayer(id|url|tilejson, options)</h2>
+<h2 id="section-l-mapbox-gridlayer">L.mapbox.gridLayer(id|url|tilejson, options)</h2>
 <p>An <code><a href="/mapbox.js/api/v1.6.0/l-mapbox-gridlayer">L.mapbox.gridLayer</a></code> loads <a href="http://mapbox.com/developers/utfgrid/">UTFGrid</a> tiles of
 interactivity into your map, which you can easily access with <code><a href="/mapbox.js/api/v1.6.0/l-mapbox-gridcontrol">L.mapbox.gridControl</a></code>.</p>
 <table>
@@ -20,7 +20,7 @@ interactivity into your map, which you can easily access with <code><a href="/ma
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -66,4 +66,4 @@ function with that data, if any.</p>
 </tbody>
 </table>
 <p><em>Returns</em>: the L.mapbox.gridLayer object</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-gridlayer.html
+++ b/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-gridlayer.html
@@ -20,7 +20,7 @@ interactivity into your map, which you can easily access with <code><a href="/ma
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 </tbody>
 </table>

--- a/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-infocontrol.html
+++ b/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-infocontrol.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.0
 permalink: /api/v1.6.0/l-mapbox-infocontrol
 ---
-{% raw %}<h2 id="section-l-mapbox-infocontrol">L.mapbox.infoControl(options)</h2>
+<h2 id="section-l-mapbox-infocontrol">L.mapbox.infoControl(options)</h2>
 <p>A map control that shows a toggleable info container. This is triggered by default and attribution is auto-detected from active layers and added to the info container.</p>
 <table>
 <thead>
@@ -63,4 +63,4 @@ map.addControl(L.mapbox.infoControl());
 </tr>
 </tbody>
 </table>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-legendcontrol.html
+++ b/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-legendcontrol.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.0
 permalink: /api/v1.6.0/l-mapbox-legendcontrol
 ---
-{% raw %}<h2 id="section-l-mapbox-legendcontrol">L.mapbox.legendControl(options)</h2>
+<h2 id="section-l-mapbox-legendcontrol">L.mapbox.legendControl(options)</h2>
 <p>A map control that shows legends added to maps in Mapbox. Legends are auto-detected from active layers.</p>
 <table>
 <thead>
@@ -63,4 +63,4 @@ map.addControl(L.mapbox.legendControl());
 </tr>
 </tbody>
 </table>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-map.html
+++ b/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-map.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.0
 permalink: /api/v1.6.0/l-mapbox-map
 ---
-{% raw %}<h2 id="section-l-mapbox-map">L.mapbox.map(element, id|url|tilejson, options)</h2>
+<h2 id="section-l-mapbox-map">L.mapbox.map(element, id|url|tilejson, options)</h2>
 <p>Create and automatically configure a map with layers, markers, and
 interactivity.</p>
 <p><span class='leaflet'><em>Extends</em>: <a href="http://leafletjs.com/reference.html#map-options">L.Map</a></span></p>
@@ -26,7 +26,7 @@ interactivity.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
+<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -44,4 +44,4 @@ var map = L.mapbox.map(&#39;map&#39;, &#39;examples.map-4l7djmvo&#39;);
 // This map will have no layers initially
 var map = L.mapbox.map(&#39;map&#39;);
 </code></pre><p><em>Returns</em>: a map object</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-map.html
+++ b/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-map.html
@@ -26,7 +26,7 @@ interactivity.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
+<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>

--- a/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-marker-icon.html
+++ b/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-marker-icon.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.0
 permalink: /api/v1.6.0/l-mapbox-marker-icon
 ---
-{% raw %}<h2 id="section-l-mapbox-marker-icon">L.mapbox.marker.icon(feature)</h2>
+<h2 id="section-l-mapbox-marker-icon">L.mapbox.marker.icon(feature)</h2>
 <p>A core icon generator used in <code><a href="/mapbox.js/api/v1.6.0/l-mapbox-marker-style">L.mapbox.marker.style</a></code></p>
 <table>
 <thead>
@@ -26,4 +26,4 @@ permalink: /api/v1.6.0/l-mapbox-marker-icon
 <p><em>Returns</em>:</p>
 <p>A <code><a href="/mapbox.js/api/v1.6.0/l-icon">L.Icon</a></code> object with custom settings for <code>iconUrl</code>, <code>iconSize</code>, <code>iconAnchor</code>,
 and <code>popupAnchor</code>.</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-marker-style.html
+++ b/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-marker-style.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.0
 permalink: /api/v1.6.0/l-mapbox-marker-style
 ---
-{% raw %}<h2 id="section-l-mapbox-marker-style">L.mapbox.marker.style(feature, latlng)</h2>
+<h2 id="section-l-mapbox-marker-style">L.mapbox.marker.style(feature, latlng)</h2>
 <p>An icon generator for use in conjunction with <code>pointToLayer</code> to generate
 markers from the <a href="http://mapbox.com/developers/api/#markers">Mapbox Markers API</a>
 and support the <a href="https://github.com/mapbox/simplestyle-spec">simplestyle-spec</a> for
@@ -39,4 +39,4 @@ features.</p>
 <p>A <code><a href="/mapbox.js/api/v1.6.0/l-marker">L.Marker</a></code> object with the latitude, longitude position and a styled marker</p>
 <p>The other sections of the <a href="https://github.com/mapbox/simplestyle-spec">simplestyle-spec</a> are implemented
 by <code><a href="/mapbox.js/api/v1.6.0/l-mapbox-simplestyle">L.mapbox.simplestyle</a></code></p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-markerlayer.html
+++ b/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-markerlayer.html
@@ -20,7 +20,7 @@ from Mapbox and elsewhere into your map.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
+<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>

--- a/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-markerlayer.html
+++ b/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-markerlayer.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.0
 permalink: /api/v1.6.0/l-mapbox-markerlayer
 ---
-{% raw %}<h2 id="section-l-mapbox-markerlayer">L.mapbox.markerLayer(id|url|tilejson, options)</h2>
+<h2 id="section-l-mapbox-markerlayer">L.mapbox.markerLayer(id|url|tilejson, options)</h2>
 <p><code><a href="/mapbox.js/api/v1.6.0/l-mapbox-markerlayer">L.mapbox.markerLayer</a></code> provides an easy way to integrate <a href="http://www.geojson.org/">GeoJSON</a>
 from Mapbox and elsewhere into your map.</p>
 <table>
@@ -20,7 +20,7 @@ from Mapbox and elsewhere into your map.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
+<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -159,4 +159,4 @@ markerLayer.setGeoJSON({
 <h3 id="section-markerlayer-getgeojson">markerLayer.getGeoJSON()</h3>
 <p>Get the contents of this layer as GeoJSON data.</p>
 <p><em>Returns</em> the GeoJSON represented by this layer</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-sanitize.html
+++ b/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-sanitize.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.0
 permalink: /api/v1.6.0/l-mapbox-sanitize
 ---
-{% raw %}<h2 id="section-l-mapbox-sanitize">L.mapbox.sanitize(string)</h2>
+<h2 id="section-l-mapbox-sanitize">L.mapbox.sanitize(string)</h2>
 <p>A HTML sanitization function, with the same effect as the default value of the <code>sanitizer</code> option of <code><a href="/mapbox.js/api/v1.6.0/l-mapbox-featurelayer">L.mapbox.featureLayer</a></code>, <code><a href="/mapbox.js/api/v1.6.0/l-mapbox-gridcontrol">L.mapbox.gridControl</a></code>, and <code><a href="/mapbox.js/api/v1.6.0/l-mapbox-legendcontrol">L.mapbox.legendControl</a></code>.</p>
 <table>
 <thead>
@@ -23,4 +23,4 @@ permalink: /api/v1.6.0/l-mapbox-sanitize
 </tr>
 </tbody>
 </table>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-sharecontrol.html
+++ b/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-sharecontrol.html
@@ -20,7 +20,7 @@ permalink: /api/v1.6.0/l-mapbox-sharecontrol
 <tr>
 <td>id <em>or</em> url <em>optional</em></td>
 <td>string</td>
-<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="https://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json">https://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
+<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileApi}}/v3/examples.map-0l53fhk2.json">{{site.tileApi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>

--- a/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-sharecontrol.html
+++ b/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-sharecontrol.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.0
 permalink: /api/v1.6.0/l-mapbox-sharecontrol
 ---
-{% raw %}<h2 id="section-l-mapbox-sharecontrol">L.mapbox.shareControl(id|url, options)</h2>
+<h2 id="section-l-mapbox-sharecontrol">L.mapbox.shareControl(id|url, options)</h2>
 <p>Adds a &quot;Share&quot; button to the map, which can be used to share the map to Twitter or Facebook, or generate HTML for a map embed.</p>
 <p><span class='leaflet'><em>Extends</em>: <a href="http://leafletjs.com/reference.html#control">L.Control</a></span></p>
 <table>
@@ -20,7 +20,7 @@ permalink: /api/v1.6.0/l-mapbox-sharecontrol
 <tr>
 <td>id <em>or</em> url <em>optional</em></td>
 <td>string</td>
-<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileApi}}/v3/examples.map-0l53fhk2.json">{{site.tileApi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
+<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileapi}}/v3/examples.map-0l53fhk2.json">{{site.tileapi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -35,4 +35,4 @@ permalink: /api/v1.6.0/l-mapbox-sharecontrol
     .addControl(L.mapbox.shareControl());
 </code></pre><p><em>Returns</em>:
 Returns a <code>L.mapbox.shareControl</code> object.</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-template.html
+++ b/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-template.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.0
 permalink: /api/v1.6.0/l-mapbox-template
 ---
-{% raw %}<h2 id="section-l-mapbox-template">L.mapbox.template(template, data)</h2>
+<h2 id="section-l-mapbox-template">L.mapbox.template(template, data)</h2>
 <p>A <a href="http://mustache.github.io/">mustache</a> template rendering function, as used by the templating feature provided by <code><a href="/mapbox.js/api/v1.6.0/l-mapbox-gridcontrol">L.mapbox.gridControl</a></code>.</p>
 <table>
 <thead>
@@ -29,8 +29,8 @@ permalink: /api/v1.6.0/l-mapbox-template
 </tbody>
 </table>
 <p><em>Example</em>:</p>
-<pre><code>var output = L.mapbox.template(&#39;Name: {{name}}&#39;, {name: &#39;John&#39;});
+<pre><code>var output = L.mapbox.template(&#39;Name: {% raw %}{{name}}{% endraw %}&#39;, {name: &#39;John&#39;});
 // output is &quot;Name: John&quot;
 </code></pre><p>Mapbox.js is optimized for mobile devices and small screens by default.
 There are, however, best practices to make sure your map always looks its best.</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-tilelayer.html
+++ b/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-tilelayer.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.0
 permalink: /api/v1.6.0/l-mapbox-tilelayer
 ---
-{% raw %}<h2 id="section-l-mapbox-tilelayer">L.mapbox.tileLayer(id|url|tilejson, options)</h2>
+<h2 id="section-l-mapbox-tilelayer">L.mapbox.tileLayer(id|url|tilejson, options)</h2>
 <p>You can add a tiled layer to your map with <code><a href="/mapbox.js/api/v1.6.0/l-mapbox-tilelayer">L.mapbox.tileLayer()</a></code>, a simple
 interface to layers from Mapbox and elsewhere.</p>
 <p><span class='leaflet'><em>Extends</em>: <a href="http://leafletjs.com/reference.html#tilelayer">L.TileLayer</a></span></p>
@@ -21,7 +21,7 @@ interface to layers from Mapbox and elsewhere.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -36,7 +36,7 @@ interface to layers from Mapbox and elsewhere.</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a TileJSON resource
-var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileapi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided, you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -94,4 +94,4 @@ var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
     format: &#39;jpg70&#39;
 });
 </code></pre><p><em>Returns</em>: the layer object</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-tilelayer.html
+++ b/docs/_posts/api/v1.6.0/0200-01-01-l-mapbox-tilelayer.html
@@ -21,7 +21,7 @@ interface to layers from Mapbox and elsewhere.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -36,7 +36,7 @@ interface to layers from Mapbox and elsewhere.</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a TileJSON resource
-var layer = L.mapbox.tileLayer(&#39;http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided, you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {

--- a/docs/_posts/api/v1.6.0/0200-01-01-l-simplestyle-style.html
+++ b/docs/_posts/api/v1.6.0/0200-01-01-l-simplestyle-style.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.0
 permalink: /api/v1.6.0/l-simplestyle-style
 ---
-{% raw %}<h2 id="section-l-simplestyle-style">L.simplestyle.style(feature)</h2>
+<h2 id="section-l-simplestyle-style">L.simplestyle.style(feature)</h2>
 <p>Given a GeoJSON Feature with optional simplestyle-spec properties, return an
 options object formatted to be used as <a href="http://leafletjs.com/reference.html#path">Leaflet Path options</a>.</p>
 <table>
@@ -30,4 +30,4 @@ options object formatted to be used as <a href="http://leafletjs.com/reference.h
 });
 </code></pre><p><em>Returns</em>:</p>
 <p>An object formatted to be used as <a href="http://leafletjs.com/reference.html#path">Leaflet Path options</a>.</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.0/0200-01-01-map-gettilejson.html
+++ b/docs/_posts/api/v1.6.0/0200-01-01-map-gettilejson.html
@@ -5,8 +5,8 @@ categories: api
 version: v1.6.0
 permalink: /api/v1.6.0/map-gettilejson
 ---
-{% raw %}<h2 id="section-map-gettilejson">map.getTileJSON()</h2>
+<h2 id="section-map-gettilejson">map.getTileJSON()</h2>
 <p>Returns this map&#39;s TileJSON object which determines its tile source,
 zoom bounds and other metadata.</p>
 <p><em>Returns</em>: the TileJSON object</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.0/0200-01-01-mobile.html
+++ b/docs/_posts/api/v1.6.0/0200-01-01-mobile.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.0
 permalink: /api/v1.6.0/mobile
 ---
-{% raw %}<h2 id="section-mobile">Mobile</h2>
+<h2 id="section-mobile">Mobile</h2>
 <p>Mapbox.js is optimized for mobile devices and small screens by default.
 There are, however, best practices to make sure your map always looks its best.</p>
 <h3 id="section-viewport">Viewport</h3>
@@ -36,4 +36,4 @@ tiles will be used when retina is detected.</p>
         detectRetina: true
     }
 }).setView([40, -74.50], 9);
-</code></pre>{% endraw %}
+</code></pre>

--- a/docs/_posts/api/v1.6.0/0200-01-01-retina.html
+++ b/docs/_posts/api/v1.6.0/0200-01-01-retina.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.0
 permalink: /api/v1.6.0/retina
 ---
-{% raw %}<h2 id="section-retina">Retina</h2>
+<h2 id="section-retina">Retina</h2>
 <p>Having the ability to use retina tiles when the device supports them is easy.
 When creating the map, use the <code>detectRetina</code> to verify if retina is available
 and <code>retinaVersion</code> to use a tilelayer which is designed for retina screens.</p>
@@ -23,4 +23,4 @@ tiles will be used when retina is detected.</p>
         detectRetina: true
     }
 }).setView([40, -74.50], 9);
-</code></pre>{% endraw %}
+</code></pre>

--- a/docs/_posts/api/v1.6.0/0200-01-01-scrolling.html
+++ b/docs/_posts/api/v1.6.0/0200-01-01-scrolling.html
@@ -5,9 +5,9 @@ categories: api
 version: v1.6.0
 permalink: /api/v1.6.0/scrolling
 ---
-{% raw %}<h2 id="section-scrolling">Scrolling</h2>
+<h2 id="section-scrolling">Scrolling</h2>
 <p>If you&#39;re planning on having a page that has large amounts of scrolling,
 try to avoid a large map height. Having a &#39;tall&#39; map can cause the user
 to get stuck on the map while scrolling. Another way around this is to disable
 <code>dragging</code> for mobile devices: <code>map.dragging.disable();</code></p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.0/0200-01-01-theming.html
+++ b/docs/_posts/api/v1.6.0/0200-01-01-theming.html
@@ -5,10 +5,10 @@ categories: api
 version: v1.6.1
 permalink: /api/v1.6.0/mapbox-theming
 ---
-{% raw %}<h2 id="section-theming">Theming</h2>
+<h2 id="section-theming">Theming</h2>
 <h3 id="section-dark-theme">Dark theme</h3>
 <p>Mapbox.js implements a simple, light style on all interaction elements. A dark theme
 is available by applying <code>class=&quot;dark&quot;</code> to the map div.</p>
 <p><em>Example</em>:</p>
 <pre><code>&lt;div id=&quot;map&quot; class=&quot;dark&quot;&gt;&lt;/div&gt;
-</code></pre>{% endraw %}
+</code></pre>

--- a/docs/_posts/api/v1.6.0/0200-01-01-viewport.html
+++ b/docs/_posts/api/v1.6.0/0200-01-01-viewport.html
@@ -5,9 +5,9 @@ categories: api
 version: v1.6.0
 permalink: /api/v1.6.0/viewport
 ---
-{% raw %}<h2 id="section-viewport">Viewport</h2>
+<h2 id="section-viewport">Viewport</h2>
 <p>Modern mobile browsers now support scaling of webpages by leveraging the meta
 tag <code>viewport</code>. This enlarges the window making your map look better on a
 mobile device. Simply include this in the head of your document:</p>
 <pre><code>&lt;meta name=&#39;viewport&#39; content=&#39;width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no&#39; /&gt;
-</code></pre>{% endraw %}
+</code></pre>

--- a/docs/_posts/api/v1.6.1/0200-01-01-.html
+++ b/docs/_posts/api/v1.6.1/0200-01-01-.html
@@ -5,4 +5,4 @@ categories: api
 version: v1.6.1
 permalink: /api/v1.6.1/
 ---
-{% raw %}{% endraw %}
+

--- a/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-featurelayer.html
+++ b/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-featurelayer.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.1
 permalink: /api/v1.6.1/l-mapbox-featurelayer
 ---
-{% raw %}<h2 id="section-l-mapbox-featurelayer">L.mapbox.featureLayer(id|url|tilejson, options)</h2>
+<h2 id="section-l-mapbox-featurelayer">L.mapbox.featureLayer(id|url|tilejson, options)</h2>
 <p><strong>NOTE: in version 1.6.0, <code><a href="/mapbox.js/api/v1.6.1/l-mapbox-markerlayer">L.mapbox.markerLayer</a></code> was renamed to <code><a href="/mapbox.js/api/v1.6.1/l-mapbox-featurelayer">L.mapbox.featureLayer</a></code>
 to signal the addition of support for lines and polygons. The <code><a href="/mapbox.js/api/v1.6.1/l-mapbox-markerlayer">L.mapbox.markerLayer</a></code>
 alias will be removed in Mapbox.js 2.0.0</strong></p>
@@ -23,7 +23,7 @@ from Mapbox and elsewhere into your map.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
+<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -162,4 +162,4 @@ featureLayer.setGeoJSON({
 <h3 id="section-featurelayer-getgeojson">featureLayer.getGeoJSON()</h3>
 <p>Get the contents of this layer as GeoJSON data.</p>
 <p><em>Returns</em> the GeoJSON represented by this layer</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-featurelayer.html
+++ b/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-featurelayer.html
@@ -23,7 +23,7 @@ from Mapbox and elsewhere into your map.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
+<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>

--- a/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-geocoder.html
+++ b/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-geocoder.html
@@ -19,7 +19,7 @@ permalink: /api/v1.6.1/l-mapbox-geocoder
 <tr>
 <td>id <em>or</em> url</td>
 <td>string</td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 </tbody>
 </table>

--- a/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-geocoder.html
+++ b/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-geocoder.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.1
 permalink: /api/v1.6.1/l-mapbox-geocoder
 ---
-{% raw %}<h2 id="section-l-mapbox-geocoder">L.mapbox.geocoder(id|url)</h2>
+<h2 id="section-l-mapbox-geocoder">L.mapbox.geocoder(id|url)</h2>
 <p>A low-level interface to geocoding, useful for more complex uses and reverse-geocoding.</p>
 <table>
 <thead>
@@ -19,7 +19,7 @@ permalink: /api/v1.6.1/l-mapbox-geocoder
 <tr>
 <td>id <em>or</em> url</td>
 <td>string</td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -84,4 +84,4 @@ permalink: /api/v1.6.1/l-mapbox-geocoder
 </tbody>
 </table>
 <p><em>Returns</em>: the geocoder object. The return value of this function is not useful - you must use a callback to get results.</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-geocodercontrol.html
+++ b/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-geocodercontrol.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.1
 permalink: /api/v1.6.1/l-mapbox-geocodercontrol
 ---
-{% raw %}<h2 id="section-l-mapbox-geocodercontrol">L.mapbox.geocoderControl(id|url, options)</h2>
+<h2 id="section-l-mapbox-geocodercontrol">L.mapbox.geocoderControl(id|url, options)</h2>
 <p>Adds geocoder functionality as well as a UI element to a map. This uses
 the <a href="http://mapbox.com/developers/api/#geocoding">Mapbox Geocoding API</a>.</p>
 <div class='note warning'>
@@ -24,7 +24,7 @@ This function is currently in private beta: <a href="https://mapbox.com/contact/
 <tr>
 <td>id <em>or</em> url (<em>required</em>)</td>
 <td>string</td>
-<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -123,4 +123,4 @@ This function is currently in private beta: <a href="https://mapbox.com/contact/
 </tr>
 </tbody>
 </table>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-geocodercontrol.html
+++ b/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-geocodercontrol.html
@@ -24,7 +24,7 @@ This function is currently in private beta: <a href="https://mapbox.com/contact/
 <tr>
 <td>id <em>or</em> url (<em>required</em>)</td>
 <td>string</td>
-<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 <tr>
 <td>options</td>

--- a/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-gridcontrol.html
+++ b/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-gridcontrol.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.1
 permalink: /api/v1.6.1/l-mapbox-gridcontrol
 ---
-{% raw %}<h2 id="section-l-mapbox-gridcontrol">L.mapbox.gridControl(layer, options)</h2>
+<h2 id="section-l-mapbox-gridcontrol">L.mapbox.gridControl(layer, options)</h2>
 <p>Interaction is what we call interactive parts of maps that are created with the powerful <a href="http://mapbox.com/tilemill/docs/crashcourse/tooltips/">tooltips &amp; regions</a> system in <a href="http://mapbox.com/tilemill/">TileMill</a>. Under the hood, it&#39;s powered by the open <a href="https://github.com/mapbox/utfgrid-spec/">UTFGrid specification</a>.</p>
 <table>
 <thead>
@@ -58,4 +58,4 @@ the UTFGrid data in the map&#39;s interactivity into HTML for display.</p>
 </tbody>
 </table>
 <p><em>Returns</em>: the <code><a href="/mapbox.js/api/v1.6.1/l-mapbox-gridcontrol">L.mapbox.gridControl</a></code> object.</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-gridlayer.html
+++ b/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-gridlayer.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.1
 permalink: /api/v1.6.1/l-mapbox-gridlayer
 ---
-{% raw %}<h2 id="section-l-mapbox-gridlayer">L.mapbox.gridLayer(id|url|tilejson, options)</h2>
+<h2 id="section-l-mapbox-gridlayer">L.mapbox.gridLayer(id|url|tilejson, options)</h2>
 <p>An <code><a href="/mapbox.js/api/v1.6.1/l-mapbox-gridlayer">L.mapbox.gridLayer</a></code> loads <a href="http://mapbox.com/developers/utfgrid/">UTFGrid</a> tiles of
 interactivity into your map, which you can easily access with <code><a href="/mapbox.js/api/v1.6.1/l-mapbox-gridcontrol">L.mapbox.gridControl</a></code>.</p>
 <table>
@@ -20,7 +20,7 @@ interactivity into your map, which you can easily access with <code><a href="/ma
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -66,4 +66,4 @@ function with that data, if any.</p>
 </tbody>
 </table>
 <p><em>Returns</em>: the L.mapbox.gridLayer object</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-gridlayer.html
+++ b/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-gridlayer.html
@@ -20,7 +20,7 @@ interactivity into your map, which you can easily access with <code><a href="/ma
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 </tbody>
 </table>

--- a/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-infocontrol.html
+++ b/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-infocontrol.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.1
 permalink: /api/v1.6.1/l-mapbox-infocontrol
 ---
-{% raw %}<h2 id="section-l-mapbox-infocontrol">L.mapbox.infoControl(options)</h2>
+<h2 id="section-l-mapbox-infocontrol">L.mapbox.infoControl(options)</h2>
 <p>A map control that shows a toggleable info container. This is triggered by default and attribution is auto-detected from active layers and added to the info container.</p>
 <table>
 <thead>
@@ -63,4 +63,4 @@ map.addControl(L.mapbox.infoControl());
 </tr>
 </tbody>
 </table>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-legendcontrol.html
+++ b/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-legendcontrol.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.1
 permalink: /api/v1.6.1/l-mapbox-legendcontrol
 ---
-{% raw %}<h2 id="section-l-mapbox-legendcontrol">L.mapbox.legendControl(options)</h2>
+<h2 id="section-l-mapbox-legendcontrol">L.mapbox.legendControl(options)</h2>
 <p>A map control that shows legends added to maps in Mapbox. Legends are auto-detected from active layers.</p>
 <table>
 <thead>
@@ -63,4 +63,4 @@ map.addControl(L.mapbox.legendControl());
 </tr>
 </tbody>
 </table>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-map.html
+++ b/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-map.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.1
 permalink: /api/v1.6.1/l-mapbox-map
 ---
-{% raw %}<h2 id="section-l-mapbox-map">L.mapbox.map(element, id|url|tilejson, options)</h2>
+<h2 id="section-l-mapbox-map">L.mapbox.map(element, id|url|tilejson, options)</h2>
 <p>Create and automatically configure a map with layers, markers, and
 interactivity.</p>
 <p><span class='leaflet'><em>Extends</em>: <code><a href="/mapbox.js/api/v1.6.1/l-map-class">L.Map</a></code></span></p>
@@ -26,7 +26,7 @@ interactivity.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
+<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -48,4 +48,4 @@ var map = L.mapbox.map(&#39;map&#39;);
 <p>Returns this map&#39;s TileJSON object which determines its tile source,
 zoom bounds and other metadata.</p>
 <p><em>Returns</em>: the TileJSON object</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-map.html
+++ b/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-map.html
@@ -26,7 +26,7 @@ interactivity.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
+<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="http://mapbox.com/wax/tilejson.html">TileJSON</a> object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>

--- a/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-marker-icon.html
+++ b/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-marker-icon.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.1
 permalink: /api/v1.6.1/l-mapbox-marker-icon
 ---
-{% raw %}<h2 id="section-l-mapbox-marker-icon">L.mapbox.marker.icon(feature)</h2>
+<h2 id="section-l-mapbox-marker-icon">L.mapbox.marker.icon(feature)</h2>
 <p>A core icon generator used in <code><a href="/mapbox.js/api/v1.6.1/l-mapbox-marker-style">L.mapbox.marker.style</a></code></p>
 <table>
 <thead>
@@ -26,4 +26,4 @@ permalink: /api/v1.6.1/l-mapbox-marker-icon
 <p><em>Returns</em>:</p>
 <p>A <code><a href="/mapbox.js/api/v1.6.1/l-icon">L.Icon</a></code> object with custom settings for <code>iconUrl</code>, <code>iconSize</code>, <code>iconAnchor</code>,
 and <code>popupAnchor</code>.</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-marker-style.html
+++ b/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-marker-style.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.1
 permalink: /api/v1.6.1/l-mapbox-marker-style
 ---
-{% raw %}<h2 id="section-l-mapbox-marker-style">L.mapbox.marker.style(feature, latlng)</h2>
+<h2 id="section-l-mapbox-marker-style">L.mapbox.marker.style(feature, latlng)</h2>
 <p>An icon generator for use in conjunction with <code>pointToLayer</code> to generate
 markers from the <a href="http://mapbox.com/developers/api/#markers">Mapbox Markers API</a>
 and support the <a href="https://github.com/mapbox/simplestyle-spec">simplestyle-spec</a> for
@@ -39,4 +39,4 @@ features.</p>
 <p>A <code><a href="/mapbox.js/api/v1.6.1/l-marker">L.Marker</a></code> object with the latitude, longitude position and a styled marker</p>
 <p>The other sections of the <a href="https://github.com/mapbox/simplestyle-spec">simplestyle-spec</a> are implemented
 by <code><a href="/mapbox.js/api/v1.6.1/l-mapbox-simplestyle">L.mapbox.simplestyle</a></code></p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-sanitize.html
+++ b/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-sanitize.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.1
 permalink: /api/v1.6.1/l-mapbox-sanitize
 ---
-{% raw %}<h2 id="section-l-mapbox-sanitize">L.mapbox.sanitize(string)</h2>
+<h2 id="section-l-mapbox-sanitize">L.mapbox.sanitize(string)</h2>
 <p>A HTML sanitization function, with the same effect as the default value of the <code>sanitizer</code> option of <code><a href="/mapbox.js/api/v1.6.1/l-mapbox-featurelayer">L.mapbox.featureLayer</a></code>, <code><a href="/mapbox.js/api/v1.6.1/l-mapbox-gridcontrol">L.mapbox.gridControl</a></code>, and <code><a href="/mapbox.js/api/v1.6.1/l-mapbox-legendcontrol">L.mapbox.legendControl</a></code>.</p>
 <table>
 <thead>
@@ -23,4 +23,4 @@ permalink: /api/v1.6.1/l-mapbox-sanitize
 </tr>
 </tbody>
 </table>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-sharecontrol.html
+++ b/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-sharecontrol.html
@@ -20,7 +20,7 @@ permalink: /api/v1.6.1/l-mapbox-sharecontrol
 <tr>
 <td>id <em>or</em> url <em>optional</em></td>
 <td>string</td>
-<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="https://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json">https://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
+<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileApi}}/v3/examples.map-0l53fhk2.json">{{site.tileApi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>

--- a/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-sharecontrol.html
+++ b/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-sharecontrol.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.1
 permalink: /api/v1.6.1/l-mapbox-sharecontrol
 ---
-{% raw %}<h2 id="section-l-mapbox-sharecontrol">L.mapbox.shareControl(id|url, options)</h2>
+<h2 id="section-l-mapbox-sharecontrol">L.mapbox.shareControl(id|url, options)</h2>
 <p>Adds a &quot;Share&quot; button to the map, which can be used to share the map to Twitter or Facebook, or generate HTML for a map embed.</p>
 <p><span class='leaflet'><em>Extends</em>: L.Control</span></p>
 <table>
@@ -20,7 +20,7 @@ permalink: /api/v1.6.1/l-mapbox-sharecontrol
 <tr>
 <td>id <em>or</em> url <em>optional</em></td>
 <td>string</td>
-<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileApi}}/v3/examples.map-0l53fhk2.json">{{site.tileApi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
+<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileapi}}/v3/examples.map-0l53fhk2.json">{{site.tileapi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -35,4 +35,4 @@ permalink: /api/v1.6.1/l-mapbox-sharecontrol
     .addControl(L.mapbox.shareControl());
 </code></pre><p><em>Returns</em>:
 Returns a <code><a href="/mapbox.js/api/v1.6.1/l-mapbox-sharecontrol">L.mapbox.shareControl</a></code> object.</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-template.html
+++ b/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-template.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.1
 permalink: /api/v1.6.1/l-mapbox-template
 ---
-{% raw %}<h2 id="section-l-mapbox-template">L.mapbox.template(template, data)</h2>
+<h2 id="section-l-mapbox-template">L.mapbox.template(template, data)</h2>
 <p>A <a href="http://mustache.github.io/">mustache</a> template rendering function, as used by the templating feature provided by <code><a href="/mapbox.js/api/v1.6.1/l-mapbox-gridcontrol">L.mapbox.gridControl</a></code>.</p>
 <table>
 <thead>
@@ -29,6 +29,6 @@ permalink: /api/v1.6.1/l-mapbox-template
 </tbody>
 </table>
 <p><em>Example</em>:</p>
-<pre><code>var output = L.mapbox.template(&#39;Name: {{name}}&#39;, {name: &#39;John&#39;});
+<pre><code>var output = L.mapbox.template(&#39;Name: {% raw %}{{name}}{% endraw %}&#39;, {name: &#39;John&#39;});
 // output is &quot;Name: John&quot;
-</code></pre>{% endraw %}
+</code></pre>

--- a/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-tilelayer.html
+++ b/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-tilelayer.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.1
 permalink: /api/v1.6.1/l-mapbox-tilelayer
 ---
-{% raw %}<h2 id="section-l-mapbox-tilelayer">L.mapbox.tileLayer(id|url|tilejson, options)</h2>
+<h2 id="section-l-mapbox-tilelayer">L.mapbox.tileLayer(id|url|tilejson, options)</h2>
 <p>You can add a tiled layer to your map with <code><a href="/mapbox.js/api/v1.6.1/l-mapbox-tilelayer">L.mapbox.tileLayer()</a></code>, a simple
 interface to layers from Mapbox and elsewhere.</p>
 <p><span class='leaflet'><em>Extends</em>: <code><a href="/mapbox.js/api/v1.6.1/l-tilelayer">L.TileLayer</a></code></span></p>
@@ -21,7 +21,7 @@ interface to layers from Mapbox and elsewhere.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -36,7 +36,7 @@ interface to layers from Mapbox and elsewhere.</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a TileJSON resource
-var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileapi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided, you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -90,4 +90,4 @@ var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
     format: &#39;jpg70&#39;
 });
 </code></pre><p><em>Returns</em>: the layer object</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-tilelayer.html
+++ b/docs/_posts/api/v1.6.1/0200-01-01-l-mapbox-tilelayer.html
@@ -21,7 +21,7 @@ interface to layers from Mapbox and elsewhere.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -36,7 +36,7 @@ interface to layers from Mapbox and elsewhere.</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a TileJSON resource
-var layer = L.mapbox.tileLayer(&#39;http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided, you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {

--- a/docs/_posts/api/v1.6.1/0200-01-01-l-simplestyle-style.html
+++ b/docs/_posts/api/v1.6.1/0200-01-01-l-simplestyle-style.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.1
 permalink: /api/v1.6.1/l-simplestyle-style
 ---
-{% raw %}<h2 id="section-l-simplestyle-style">L.simplestyle.style(feature)</h2>
+<h2 id="section-l-simplestyle-style">L.simplestyle.style(feature)</h2>
 <p>Given a GeoJSON Feature with optional simplestyle-spec properties, return an
 options object formatted to be used as <a href="http://leafletjs.com/reference.html#path">Leaflet Path options</a>.</p>
 <table>
@@ -30,4 +30,4 @@ options object formatted to be used as <a href="http://leafletjs.com/reference.h
 });
 </code></pre><p><em>Returns</em>:</p>
 <p>An object formatted to be used as <a href="http://leafletjs.com/reference.html#path">Leaflet Path options</a>.</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.1/0200-01-01-mobile.html
+++ b/docs/_posts/api/v1.6.1/0200-01-01-mobile.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.1
 permalink: /api/v1.6.1/mobile
 ---
-{% raw %}<h2 id="section-mobile">Mobile</h2>
+<h2 id="section-mobile">Mobile</h2>
 <p>Mapbox.js is optimized for mobile devices and small screens by default.
 There are, however, best practices to make sure your map always looks its best.</p>
 <h3 id="section-viewport">Viewport</h3>
@@ -36,4 +36,4 @@ tiles will be used when retina is detected.</p>
         detectRetina: true
     }
 }).setView([40, -74.50], 9);
-</code></pre>{% endraw %}
+</code></pre>

--- a/docs/_posts/api/v1.6.1/0200-01-01-theming.html
+++ b/docs/_posts/api/v1.6.1/0200-01-01-theming.html
@@ -5,10 +5,10 @@ categories: api
 version: v1.6.1
 permalink: /api/v1.6.1/theming
 ---
-{% raw %}<h2 id="section-theming">Theming</h2>
+<h2 id="section-theming">Theming</h2>
 <h3 id="section-dark-theme">Dark theme</h3>
 <p>Mapbox.js implements a simple, light style on all interaction elements. A dark theme
 is available by applying <code>class=&quot;dark&quot;</code> to the map div.</p>
 <p><em>Example</em>:</p>
 <pre><code>&lt;div id=&quot;map&quot; class=&quot;dark&quot;&gt;&lt;/div&gt;
-</code></pre>{% endraw %}
+</code></pre>

--- a/docs/_posts/api/v1.6.2/0200-01-01-.html
+++ b/docs/_posts/api/v1.6.2/0200-01-01-.html
@@ -5,4 +5,4 @@ categories: api
 version: v1.6.2
 permalink: /api/v1.6.2/
 ---
-{% raw %}{% endraw %}
+

--- a/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-config-force_https.html
+++ b/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-config-force_https.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.2
 permalink: /api/v1.6.2/l-mapbox-config-force_https
 ---
-{% raw %}<h2 id="section-l-mapbox-config-force_https">L.mapbox.config.FORCE_HTTPS</h2>
+<h2 id="section-l-mapbox-config-force_https">L.mapbox.config.FORCE_HTTPS</h2>
 <p>By default, this is <code>false</code>. Mapbox.js auto-detects whether the page your map
 is embedded in is using HTTPS or SSL, and matches: if you use HTTPS on your site,
 it uses HTTPS resources.</p>
@@ -13,4 +13,4 @@ it uses HTTPS resources.</p>
 regardless of the host page&#39;s scheme.</p>
 <p><em>Example</em>:</p>
 <pre><code>L.mapbox.config.FORCE_HTTPS = true;
-</code></pre>{% endraw %}
+</code></pre>

--- a/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-config-http_urls.html
+++ b/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-config-http_urls.html
@@ -5,8 +5,8 @@ categories: api
 version: v1.6.2
 permalink: /api/v1.6.2/l-mapbox-config-http_urls
 ---
-{% raw %}<h2 id="section-l-mapbox-config-http_urls">L.mapbox.config.HTTP_URLS</h2>
+<h2 id="section-l-mapbox-config-http_urls">L.mapbox.config.HTTP_URLS</h2>
 <p>An array of base URLs. By default, these point to the <a href="https://www.mapbox.com/developers/api/">Mapbox Web Services</a>.
 When you refer to a tileset, grid, marker, or geocoding endpoint, a URL
 from this array is chosen.</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-config-https_urls.html
+++ b/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-config-https_urls.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.2
 permalink: /api/v1.6.2/l-mapbox-config-https_urls
 ---
-{% raw %}<h2 id="section-l-mapbox-config-https_urls">L.mapbox.config.HTTPS_URLS</h2>
+<h2 id="section-l-mapbox-config-https_urls">L.mapbox.config.HTTPS_URLS</h2>
 <p>The same as <code><a href="/mapbox.js/api/v1.6.2/l-mapbox-config-http_urls">L.mapbox.config.HTTP_URLS</a></code>, but used when SSL mode is detected or
 <code>FORCE_HTTPS</code> is set to <code>true</code>.</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-featurelayer.html
+++ b/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-featurelayer.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.2
 permalink: /api/v1.6.2/l-mapbox-featurelayer
 ---
-{% raw %}<h2 id="section-l-mapbox-featurelayer">L.mapbox.featureLayer(id|url|geojson, options)</h2>
+<h2 id="section-l-mapbox-featurelayer">L.mapbox.featureLayer(id|url|geojson, options)</h2>
 <p><span class='leaflet'><em>Extends</em>: <code><a href="/mapbox.js/api/v1.6.2/l-featuregroup">L.FeatureGroup</a></code></span></p>
 <p><strong>NOTE: in version 1.6.0, <code><a href="/mapbox.js/api/v1.6.2/l-mapbox-markerlayer">L.mapbox.markerLayer</a></code> was renamed to <code><a href="/mapbox.js/api/v1.6.2/l-mapbox-featurelayer">L.mapbox.featureLayer</a></code>
 to signal the addition of support for lines and polygons. The <code><a href="/mapbox.js/api/v1.6.2/l-mapbox-markerlayer">L.mapbox.markerLayer</a></code>
@@ -24,7 +24,7 @@ from Mapbox and elsewhere into your map.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> geojson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
+<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -163,4 +163,4 @@ featureLayer.setGeoJSON({
 <h3 id="section-featurelayer-getgeojson">featureLayer.getGeoJSON()</h3>
 <p>Get the contents of this layer as GeoJSON data.</p>
 <p><em>Returns</em> the GeoJSON represented by this layer</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-featurelayer.html
+++ b/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-featurelayer.html
@@ -24,7 +24,7 @@ from Mapbox and elsewhere into your map.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> geojson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
+<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>

--- a/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-geocoder.html
+++ b/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-geocoder.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.2
 permalink: /api/v1.6.2/l-mapbox-geocoder
 ---
-{% raw %}<h2 id="section-l-mapbox-geocoder">L.mapbox.geocoder(id|url)</h2>
+<h2 id="section-l-mapbox-geocoder">L.mapbox.geocoder(id|url)</h2>
 <p>A low-level interface to geocoding, useful for more complex uses and reverse-geocoding.</p>
 <table>
 <thead>
@@ -19,7 +19,7 @@ permalink: /api/v1.6.2/l-mapbox-geocoder
 <tr>
 <td>id <em>or</em> url</td>
 <td>string</td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -84,4 +84,4 @@ permalink: /api/v1.6.2/l-mapbox-geocoder
 </tbody>
 </table>
 <p><em>Returns</em>: the geocoder object. The return value of this function is not useful - you must use a callback to get results.</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-geocoder.html
+++ b/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-geocoder.html
@@ -19,7 +19,7 @@ permalink: /api/v1.6.2/l-mapbox-geocoder
 <tr>
 <td>id <em>or</em> url</td>
 <td>string</td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 </tbody>
 </table>

--- a/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-geocodercontrol.html
+++ b/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-geocodercontrol.html
@@ -24,7 +24,7 @@ This function is currently in private beta: <a href="https://mapbox.com/contact/
 <tr>
 <td>id <em>or</em> url (<em>required</em>)</td>
 <td>string</td>
-<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 <tr>
 <td>options</td>

--- a/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-geocodercontrol.html
+++ b/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-geocodercontrol.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.2
 permalink: /api/v1.6.2/l-mapbox-geocodercontrol
 ---
-{% raw %}<h2 id="section-l-mapbox-geocodercontrol">L.mapbox.geocoderControl(id|url, options)</h2>
+<h2 id="section-l-mapbox-geocodercontrol">L.mapbox.geocoderControl(id|url, options)</h2>
 <p>Adds geocoder functionality as well as a UI element to a map. This uses
 the <a href="http://mapbox.com/developers/api/#geocoding">Mapbox Geocoding API</a>.</p>
 <div class='note warning'>
@@ -24,7 +24,7 @@ This function is currently in private beta: <a href="https://mapbox.com/contact/
 <tr>
 <td>id <em>or</em> url (<em>required</em>)</td>
 <td>string</td>
-<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -123,4 +123,4 @@ This function is currently in private beta: <a href="https://mapbox.com/contact/
 </tr>
 </tbody>
 </table>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-gridcontrol.html
+++ b/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-gridcontrol.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.2
 permalink: /api/v1.6.2/l-mapbox-gridcontrol
 ---
-{% raw %}<h2 id="section-l-mapbox-gridcontrol">L.mapbox.gridControl(layer, options)</h2>
+<h2 id="section-l-mapbox-gridcontrol">L.mapbox.gridControl(layer, options)</h2>
 <p><span class='leaflet'><em>Extends</em>: <code><a href="/mapbox.js/api/v1.6.2/l-control">L.Control</a></code></span></p>
 <p>Interaction is what we call interactive parts of maps that are created with the powerful <a href="http://mapbox.com/tilemill/docs/crashcourse/tooltips/">tooltips &amp; regions</a> system in <a href="http://mapbox.com/tilemill/">TileMill</a>. Under the hood, it&#39;s powered by the open <a href="https://github.com/mapbox/utfgrid-spec/">UTFGrid specification</a>.</p>
 <table>
@@ -59,4 +59,4 @@ the UTFGrid data in the map&#39;s interactivity into HTML for display.</p>
 </tbody>
 </table>
 <p><em>Returns</em>: the <code><a href="/mapbox.js/api/v1.6.2/l-mapbox-gridcontrol">L.mapbox.gridControl</a></code> object.</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-gridlayer.html
+++ b/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-gridlayer.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.2
 permalink: /api/v1.6.2/l-mapbox-gridlayer
 ---
-{% raw %}<h2 id="section-l-mapbox-gridlayer">L.mapbox.gridLayer(id|url|tilejson, options)</h2>
+<h2 id="section-l-mapbox-gridlayer">L.mapbox.gridLayer(id|url|tilejson, options)</h2>
 <p>An <code><a href="/mapbox.js/api/v1.6.2/l-mapbox-gridlayer">L.mapbox.gridLayer</a></code> loads <a href="http://mapbox.com/developers/utfgrid/">UTFGrid</a> tiles of
 interactivity into your map, which you can easily access with <code><a href="/mapbox.js/api/v1.6.2/l-mapbox-gridcontrol">L.mapbox.gridControl</a></code>.</p>
 <table>
@@ -20,7 +20,7 @@ interactivity into your map, which you can easily access with <code><a href="/ma
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -111,4 +111,4 @@ function with that data, if any.</p>
 </tbody>
 </table>
 <p><em>Returns</em>: the L.mapbox.gridLayer object</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-gridlayer.html
+++ b/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-gridlayer.html
@@ -20,7 +20,7 @@ interactivity into your map, which you can easily access with <code><a href="/ma
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 </tbody>
 </table>

--- a/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-infocontrol.html
+++ b/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-infocontrol.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.2
 permalink: /api/v1.6.2/l-mapbox-infocontrol
 ---
-{% raw %}<h2 id="section-l-mapbox-infocontrol">L.mapbox.infoControl(options)</h2>
+<h2 id="section-l-mapbox-infocontrol">L.mapbox.infoControl(options)</h2>
 <p><span class='leaflet'><em>Extends</em>: <code><a href="/mapbox.js/api/v1.6.2/l-control">L.Control</a></code></span></p>
 <p>A map control that shows a toggleable info container. This is triggered by default and attribution is auto-detected from active layers and added to the info container.</p>
 <table>
@@ -64,4 +64,4 @@ map.addControl(L.mapbox.infoControl());
 </tr>
 </tbody>
 </table>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-legendcontrol.html
+++ b/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-legendcontrol.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.2
 permalink: /api/v1.6.2/l-mapbox-legendcontrol
 ---
-{% raw %}<h2 id="section-l-mapbox-legendcontrol">L.mapbox.legendControl(options)</h2>
+<h2 id="section-l-mapbox-legendcontrol">L.mapbox.legendControl(options)</h2>
 <p><span class='leaflet'><em>Extends</em>: L.Control</span></p>
 <p>A map control that shows legends added to maps in Mapbox. Legends are auto-detected from active layers.</p>
 <table>
@@ -64,4 +64,4 @@ map.addControl(L.mapbox.legendControl());
 </tr>
 </tbody>
 </table>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-map.html
+++ b/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-map.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.2
 permalink: /api/v1.6.2/l-mapbox-map
 ---
-{% raw %}<h2 id="section-l-mapbox-map">L.mapbox.map(element, id|url|tilejson, options)</h2>
+<h2 id="section-l-mapbox-map">L.mapbox.map(element, id|url|tilejson, options)</h2>
 <p>Create and automatically configure a map with layers, markers, and
 interactivity.</p>
 <p><span class='leaflet'><em>Extends</em>: <code><a href="/mapbox.js/api/v1.6.2/l-map-class">L.Map</a></code></span></p>
@@ -26,7 +26,7 @@ interactivity.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="https://www.mapbox.com/developers/tilejson/">TileJSON</a> object, from your own Javascript code</li></ul></td>
+<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="https://www.mapbox.com/developers/tilejson/">TileJSON</a> object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -48,4 +48,4 @@ var map = L.mapbox.map(&#39;map&#39;);
 <p>Returns this map&#39;s TileJSON object which determines its tile source,
 zoom bounds and other metadata.</p>
 <p><em>Returns</em>: the TileJSON object</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-map.html
+++ b/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-map.html
@@ -26,7 +26,7 @@ interactivity.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="https://www.mapbox.com/developers/tilejson/">TileJSON</a> object, from your own Javascript code</li></ul></td>
+<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="https://www.mapbox.com/developers/tilejson/">TileJSON</a> object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>

--- a/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-marker-icon.html
+++ b/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-marker-icon.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.2
 permalink: /api/v1.6.2/l-mapbox-marker-icon
 ---
-{% raw %}<h2 id="section-l-mapbox-marker-icon">L.mapbox.marker.icon(feature)</h2>
+<h2 id="section-l-mapbox-marker-icon">L.mapbox.marker.icon(feature)</h2>
 <p>A core icon generator used in <code><a href="/mapbox.js/api/v1.6.2/l-mapbox-marker-style">L.mapbox.marker.style</a></code></p>
 <table>
 <thead>
@@ -26,4 +26,4 @@ permalink: /api/v1.6.2/l-mapbox-marker-icon
 <p><em>Returns</em>:</p>
 <p>A <code><a href="/mapbox.js/api/v1.6.2/l-icon">L.Icon</a></code> object with custom settings for <code>iconUrl</code>, <code>iconSize</code>, <code>iconAnchor</code>,
 and <code>popupAnchor</code>.</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-marker-style.html
+++ b/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-marker-style.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.2
 permalink: /api/v1.6.2/l-mapbox-marker-style
 ---
-{% raw %}<h2 id="section-l-mapbox-marker-style">L.mapbox.marker.style(feature, latlng)</h2>
+<h2 id="section-l-mapbox-marker-style">L.mapbox.marker.style(feature, latlng)</h2>
 <p>An icon generator for use in conjunction with <code>pointToLayer</code> to generate
 markers from the <a href="http://mapbox.com/developers/api/#markers">Mapbox Markers API</a>
 and support the <a href="https://github.com/mapbox/simplestyle-spec">simplestyle-spec</a> for
@@ -39,4 +39,4 @@ features.</p>
 <p>A <code><a href="/mapbox.js/api/v1.6.2/l-marker">L.Marker</a></code> object with the latitude, longitude position and a styled marker</p>
 <p>The other sections of the <a href="https://github.com/mapbox/simplestyle-spec">simplestyle-spec</a> are implemented
 by <code><a href="/mapbox.js/api/v1.6.2/l-mapbox-simplestyle-style">L.mapbox.simplestyle.style</a></code></p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-sanitize.html
+++ b/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-sanitize.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.2
 permalink: /api/v1.6.2/l-mapbox-sanitize
 ---
-{% raw %}<h2 id="section-l-mapbox-sanitize">L.mapbox.sanitize(string)</h2>
+<h2 id="section-l-mapbox-sanitize">L.mapbox.sanitize(string)</h2>
 <p>A HTML sanitization function, with the same effect as the default value of the <code>sanitizer</code> option of <code><a href="/mapbox.js/api/v1.6.2/l-mapbox-featurelayer">L.mapbox.featureLayer</a></code>, <code><a href="/mapbox.js/api/v1.6.2/l-mapbox-gridcontrol">L.mapbox.gridControl</a></code>, and <code><a href="/mapbox.js/api/v1.6.2/l-mapbox-legendcontrol">L.mapbox.legendControl</a></code>.</p>
 <table>
 <thead>
@@ -23,4 +23,4 @@ permalink: /api/v1.6.2/l-mapbox-sanitize
 </tr>
 </tbody>
 </table>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-sharecontrol.html
+++ b/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-sharecontrol.html
@@ -20,7 +20,7 @@ permalink: /api/v1.6.2/l-mapbox-sharecontrol
 <tr>
 <td>id <em>or</em> url <em>optional</em></td>
 <td>string</td>
-<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="https://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json">https://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
+<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileApi}}/v3/examples.map-0l53fhk2.json">{{site.tileApi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>

--- a/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-sharecontrol.html
+++ b/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-sharecontrol.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.2
 permalink: /api/v1.6.2/l-mapbox-sharecontrol
 ---
-{% raw %}<h2 id="section-l-mapbox-sharecontrol">L.mapbox.shareControl(id|url, options)</h2>
+<h2 id="section-l-mapbox-sharecontrol">L.mapbox.shareControl(id|url, options)</h2>
 <p>Adds a &quot;Share&quot; button to the map, which can be used to share the map to Twitter or Facebook, or generate HTML for a map embed.</p>
 <p><span class='leaflet'><em>Extends</em>: <code><a href="/mapbox.js/api/v1.6.2/l-control">L.Control</a></code></span></p>
 <table>
@@ -20,7 +20,7 @@ permalink: /api/v1.6.2/l-mapbox-sharecontrol
 <tr>
 <td>id <em>or</em> url <em>optional</em></td>
 <td>string</td>
-<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileApi}}/v3/examples.map-0l53fhk2.json">{{site.tileApi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
+<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileapi}}/v3/examples.map-0l53fhk2.json">{{site.tileapi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -35,4 +35,4 @@ permalink: /api/v1.6.2/l-mapbox-sharecontrol
     .addControl(L.mapbox.shareControl());
 </code></pre><p><em>Returns</em>:
 Returns a <code><a href="/mapbox.js/api/v1.6.2/l-mapbox-sharecontrol">L.mapbox.shareControl</a></code> object.</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-simplestyle-style.html
+++ b/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-simplestyle-style.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.2
 permalink: /api/v1.6.2/l-mapbox-simplestyle-style
 ---
-{% raw %}<h2 id="section-l-mapbox-simplestyle-style">L.mapbox.simplestyle.style(feature)</h2>
+<h2 id="section-l-mapbox-simplestyle-style">L.mapbox.simplestyle.style(feature)</h2>
 <p>Given a GeoJSON Feature with optional simplestyle-spec properties, return an
 options object formatted to be used as <a href="http://leafletjs.com/reference.html#path">Leaflet Path options</a>.</p>
 <table>
@@ -30,4 +30,4 @@ options object formatted to be used as <a href="http://leafletjs.com/reference.h
 });
 </code></pre><p><em>Returns</em>:</p>
 <p>An object formatted to be used as <a href="http://leafletjs.com/reference.html#path">Leaflet Path options</a>.</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-template.html
+++ b/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-template.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.2
 permalink: /api/v1.6.2/l-mapbox-template
 ---
-{% raw %}<h2 id="section-l-mapbox-template">L.mapbox.template(template, data)</h2>
+<h2 id="section-l-mapbox-template">L.mapbox.template(template, data)</h2>
 <p>A <a href="http://mustache.github.io/">mustache</a> template rendering function, as used by the templating feature provided by <code><a href="/mapbox.js/api/v1.6.2/l-mapbox-gridcontrol">L.mapbox.gridControl</a></code>.</p>
 <table>
 <thead>
@@ -29,6 +29,6 @@ permalink: /api/v1.6.2/l-mapbox-template
 </tbody>
 </table>
 <p><em>Example</em>:</p>
-<pre><code>var output = L.mapbox.template(&#39;Name: {{name}}&#39;, {name: &#39;John&#39;});
+<pre><code>var output = L.mapbox.template(&#39;Name: {% raw %}{{name}}{% endraw %}&#39;, {name: &#39;John&#39;});
 // output is &quot;Name: John&quot;
-</code></pre>{% endraw %}
+</code></pre>

--- a/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-tilelayer.html
+++ b/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-tilelayer.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.2
 permalink: /api/v1.6.2/l-mapbox-tilelayer
 ---
-{% raw %}<h2 id="section-l-mapbox-tilelayer">L.mapbox.tileLayer(id|url|tilejson, options)</h2>
+<h2 id="section-l-mapbox-tilelayer">L.mapbox.tileLayer(id|url|tilejson, options)</h2>
 <p>You can add a tiled layer to your map with <code><a href="/mapbox.js/api/v1.6.2/l-mapbox-tilelayer">L.mapbox.tileLayer()</a></code>, a simple
 interface to layers from Mapbox and elsewhere.</p>
 <p><span class='leaflet'><em>Extends</em>: <code><a href="/mapbox.js/api/v1.6.2/l-tilelayer">L.TileLayer</a></code></span></p>
@@ -21,7 +21,7 @@ interface to layers from Mapbox and elsewhere.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -36,7 +36,7 @@ interface to layers from Mapbox and elsewhere.</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a TileJSON resource
-var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileapi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided, you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -90,4 +90,4 @@ var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
     format: &#39;jpg70&#39;
 });
 </code></pre><p><em>Returns</em>: the layer object</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-tilelayer.html
+++ b/docs/_posts/api/v1.6.2/0200-01-01-l-mapbox-tilelayer.html
@@ -21,7 +21,7 @@ interface to layers from Mapbox and elsewhere.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -36,7 +36,7 @@ interface to layers from Mapbox and elsewhere.</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a TileJSON resource
-var layer = L.mapbox.tileLayer(&#39;http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided, you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {

--- a/docs/_posts/api/v1.6.2/0200-01-01-mobile.html
+++ b/docs/_posts/api/v1.6.2/0200-01-01-mobile.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.2
 permalink: /api/v1.6.2/mobile
 ---
-{% raw %}<h2 id="section-mobile">Mobile</h2>
+<h2 id="section-mobile">Mobile</h2>
 <p>Mapbox.js is optimized for mobile devices and small screens by default.
 There are, however, best practices to make sure your map always looks its best.</p>
 <h3 id="section-viewport">Viewport</h3>
@@ -36,4 +36,4 @@ tiles will be used when retina is detected.</p>
         detectRetina: true
     }
 }).setView([40, -74.50], 9);
-</code></pre>{% endraw %}
+</code></pre>

--- a/docs/_posts/api/v1.6.2/0200-01-01-theming.html
+++ b/docs/_posts/api/v1.6.2/0200-01-01-theming.html
@@ -5,10 +5,10 @@ categories: api
 version: v1.6.2
 permalink: /api/v1.6.2/theming
 ---
-{% raw %}<h2 id="section-theming">Theming</h2>
+<h2 id="section-theming">Theming</h2>
 <h3 id="section-dark-theme">Dark theme</h3>
 <p>Mapbox.js implements a simple, light style on all interaction elements. A dark theme
 is available by applying <code>class=&quot;dark&quot;</code> to the map div.</p>
 <p><em>Example</em>:</p>
 <pre><code>&lt;div id=&quot;map&quot; class=&quot;dark&quot;&gt;&lt;/div&gt;
-</code></pre>{% endraw %}
+</code></pre>

--- a/docs/_posts/api/v1.6.3/0200-01-01-.html
+++ b/docs/_posts/api/v1.6.3/0200-01-01-.html
@@ -5,4 +5,4 @@ categories: api
 version: v1.6.3
 permalink: /api/v1.6.3/
 ---
-{% raw %}{% endraw %}
+

--- a/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-config-force_https.html
+++ b/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-config-force_https.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.3
 permalink: /api/v1.6.3/l-mapbox-config-force_https
 ---
-{% raw %}<h2 id="section-l-mapbox-config-force_https">L.mapbox.config.FORCE_HTTPS</h2>
+<h2 id="section-l-mapbox-config-force_https">L.mapbox.config.FORCE_HTTPS</h2>
 <p>By default, this is <code>false</code>. Mapbox.js auto-detects whether the page your map
 is embedded in is using HTTPS or SSL, and matches: if you use HTTPS on your site,
 it uses HTTPS resources.</p>
@@ -13,4 +13,4 @@ it uses HTTPS resources.</p>
 regardless of the host page&#39;s scheme.</p>
 <p><em>Example</em>:</p>
 <pre><code>L.mapbox.config.FORCE_HTTPS = true;
-</code></pre>{% endraw %}
+</code></pre>

--- a/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-config-http_urls.html
+++ b/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-config-http_urls.html
@@ -5,8 +5,8 @@ categories: api
 version: v1.6.3
 permalink: /api/v1.6.3/l-mapbox-config-http_urls
 ---
-{% raw %}<h2 id="section-l-mapbox-config-http_urls">L.mapbox.config.HTTP_URLS</h2>
+<h2 id="section-l-mapbox-config-http_urls">L.mapbox.config.HTTP_URLS</h2>
 <p>An array of base URLs. By default, these point to the <a href="https://www.mapbox.com/developers/api/">Mapbox Web Services</a>.
 When you refer to a tileset, grid, marker, or geocoding endpoint, a URL
 from this array is chosen.</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-config-https_urls.html
+++ b/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-config-https_urls.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.3
 permalink: /api/v1.6.3/l-mapbox-config-https_urls
 ---
-{% raw %}<h2 id="section-l-mapbox-config-https_urls">L.mapbox.config.HTTPS_URLS</h2>
+<h2 id="section-l-mapbox-config-https_urls">L.mapbox.config.HTTPS_URLS</h2>
 <p>The same as <code><a href="/mapbox.js/api/v1.6.3/l-mapbox-config-http_urls">L.mapbox.config.HTTP_URLS</a></code>, but used when SSL mode is detected or
 <code>FORCE_HTTPS</code> is set to <code>true</code>.</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-featurelayer.html
+++ b/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-featurelayer.html
@@ -24,7 +24,7 @@ from Mapbox and elsewhere into your map.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> geojson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
+<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>

--- a/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-featurelayer.html
+++ b/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-featurelayer.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.3
 permalink: /api/v1.6.3/l-mapbox-featurelayer
 ---
-{% raw %}<h2 id="section-l-mapbox-featurelayer">L.mapbox.featureLayer(id|url|geojson, options)</h2>
+<h2 id="section-l-mapbox-featurelayer">L.mapbox.featureLayer(id|url|geojson, options)</h2>
 <p><span class='leaflet'><em>Extends</em>: <code><a href="/mapbox.js/api/v1.6.3/l-featuregroup">L.FeatureGroup</a></code></span></p>
 <p><strong>NOTE: in version 1.6.0, <code><a href="/mapbox.js/api/v1.6.3/l-mapbox-markerlayer">L.mapbox.markerLayer</a></code> was renamed to <code><a href="/mapbox.js/api/v1.6.3/l-mapbox-featurelayer">L.mapbox.featureLayer</a></code>
 to signal the addition of support for lines and polygons. The <code><a href="/mapbox.js/api/v1.6.3/l-mapbox-markerlayer">L.mapbox.markerLayer</a></code>
@@ -24,7 +24,7 @@ from Mapbox and elsewhere into your map.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> geojson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
+<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -165,4 +165,4 @@ featureLayer.setGeoJSON({
 <h3 id="section-featurelayer-getgeojson">featureLayer.getGeoJSON()</h3>
 <p>Get the contents of this layer as GeoJSON data.</p>
 <p><em>Returns</em> the GeoJSON represented by this layer</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-geocoder.html
+++ b/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-geocoder.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.3
 permalink: /api/v1.6.3/l-mapbox-geocoder
 ---
-{% raw %}<h2 id="section-l-mapbox-geocoder">L.mapbox.geocoder(id|url)</h2>
+<h2 id="section-l-mapbox-geocoder">L.mapbox.geocoder(id|url)</h2>
 <p>A low-level interface to geocoding, useful for more complex uses and reverse-geocoding.</p>
 <table>
 <thead>
@@ -19,7 +19,7 @@ permalink: /api/v1.6.3/l-mapbox-geocoder
 <tr>
 <td>id <em>or</em> url</td>
 <td>string</td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -85,4 +85,4 @@ permalink: /api/v1.6.3/l-mapbox-geocoder
 </tbody>
 </table>
 <p><em>Returns</em>: the geocoder object. The return value of this function is not useful - you must use a callback to get results.</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-geocoder.html
+++ b/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-geocoder.html
@@ -19,7 +19,7 @@ permalink: /api/v1.6.3/l-mapbox-geocoder
 <tr>
 <td>id <em>or</em> url</td>
 <td>string</td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 </tbody>
 </table>

--- a/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-geocodercontrol.html
+++ b/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-geocodercontrol.html
@@ -24,7 +24,7 @@ This function is currently in private beta: <a href="https://mapbox.com/contact/
 <tr>
 <td>id <em>or</em> url (<em>required</em>)</td>
 <td>string</td>
-<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 <tr>
 <td>options</td>

--- a/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-geocodercontrol.html
+++ b/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-geocodercontrol.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.3
 permalink: /api/v1.6.3/l-mapbox-geocodercontrol
 ---
-{% raw %}<h2 id="section-l-mapbox-geocodercontrol">L.mapbox.geocoderControl(id|url, options)</h2>
+<h2 id="section-l-mapbox-geocodercontrol">L.mapbox.geocoderControl(id|url, options)</h2>
 <p>Adds geocoder functionality as well as a UI element to a map. This uses
 the <a href="http://mapbox.com/developers/api/#geocoding">Mapbox Geocoding API</a>.</p>
 <div class='note warning'>
@@ -24,7 +24,7 @@ This function is currently in private beta: <a href="https://mapbox.com/contact/
 <tr>
 <td>id <em>or</em> url (<em>required</em>)</td>
 <td>string</td>
-<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -124,4 +124,4 @@ This function is currently in private beta: <a href="https://mapbox.com/contact/
 </tr>
 </tbody>
 </table>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-gridcontrol.html
+++ b/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-gridcontrol.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.3
 permalink: /api/v1.6.3/l-mapbox-gridcontrol
 ---
-{% raw %}<h2 id="section-l-mapbox-gridcontrol">L.mapbox.gridControl(layer, options)</h2>
+<h2 id="section-l-mapbox-gridcontrol">L.mapbox.gridControl(layer, options)</h2>
 <p><span class='leaflet'><em>Extends</em>: <code><a href="/mapbox.js/api/v1.6.3/l-control">L.Control</a></code></span></p>
 <p>Interaction is what we call interactive parts of maps that are created with the powerful <a href="http://mapbox.com/tilemill/docs/crashcourse/tooltips/">tooltips &amp; regions</a> system in <a href="http://mapbox.com/tilemill/">TileMill</a>. Under the hood, it&#39;s powered by the open <a href="https://github.com/mapbox/utfgrid-spec/">UTFGrid specification</a>.</p>
 <table>
@@ -60,4 +60,4 @@ the UTFGrid data in the map&#39;s interactivity into HTML for display.</p>
 </tbody>
 </table>
 <p><em>Returns</em>: the <code><a href="/mapbox.js/api/v1.6.3/l-mapbox-gridcontrol">L.mapbox.gridControl</a></code> object.</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-gridlayer.html
+++ b/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-gridlayer.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.3
 permalink: /api/v1.6.3/l-mapbox-gridlayer
 ---
-{% raw %}<h2 id="section-l-mapbox-gridlayer">L.mapbox.gridLayer(id|url|tilejson, options)</h2>
+<h2 id="section-l-mapbox-gridlayer">L.mapbox.gridLayer(id|url|tilejson, options)</h2>
 <p>An <code><a href="/mapbox.js/api/v1.6.3/l-mapbox-gridlayer">L.mapbox.gridLayer</a></code> loads <a href="http://mapbox.com/developers/utfgrid/">UTFGrid</a> tiles of
 interactivity into your map, which you can easily access with <code><a href="/mapbox.js/api/v1.6.3/l-mapbox-gridcontrol">L.mapbox.gridControl</a></code>.</p>
 <table>
@@ -20,7 +20,7 @@ interactivity into your map, which you can easily access with <code><a href="/ma
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -112,4 +112,4 @@ function with that data, if any.</p>
 </tbody>
 </table>
 <p><em>Returns</em>: the L.mapbox.gridLayer object</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-gridlayer.html
+++ b/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-gridlayer.html
@@ -20,7 +20,7 @@ interactivity into your map, which you can easily access with <code><a href="/ma
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 </tbody>
 </table>

--- a/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-infocontrol.html
+++ b/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-infocontrol.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.3
 permalink: /api/v1.6.3/l-mapbox-infocontrol
 ---
-{% raw %}<h2 id="section-l-mapbox-infocontrol">L.mapbox.infoControl(options)</h2>
+<h2 id="section-l-mapbox-infocontrol">L.mapbox.infoControl(options)</h2>
 <p><span class='leaflet'><em>Extends</em>: <code><a href="/mapbox.js/api/v1.6.3/l-control">L.Control</a></code></span></p>
 <p>A map control that shows a toggleable info container. If set, attribution is auto-detected from active layers and added to the info container.</p>
 <table>
@@ -65,4 +65,4 @@ map.addControl(L.mapbox.infoControl().addInfo(&#39;foo&#39;));
 </tr>
 </tbody>
 </table>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-legendcontrol.html
+++ b/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-legendcontrol.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.3
 permalink: /api/v1.6.3/l-mapbox-legendcontrol
 ---
-{% raw %}<h2 id="section-l-mapbox-legendcontrol">L.mapbox.legendControl(options)</h2>
+<h2 id="section-l-mapbox-legendcontrol">L.mapbox.legendControl(options)</h2>
 <p><span class='leaflet'><em>Extends</em>: L.Control</span></p>
 <p>A map control that shows legends added to maps in Mapbox. Legends are auto-detected from active layers.</p>
 <table>
@@ -65,4 +65,4 @@ map.addControl(L.mapbox.legendControl());
 </tr>
 </tbody>
 </table>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-map.html
+++ b/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-map.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.3
 permalink: /api/v1.6.3/l-mapbox-map
 ---
-{% raw %}<h2 id="section-l-mapbox-map">L.mapbox.map(element, id|url|tilejson, options)</h2>
+<h2 id="section-l-mapbox-map">L.mapbox.map(element, id|url|tilejson, options)</h2>
 <p>Create and automatically configure a map with layers, markers, and
 interactivity.</p>
 <p><span class='leaflet'><em>Extends</em>: <code><a href="/mapbox.js/api/v1.6.3/l-map-class">L.Map</a></code></span></p>
@@ -26,7 +26,7 @@ interactivity.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="https://www.mapbox.com/developers/tilejson/">TileJSON</a> object, from your own Javascript code</li></ul></td>
+<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="https://www.mapbox.com/developers/tilejson/">TileJSON</a> object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -49,4 +49,4 @@ var map = L.mapbox.map(&#39;map&#39;);
 <p>Returns this map&#39;s TileJSON object which determines its tile source,
 zoom bounds and other metadata.</p>
 <p><em>Returns</em>: the TileJSON object</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-map.html
+++ b/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-map.html
@@ -26,7 +26,7 @@ interactivity.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="https://www.mapbox.com/developers/tilejson/">TileJSON</a> object, from your own Javascript code</li></ul></td>
+<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="https://www.mapbox.com/developers/tilejson/">TileJSON</a> object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>

--- a/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-marker-icon.html
+++ b/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-marker-icon.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.3
 permalink: /api/v1.6.3/l-mapbox-marker-icon
 ---
-{% raw %}<h2 id="section-l-mapbox-marker-icon">L.mapbox.marker.icon(properties)</h2>
+<h2 id="section-l-mapbox-marker-icon">L.mapbox.marker.icon(properties)</h2>
 <p>A core icon generator used in <code><a href="/mapbox.js/api/v1.6.3/l-mapbox-marker-style">L.mapbox.marker.style</a></code></p>
 <table>
 <thead>
@@ -27,4 +27,4 @@ permalink: /api/v1.6.3/l-mapbox-marker-icon
 <p>A <code><a href="/mapbox.js/api/v1.6.3/l-icon">L.Icon</a></code> object with custom settings for <code>iconUrl</code>, <code>iconSize</code>, <code>iconAnchor</code>,
 and <code>popupAnchor</code>.</p>
 <p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/l-mapbox-marker/">A working example of L.mapbox.marker.icon in use</a></p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-marker-style.html
+++ b/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-marker-style.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.3
 permalink: /api/v1.6.3/l-mapbox-marker-style
 ---
-{% raw %}<h2 id="section-l-mapbox-marker-style">L.mapbox.marker.style(feature, latlng)</h2>
+<h2 id="section-l-mapbox-marker-style">L.mapbox.marker.style(feature, latlng)</h2>
 <p>An icon generator for use in conjunction with <code>pointToLayer</code> to generate
 markers from the <a href="http://mapbox.com/developers/api/#markers">Mapbox Markers API</a>
 and support the <a href="https://github.com/mapbox/simplestyle-spec">simplestyle-spec</a> for
@@ -39,4 +39,4 @@ features.</p>
 <p>A <code><a href="/mapbox.js/api/v1.6.3/l-marker">L.Marker</a></code> object with the latitude, longitude position and a styled marker</p>
 <p>The other sections of the <a href="https://github.com/mapbox/simplestyle-spec">simplestyle-spec</a> are implemented
 by <code><a href="/mapbox.js/api/v1.6.3/l-mapbox-simplestyle-style">L.mapbox.simplestyle.style</a></code></p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-sanitize.html
+++ b/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-sanitize.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.3
 permalink: /api/v1.6.3/l-mapbox-sanitize
 ---
-{% raw %}<h2 id="section-l-mapbox-sanitize">L.mapbox.sanitize(string)</h2>
+<h2 id="section-l-mapbox-sanitize">L.mapbox.sanitize(string)</h2>
 <p>A HTML sanitization function, with the same effect as the default value of the <code>sanitizer</code> option of <code><a href="/mapbox.js/api/v1.6.3/l-mapbox-featurelayer">L.mapbox.featureLayer</a></code>, <code><a href="/mapbox.js/api/v1.6.3/l-mapbox-gridcontrol">L.mapbox.gridControl</a></code>, and <code><a href="/mapbox.js/api/v1.6.3/l-mapbox-legendcontrol">L.mapbox.legendControl</a></code>.</p>
 <table>
 <thead>
@@ -23,4 +23,4 @@ permalink: /api/v1.6.3/l-mapbox-sanitize
 </tr>
 </tbody>
 </table>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-sharecontrol.html
+++ b/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-sharecontrol.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.3
 permalink: /api/v1.6.3/l-mapbox-sharecontrol
 ---
-{% raw %}<h2 id="section-l-mapbox-sharecontrol">L.mapbox.shareControl(id|url, options)</h2>
+<h2 id="section-l-mapbox-sharecontrol">L.mapbox.shareControl(id|url, options)</h2>
 <p>Adds a &quot;Share&quot; button to the map, which can be used to share the map to Twitter or Facebook, or generate HTML for a map embed.</p>
 <p><span class='leaflet'><em>Extends</em>: <code><a href="/mapbox.js/api/v1.6.3/l-control">L.Control</a></code></span></p>
 <table>
@@ -20,7 +20,7 @@ permalink: /api/v1.6.3/l-mapbox-sharecontrol
 <tr>
 <td>id <em>or</em> url <em>optional</em></td>
 <td>string</td>
-<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileApi}}/v3/examples.map-0l53fhk2.json">{{site.tileApi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
+<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileapi}}/v3/examples.map-0l53fhk2.json">{{site.tileapi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -35,4 +35,4 @@ permalink: /api/v1.6.3/l-mapbox-sharecontrol
     .addControl(L.mapbox.shareControl());
 </code></pre><p><em>Returns</em>:
 Returns a <code><a href="/mapbox.js/api/v1.6.3/l-mapbox-sharecontrol">L.mapbox.shareControl</a></code> object.</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-sharecontrol.html
+++ b/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-sharecontrol.html
@@ -20,7 +20,7 @@ permalink: /api/v1.6.3/l-mapbox-sharecontrol
 <tr>
 <td>id <em>or</em> url <em>optional</em></td>
 <td>string</td>
-<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="https://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json">https://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
+<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="{{site.tileApi}}/v3/examples.map-0l53fhk2.json">{{site.tileApi}}/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>

--- a/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-simplestyle-style.html
+++ b/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-simplestyle-style.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.3
 permalink: /api/v1.6.3/l-mapbox-simplestyle-style
 ---
-{% raw %}<h2 id="section-l-mapbox-simplestyle-style">L.mapbox.simplestyle.style(feature)</h2>
+<h2 id="section-l-mapbox-simplestyle-style">L.mapbox.simplestyle.style(feature)</h2>
 <p>Given a GeoJSON Feature with optional simplestyle-spec properties, return an
 options object formatted to be used as <a href="http://leafletjs.com/reference.html#path">Leaflet Path options</a>.</p>
 <table>
@@ -31,4 +31,4 @@ options object formatted to be used as <a href="http://leafletjs.com/reference.h
 </code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/geojson-simplestyle/">A working example of L.mapbox.simplestyle in use</a></p>
 <p><em>Returns</em>:</p>
 <p>An object formatted to be used as <a href="http://leafletjs.com/reference.html#path">Leaflet Path options</a>.</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-template.html
+++ b/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-template.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.3
 permalink: /api/v1.6.3/l-mapbox-template
 ---
-{% raw %}<h2 id="section-l-mapbox-template">L.mapbox.template(template, data)</h2>
+<h2 id="section-l-mapbox-template">L.mapbox.template(template, data)</h2>
 <p>A <a href="http://mustache.github.io/">mustache</a> template rendering function, as used by the templating feature provided by <code><a href="/mapbox.js/api/v1.6.3/l-mapbox-gridcontrol">L.mapbox.gridControl</a></code>.</p>
 <table>
 <thead>
@@ -29,6 +29,6 @@ permalink: /api/v1.6.3/l-mapbox-template
 </tbody>
 </table>
 <p><em>Example</em>:</p>
-<pre><code>var output = L.mapbox.template(&#39;Name: {{name}}&#39;, {name: &#39;John&#39;});
+<pre><code>var output = L.mapbox.template(&#39;Name: {% raw %}{{name}}{% endraw %}&#39;, {name: &#39;John&#39;});
 // output is &quot;Name: John&quot;
-</code></pre>{% endraw %}
+</code></pre>

--- a/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-tilelayer.html
+++ b/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-tilelayer.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.3
 permalink: /api/v1.6.3/l-mapbox-tilelayer
 ---
-{% raw %}<h2 id="section-l-mapbox-tilelayer">L.mapbox.tileLayer(id|url|tilejson, options)</h2>
+<h2 id="section-l-mapbox-tilelayer">L.mapbox.tileLayer(id|url|tilejson, options)</h2>
 <p>You can add a tiled layer to your map with <code><a href="/mapbox.js/api/v1.6.3/l-mapbox-tilelayer">L.mapbox.tileLayer()</a></code>, a simple
 interface to layers from Mapbox and elsewhere.</p>
 <p><span class='leaflet'><em>Extends</em>: <code><a href="/mapbox.js/api/v1.6.3/l-tilelayer">L.TileLayer</a></code></span></p>
@@ -21,7 +21,7 @@ interface to layers from Mapbox and elsewhere.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -36,7 +36,7 @@ interface to layers from Mapbox and elsewhere.</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a TileJSON resource
-var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileapi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided, you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -92,4 +92,4 @@ var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
 });
 </code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>
-{% endraw %}
+

--- a/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-tilelayer.html
+++ b/docs/_posts/api/v1.6.3/0200-01-01-l-mapbox-tilelayer.html
@@ -21,7 +21,7 @@ interface to layers from Mapbox and elsewhere.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -36,7 +36,7 @@ interface to layers from Mapbox and elsewhere.</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a TileJSON resource
-var layer = L.mapbox.tileLayer(&#39;http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided, you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {

--- a/docs/_posts/api/v1.6.3/0200-01-01-mobile.html
+++ b/docs/_posts/api/v1.6.3/0200-01-01-mobile.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.3
 permalink: /api/v1.6.3/mobile
 ---
-{% raw %}<h2 id="section-mobile">Mobile</h2>
+<h2 id="section-mobile">Mobile</h2>
 <p>Mapbox.js is optimized for mobile devices and small screens by default.
 There are, however, best practices to make sure your map always looks its best.</p>
 <h3 id="section-viewport">Viewport</h3>
@@ -36,4 +36,4 @@ tiles will be used when retina is detected.</p>
         detectRetina: true
     }
 }).setView([40, -74.50], 9);
-</code></pre>{% endraw %}
+</code></pre>

--- a/docs/_posts/api/v1.6.3/0200-01-01-theming.html
+++ b/docs/_posts/api/v1.6.3/0200-01-01-theming.html
@@ -5,10 +5,10 @@ categories: api
 version: v1.6.3
 permalink: /api/v1.6.3/theming
 ---
-{% raw %}<h2 id="section-theming">Theming</h2>
+<h2 id="section-theming">Theming</h2>
 <h3 id="section-dark-theme">Dark theme</h3>
 <p>Mapbox.js implements a simple, light style on all interaction elements. A dark theme
 is available by applying <code>class=&quot;dark&quot;</code> to the map div.</p>
 <p><em>Example</em>:</p>
 <pre><code>&lt;div id=&quot;map&quot; class=&quot;dark&quot;&gt;&lt;/div&gt;
-</code></pre>{% endraw %}
+</code></pre>

--- a/docs/_posts/api/v1.6.4/0200-01-01-.html
+++ b/docs/_posts/api/v1.6.4/0200-01-01-.html
@@ -5,4 +5,3 @@ categories: api
 version: v1.6.4
 permalink: /api/v1.6.4/
 ---
-{% raw %}{% endraw %}

--- a/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-config-force_https.html
+++ b/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-config-force_https.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.4
 permalink: /api/v1.6.4/l-mapbox-config-force_https
 ---
-{% raw %}<h2 id="section-l-mapbox-config-force_https">L.mapbox.config.FORCE_HTTPS</h2>
+<h2 id="section-l-mapbox-config-force_https">L.mapbox.config.FORCE_HTTPS</h2>
 <p>By default, this is <code>false</code>. Mapbox.js auto-detects whether the page your map
 is embedded in is using HTTPS or SSL, and matches: if you use HTTPS on your site,
 it uses HTTPS resources.</p>
@@ -13,4 +13,4 @@ it uses HTTPS resources.</p>
 regardless of the host page&#39;s scheme.</p>
 <p><em>Example</em>:</p>
 <pre><code>L.mapbox.config.FORCE_HTTPS = true;
-</code></pre>{% endraw %}
+</code></pre>

--- a/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-config-http_urls.html
+++ b/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-config-http_urls.html
@@ -5,8 +5,7 @@ categories: api
 version: v1.6.4
 permalink: /api/v1.6.4/l-mapbox-config-http_urls
 ---
-{% raw %}<h2 id="section-l-mapbox-config-http_urls">L.mapbox.config.HTTP_URLS</h2>
+<h2 id="section-l-mapbox-config-http_urls">L.mapbox.config.HTTP_URLS</h2>
 <p>An array of base URLs. By default, these point to the <a href="https://www.mapbox.com/developers/api/">Mapbox Web Services</a>.
 When you refer to a tileset, grid, marker, or geocoding endpoint, a URL
 from this array is chosen.</p>
-{% endraw %}

--- a/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-config-https_urls.html
+++ b/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-config-https_urls.html
@@ -5,7 +5,6 @@ categories: api
 version: v1.6.4
 permalink: /api/v1.6.4/l-mapbox-config-https_urls
 ---
-{% raw %}<h2 id="section-l-mapbox-config-https_urls">L.mapbox.config.HTTPS_URLS</h2>
+<h2 id="section-l-mapbox-config-https_urls">L.mapbox.config.HTTPS_URLS</h2>
 <p>The same as <code><a href="/mapbox.js/api/v1.6.4/l-mapbox-config-http_urls">L.mapbox.config.HTTP_URLS</a></code>, but used when SSL mode is detected or
 <code>FORCE_HTTPS</code> is set to <code>true</code>.</p>
-{% endraw %}

--- a/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-featurelayer.html
+++ b/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-featurelayer.html
@@ -24,7 +24,7 @@ from Mapbox and elsewhere into your map.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> geojson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
+<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>

--- a/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-featurelayer.html
+++ b/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-featurelayer.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.4
 permalink: /api/v1.6.4/l-mapbox-featurelayer
 ---
-{% raw %}<h2 id="section-l-mapbox-featurelayer">L.mapbox.featureLayer(id|url|geojson, options)</h2>
+<h2 id="section-l-mapbox-featurelayer">L.mapbox.featureLayer(id|url|geojson, options)</h2>
 <p><span class='leaflet'><em>Extends</em>: <code><a href="/mapbox.js/api/v1.6.4/l-featuregroup">L.FeatureGroup</a></code></span></p>
 <p><strong>NOTE: in version 1.6.0, <code><a href="/mapbox.js/api/v1.6.4/l-mapbox-markerlayer">L.mapbox.markerLayer</a></code> was renamed to <code><a href="/mapbox.js/api/v1.6.4/l-mapbox-featurelayer">L.mapbox.featureLayer</a></code>
 to signal the addition of support for lines and polygons. The <code><a href="/mapbox.js/api/v1.6.4/l-mapbox-markerlayer">L.mapbox.markerLayer</a></code>
@@ -24,7 +24,7 @@ from Mapbox and elsewhere into your map.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> geojson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
+<td>Must be either <ul><li>An id string examples.map-foo</li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A GeoJSON object, from your own Javascript code</li><li><code>null</code>, if you wish to only provide <code>options</code> and not initial data.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -165,4 +165,3 @@ featureLayer.setGeoJSON({
 <h3 id="section-featurelayer-getgeojson">featureLayer.getGeoJSON()</h3>
 <p>Get the contents of this layer as GeoJSON data.</p>
 <p><em>Returns</em> the GeoJSON represented by this layer</p>
-{% endraw %}

--- a/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-geocoder.html
+++ b/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-geocoder.html
@@ -19,7 +19,7 @@ permalink: /api/v1.6.4/l-mapbox-geocoder
 <tr>
 <td>id <em>or</em> url</td>
 <td>string</td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 </tbody>
 </table>

--- a/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-geocoder.html
+++ b/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-geocoder.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.4
 permalink: /api/v1.6.4/l-mapbox-geocoder
 ---
-{% raw %}<h2 id="section-l-mapbox-geocoder">L.mapbox.geocoder(id|url)</h2>
+<h2 id="section-l-mapbox-geocoder">L.mapbox.geocoder(id|url)</h2>
 <p>A low-level interface to geocoding, useful for more complex uses and reverse-geocoding.</p>
 <table>
 <thead>
@@ -19,7 +19,7 @@ permalink: /api/v1.6.4/l-mapbox-geocoder
 <tr>
 <td>id <em>or</em> url</td>
 <td>string</td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -85,4 +85,3 @@ permalink: /api/v1.6.4/l-mapbox-geocoder
 </tbody>
 </table>
 <p><em>Returns</em>: the geocoder object. The return value of this function is not useful - you must use a callback to get results.</p>
-{% endraw %}

--- a/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-geocodercontrol.html
+++ b/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-geocodercontrol.html
@@ -24,7 +24,7 @@ This function is currently in private beta: <a href="https://mapbox.com/contact/
 <tr>
 <td>id <em>or</em> url (<em>required</em>)</td>
 <td>string</td>
-<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 <tr>
 <td>options</td>

--- a/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-geocodercontrol.html
+++ b/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-geocodercontrol.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.4
 permalink: /api/v1.6.4/l-mapbox-geocodercontrol
 ---
-{% raw %}<h2 id="section-l-mapbox-geocodercontrol">L.mapbox.geocoderControl(id|url, options)</h2>
+<h2 id="section-l-mapbox-geocodercontrol">L.mapbox.geocoderControl(id|url, options)</h2>
 <p>Adds geocoder functionality as well as a UI element to a map. This uses
 the <a href="http://mapbox.com/developers/api/#geocoding">Mapbox Geocoding API</a>.</p>
 <div class='note warning'>
@@ -24,7 +24,7 @@ This function is currently in private beta: <a href="https://mapbox.com/contact/
 <tr>
 <td>id <em>or</em> url (<em>required</em>)</td>
 <td>string</td>
-<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
+<td>Either a <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -124,4 +124,3 @@ This function is currently in private beta: <a href="https://mapbox.com/contact/
 </tr>
 </tbody>
 </table>
-{% endraw %}

--- a/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-gridcontrol.html
+++ b/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-gridcontrol.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.4
 permalink: /api/v1.6.4/l-mapbox-gridcontrol
 ---
-{% raw %}<h2 id="section-l-mapbox-gridcontrol">L.mapbox.gridControl(layer, options)</h2>
+<h2 id="section-l-mapbox-gridcontrol">L.mapbox.gridControl(layer, options)</h2>
 <p><span class='leaflet'><em>Extends</em>: <code><a href="/mapbox.js/api/v1.6.4/l-control">L.Control</a></code></span></p>
 <p>Interaction is what we call interactive parts of maps that are created with the powerful <a href="http://mapbox.com/tilemill/docs/crashcourse/tooltips/">tooltips &amp; regions</a> system in <a href="http://mapbox.com/tilemill/">TileMill</a>. Under the hood, it&#39;s powered by the open <a href="https://github.com/mapbox/utfgrid-spec/">UTFGrid specification</a>.</p>
 <table>
@@ -60,4 +60,3 @@ the UTFGrid data in the map&#39;s interactivity into HTML for display.</p>
 </tbody>
 </table>
 <p><em>Returns</em>: the <code><a href="/mapbox.js/api/v1.6.4/l-mapbox-gridcontrol">L.mapbox.gridControl</a></code> object.</p>
-{% endraw %}

--- a/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-gridlayer.html
+++ b/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-gridlayer.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.4
 permalink: /api/v1.6.4/l-mapbox-gridlayer
 ---
-{% raw %}<h2 id="section-l-mapbox-gridlayer">L.mapbox.gridLayer(id|url|tilejson, options)</h2>
+<h2 id="section-l-mapbox-gridlayer">L.mapbox.gridLayer(id|url|tilejson, options)</h2>
 <p>An <code><a href="/mapbox.js/api/v1.6.4/l-mapbox-gridlayer">L.mapbox.gridLayer</a></code> loads <a href="http://mapbox.com/developers/utfgrid/">UTFGrid</a> tiles of
 interactivity into your map, which you can easily access with <code><a href="/mapbox.js/api/v1.6.4/l-mapbox-gridcontrol">L.mapbox.gridControl</a></code>.</p>
 <table>
@@ -20,7 +20,7 @@ interactivity into your map, which you can easily access with <code><a href="/ma
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 </tbody>
 </table>
@@ -112,4 +112,3 @@ function with that data, if any.</p>
 </tbody>
 </table>
 <p><em>Returns</em>: the L.mapbox.gridLayer object</p>
-{% endraw %}

--- a/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-gridlayer.html
+++ b/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-gridlayer.html
@@ -20,7 +20,7 @@ interactivity into your map, which you can easily access with <code><a href="/ma
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td><ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 </tbody>
 </table>

--- a/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-infocontrol.html
+++ b/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-infocontrol.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.4
 permalink: /api/v1.6.4/l-mapbox-infocontrol
 ---
-{% raw %}<h2 id="section-l-mapbox-infocontrol">L.mapbox.infoControl(options)</h2>
+<h2 id="section-l-mapbox-infocontrol">L.mapbox.infoControl(options)</h2>
 <p><span class='leaflet'><em>Extends</em>: <code><a href="/mapbox.js/api/v1.6.4/l-control">L.Control</a></code></span></p>
 <p>A map control that shows a toggleable info container. If set, attribution is auto-detected from active layers and added to the info container.</p>
 <table>
@@ -65,4 +65,3 @@ map.addControl(L.mapbox.infoControl().addInfo(&#39;foo&#39;));
 </tr>
 </tbody>
 </table>
-{% endraw %}

--- a/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-legendcontrol.html
+++ b/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-legendcontrol.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.4
 permalink: /api/v1.6.4/l-mapbox-legendcontrol
 ---
-{% raw %}<h2 id="section-l-mapbox-legendcontrol">L.mapbox.legendControl(options)</h2>
+<h2 id="section-l-mapbox-legendcontrol">L.mapbox.legendControl(options)</h2>
 <p><span class='leaflet'><em>Extends</em>: L.Control</span></p>
 <p>A map control that shows legends added to maps in Mapbox. Legends are auto-detected from active layers.</p>
 <table>
@@ -65,4 +65,3 @@ map.addControl(L.mapbox.legendControl());
 </tr>
 </tbody>
 </table>
-{% endraw %}

--- a/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-map.html
+++ b/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-map.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.4
 permalink: /api/v1.6.4/l-mapbox-map
 ---
-{% raw %}<h2 id="section-l-mapbox-map">L.mapbox.map(element, id|url|tilejson, options)</h2>
+<h2 id="section-l-mapbox-map">L.mapbox.map(element, id|url|tilejson, options)</h2>
 <p>Create and automatically configure a map with layers, markers, and
 interactivity.</p>
 <p><span class='leaflet'><em>Extends</em>: <code><a href="/mapbox.js/api/v1.6.4/l-map-class">L.Map</a></code></span></p>
@@ -26,7 +26,7 @@ interactivity.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="https://www.mapbox.com/developers/tilejson/">TileJSON</a> object, from your own Javascript code</li></ul></td>
+<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="https://www.mapbox.com/developers/tilejson/">TileJSON</a> object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -49,4 +49,3 @@ var map = L.mapbox.map(&#39;map&#39;);
 <p>Returns this map&#39;s TileJSON object which determines its tile source,
 zoom bounds and other metadata.</p>
 <p><em>Returns</em>: the TileJSON object</p>
-{% endraw %}

--- a/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-map.html
+++ b/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-map.html
@@ -26,7 +26,7 @@ interactivity.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="https://www.mapbox.com/developers/tilejson/">TileJSON</a> object, from your own Javascript code</li></ul></td>
+<td>url can be <ul><li>a map <code>id</code> string <code>examples.map-foo</code></li><li> a URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>a <a href="https://www.mapbox.com/developers/tilejson/">TileJSON</a> object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>

--- a/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-marker-icon.html
+++ b/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-marker-icon.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.4
 permalink: /api/v1.6.4/l-mapbox-marker-icon
 ---
-{% raw %}<h2 id="section-l-mapbox-marker-icon">L.mapbox.marker.icon(properties)</h2>
+<h2 id="section-l-mapbox-marker-icon">L.mapbox.marker.icon(properties)</h2>
 <p>A core icon generator used in <code><a href="/mapbox.js/api/v1.6.4/l-mapbox-marker-style">L.mapbox.marker.style</a></code></p>
 <table>
 <thead>
@@ -27,4 +27,3 @@ permalink: /api/v1.6.4/l-mapbox-marker-icon
 <p>A <code><a href="/mapbox.js/api/v1.6.4/l-icon">L.Icon</a></code> object with custom settings for <code>iconUrl</code>, <code>iconSize</code>, <code>iconAnchor</code>,
 and <code>popupAnchor</code>.</p>
 <p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/l-mapbox-marker/">A working example of L.mapbox.marker.icon in use</a></p>
-{% endraw %}

--- a/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-marker-style.html
+++ b/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-marker-style.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.4
 permalink: /api/v1.6.4/l-mapbox-marker-style
 ---
-{% raw %}<h2 id="section-l-mapbox-marker-style">L.mapbox.marker.style(feature, latlng)</h2>
+<h2 id="section-l-mapbox-marker-style">L.mapbox.marker.style(feature, latlng)</h2>
 <p>An icon generator for use in conjunction with <code>pointToLayer</code> to generate
 markers from the <a href="http://mapbox.com/developers/api/#markers">Mapbox Markers API</a>
 and support the <a href="https://github.com/mapbox/simplestyle-spec">simplestyle-spec</a> for
@@ -39,4 +39,3 @@ features.</p>
 <p>A <code><a href="/mapbox.js/api/v1.6.4/l-marker">L.Marker</a></code> object with the latitude, longitude position and a styled marker</p>
 <p>The other sections of the <a href="https://github.com/mapbox/simplestyle-spec">simplestyle-spec</a> are implemented
 by <code><a href="/mapbox.js/api/v1.6.4/l-mapbox-simplestyle-style">L.mapbox.simplestyle.style</a></code></p>
-{% endraw %}

--- a/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-sanitize.html
+++ b/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-sanitize.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.4
 permalink: /api/v1.6.4/l-mapbox-sanitize
 ---
-{% raw %}<h2 id="section-l-mapbox-sanitize">L.mapbox.sanitize(string)</h2>
+<h2 id="section-l-mapbox-sanitize">L.mapbox.sanitize(string)</h2>
 <p>A HTML sanitization function, with the same effect as the default value of the <code>sanitizer</code> option of <code><a href="/mapbox.js/api/v1.6.4/l-mapbox-featurelayer">L.mapbox.featureLayer</a></code>, <code><a href="/mapbox.js/api/v1.6.4/l-mapbox-gridcontrol">L.mapbox.gridControl</a></code>, and <code><a href="/mapbox.js/api/v1.6.4/l-mapbox-legendcontrol">L.mapbox.legendControl</a></code>.</p>
 <table>
 <thead>
@@ -23,4 +23,3 @@ permalink: /api/v1.6.4/l-mapbox-sanitize
 </tr>
 </tbody>
 </table>
-{% endraw %}

--- a/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-sharecontrol.html
+++ b/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-sharecontrol.html
@@ -20,7 +20,7 @@ permalink: /api/v1.6.4/l-mapbox-sharecontrol
 <tr>
 <td>id <em>or</em> url <em>optional</em></td>
 <td>string</td>
-<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code><a href="https://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json">https://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</a></code> If not supplied, the TileJSON from the map is used.</li></ul></td>
+<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code> If not supplied, the TileJSON from the map is used.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>

--- a/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-sharecontrol.html
+++ b/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-sharecontrol.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.4
 permalink: /api/v1.6.4/l-mapbox-sharecontrol
 ---
-{% raw %}<h2 id="section-l-mapbox-sharecontrol">L.mapbox.shareControl(id|url, options)</h2>
+<h2 id="section-l-mapbox-sharecontrol">L.mapbox.shareControl(id|url, options)</h2>
 <p>Adds a &quot;Share&quot; button to the map, which can be used to share the map to Twitter or Facebook, or generate HTML for a map embed.</p>
 <p><span class='leaflet'><em>Extends</em>: <code><a href="/mapbox.js/api/v1.6.4/l-control">L.Control</a></code></span></p>
 <table>
@@ -20,7 +20,7 @@ permalink: /api/v1.6.4/l-mapbox-sharecontrol
 <tr>
 <td>id <em>or</em> url <em>optional</em></td>
 <td>string</td>
-<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code> If not supplied, the TileJSON from the map is used.</li></ul></td>
+<td>Either a <ul><li><code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code> If not supplied, the TileJSON from the map is used.</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -35,4 +35,3 @@ permalink: /api/v1.6.4/l-mapbox-sharecontrol
     .addControl(L.mapbox.shareControl());
 </code></pre><p><em>Returns</em>:
 Returns a <code><a href="/mapbox.js/api/v1.6.4/l-mapbox-sharecontrol">L.mapbox.shareControl</a></code> object.</p>
-{% endraw %}

--- a/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-simplestyle-style.html
+++ b/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-simplestyle-style.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.4
 permalink: /api/v1.6.4/l-mapbox-simplestyle-style
 ---
-{% raw %}<h2 id="section-l-mapbox-simplestyle-style">L.mapbox.simplestyle.style(feature)</h2>
+<h2 id="section-l-mapbox-simplestyle-style">L.mapbox.simplestyle.style(feature)</h2>
 <p>Given a GeoJSON Feature with optional simplestyle-spec properties, return an
 options object formatted to be used as <a href="http://leafletjs.com/reference.html#path">Leaflet Path options</a>.</p>
 <table>
@@ -31,4 +31,3 @@ options object formatted to be used as <a href="http://leafletjs.com/reference.h
 </code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/geojson-simplestyle/">A working example of L.mapbox.simplestyle in use</a></p>
 <p><em>Returns</em>:</p>
 <p>An object formatted to be used as <a href="http://leafletjs.com/reference.html#path">Leaflet Path options</a>.</p>
-{% endraw %}

--- a/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-template.html
+++ b/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-template.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.4
 permalink: /api/v1.6.4/l-mapbox-template
 ---
-{% raw %}<h2 id="section-l-mapbox-template">L.mapbox.template(template, data)</h2>
+<h2 id="section-l-mapbox-template">L.mapbox.template(template, data)</h2>
 <p>A <a href="http://mustache.github.io/">mustache</a> template rendering function, as used by the templating feature provided by <code><a href="/mapbox.js/api/v1.6.4/l-mapbox-gridcontrol">L.mapbox.gridControl</a></code>.</p>
 <table>
 <thead>
@@ -29,6 +29,6 @@ permalink: /api/v1.6.4/l-mapbox-template
 </tbody>
 </table>
 <p><em>Example</em>:</p>
-<pre><code>var output = L.mapbox.template(&#39;Name: {{name}}&#39;, {name: &#39;John&#39;});
+<pre><code>var output = L.mapbox.template(&#39;Name: {% raw %}{{name}}{% endraw %}&#39;, {name: &#39;John&#39;});
 // output is &quot;Name: John&quot;
-</code></pre>{% endraw %}
+</code></pre>

--- a/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-tilelayer.html
+++ b/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-tilelayer.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.4
 permalink: /api/v1.6.4/l-mapbox-tilelayer
 ---
-{% raw %}<h2 id="section-l-mapbox-tilelayer">L.mapbox.tileLayer(id|url|tilejson, options)</h2>
+<h2 id="section-l-mapbox-tilelayer">L.mapbox.tileLayer(id|url|tilejson, options)</h2>
 <p>You can add a tiled layer to your map with <code><a href="/mapbox.js/api/v1.6.4/l-mapbox-tilelayer">L.mapbox.tileLayer()</a></code>, a simple
 interface to layers from Mapbox and elsewhere.</p>
 <p><span class='leaflet'><em>Extends</em>: <code><a href="/mapbox.js/api/v1.6.4/l-tilelayer">L.TileLayer</a></code></span></p>
@@ -21,7 +21,7 @@ interface to layers from Mapbox and elsewhere.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileapi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -36,7 +36,7 @@ interface to layers from Mapbox and elsewhere.</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a TileJSON resource
-var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileapi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided, you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
@@ -92,4 +92,3 @@ var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
 });
 </code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>
-{% endraw %}

--- a/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-tilelayer.html
+++ b/docs/_posts/api/v1.6.4/0200-01-01-l-mapbox-tilelayer.html
@@ -21,7 +21,7 @@ interface to layers from Mapbox and elsewhere.</p>
 <tr>
 <td>id <em>or</em> url <em>or</em> tilejson (<em>required</em>)</td>
 <td><strong>string</strong> if <em>id</em> or <em>url</em> <strong>object</strong> if <em>tilejson</em></td>
-<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
+<td>Value must be <ul><li>An <code>id</code> string <code>examples.map-foo</code></li><li>A URL to TileJSON, like <code>{{site.tileApi}}/v3/examples.map-0l53fhk2.json</code></li><li>A TileJSON object, from your own Javascript code</li></ul></td>
 </tr>
 <tr>
 <td>options</td>
@@ -36,7 +36,7 @@ interface to layers from Mapbox and elsewhere.</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;);
 
 // you can also provide a full url to a TileJSON resource
-var layer = L.mapbox.tileLayer(&#39;http://a.tiles.mapbox.com/v3/examples.map-0l53fhk2.json&#39;);
+var layer = L.mapbox.tileLayer(&#39;{{site.tileApi}}/v3/examples.map-0l53fhk2.json&#39;);
 
 // if provided, you can support retina tiles
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {

--- a/docs/_posts/api/v1.6.4/0200-01-01-mobile.html
+++ b/docs/_posts/api/v1.6.4/0200-01-01-mobile.html
@@ -5,7 +5,7 @@ categories: api
 version: v1.6.4
 permalink: /api/v1.6.4/mobile
 ---
-{% raw %}<h2 id="section-mobile">Mobile</h2>
+<h2 id="section-mobile">Mobile</h2>
 <p>Mapbox.js is optimized for mobile devices and small screens by default.
 There are, however, best practices to make sure your map always looks its best.</p>
 <h3 id="section-viewport">Viewport</h3>
@@ -36,4 +36,4 @@ tiles will be used when retina is detected.</p>
         detectRetina: true
     }
 }).setView([40, -74.50], 9);
-</code></pre>{% endraw %}
+</code></pre>

--- a/docs/_posts/api/v1.6.4/0200-01-01-theming.html
+++ b/docs/_posts/api/v1.6.4/0200-01-01-theming.html
@@ -5,10 +5,10 @@ categories: api
 version: v1.6.4
 permalink: /api/v1.6.4/theming
 ---
-{% raw %}<h2 id="section-theming">Theming</h2>
+<h2 id="section-theming">Theming</h2>
 <h3 id="section-dark-theme">Dark theme</h3>
 <p>Mapbox.js implements a simple, light style on all interaction elements. A dark theme
 is available by applying <code>class=&quot;dark&quot;</code> to the map div.</p>
 <p><em>Example</em>:</p>
 <pre><code>&lt;div id=&quot;map&quot; class=&quot;dark&quot;&gt;&lt;/div&gt;
-</code></pre>{% endraw %}
+</code></pre>

--- a/docs/_posts/examples/v1.0.0/0100-01-01-animating-flight-paths.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-animating-flight-paths.html
@@ -9,7 +9,7 @@ tags:
   - animation
 ---
 <!-- We use arc.js to make our paths curved. -->
-<script src='https://api.tiles.mapbox.com/mapbox.js/plugins/arc.js/v0.1.0/arc.js'></script>
+<script src='{{site.tileApi}}/mapbox.js/plugins/arc.js/v0.1.0/arc.js'></script>
 <!-- This is our data file - it's an array of [[lat,lng],[lat,lng]] pairs
      that define starting and ending locations of flight paths -->
 <script src='{{site.baseurl}}/assets/data/flights.js'></script>

--- a/docs/_posts/examples/v1.0.0/0100-01-01-animating-flight-paths.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-animating-flight-paths.html
@@ -9,7 +9,7 @@ tags:
   - animation
 ---
 <!-- We use arc.js to make our paths curved. -->
-<script src='{{site.tileApi}}/mapbox.js/plugins/arc.js/v0.1.0/arc.js'></script>
+<script src='{{site.tileapi}}/mapbox.js/plugins/arc.js/v0.1.0/arc.js'></script>
 <!-- This is our data file - it's an array of [[lat,lng],[lat,lng]] pairs
      that define starting and ending locations of flight paths -->
 <script src='{{site.baseurl}}/assets/data/flights.js'></script>

--- a/docs/_posts/examples/v1.0.0/0100-01-01-arcjs.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-arcjs.html
@@ -7,7 +7,7 @@ description: Drawing a great arc with arc.js
 tags:
   - plugins
 ---
-<script src='https://api.tiles.mapbox.com/mapbox.js/plugins/arc.js/v0.1.0/arc.js'></script>
+<script src='{{site.tileApi}}/mapbox.js/plugins/arc.js/v0.1.0/arc.js'></script>
 <div id='map'></div>
 
 <script>

--- a/docs/_posts/examples/v1.0.0/0100-01-01-arcjs.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-arcjs.html
@@ -7,7 +7,7 @@ description: Drawing a great arc with arc.js
 tags:
   - plugins
 ---
-<script src='{{site.tileApi}}/mapbox.js/plugins/arc.js/v0.1.0/arc.js'></script>
+<script src='{{site.tileapi}}/mapbox.js/plugins/arc.js/v0.1.0/arc.js'></script>
 <div id='map'></div>
 
 <script>

--- a/docs/_posts/examples/v1.0.0/0100-01-01-firebase-live-editing.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-firebase-live-editing.html
@@ -10,8 +10,8 @@ tags:
 ---
 
 <script src='https://cdn.firebase.com/js/client/1.0.6/firebase.js'></script>
-<script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-label/v0.2.1/leaflet.label.js'></script>
-<link href='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-label/v0.2.1/leaflet.label.css' rel='stylesheet' />
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-label/v0.2.1/leaflet.label.js'></script>
+<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-label/v0.2.1/leaflet.label.css' rel='stylesheet' />
 <style>
 .leaflet-popup-close-button { display:none; }
 fieldset { width:240px; }

--- a/docs/_posts/examples/v1.0.0/0100-01-01-firebase-live-editing.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-firebase-live-editing.html
@@ -10,8 +10,8 @@ tags:
 ---
 
 <script src='https://cdn.firebase.com/js/client/1.0.6/firebase.js'></script>
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-label/v0.2.1/leaflet.label.js'></script>
-<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-label/v0.2.1/leaflet.label.css' rel='stylesheet' />
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-label/v0.2.1/leaflet.label.js'></script>
+<link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-label/v0.2.1/leaflet.label.css' rel='stylesheet' />
 <style>
 .leaflet-popup-close-button { display:none; }
 fieldset { width:240px; }

--- a/docs/_posts/examples/v1.0.0/0100-01-01-identify-tool.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-identify-tool.html
@@ -7,7 +7,7 @@ description: Use leaflet-pip to identify overlapping polygons and highlight them
 tags:
   - plugins
 ---
-<script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-pip/v0.0.2/leaflet-pip.js'></script>
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-pip/v0.0.2/leaflet-pip.js'></script>
 
 <style>
 .leaflet-popup { width:240px; }

--- a/docs/_posts/examples/v1.0.0/0100-01-01-identify-tool.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-identify-tool.html
@@ -7,7 +7,7 @@ description: Use leaflet-pip to identify overlapping polygons and highlight them
 tags:
   - plugins
 ---
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-pip/v0.0.2/leaflet-pip.js'></script>
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-pip/v0.0.2/leaflet-pip.js'></script>
 
 <style>
 .leaflet-popup { width:240px; }

--- a/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-draw.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-draw.html
@@ -7,8 +7,8 @@ description: Add drawing tools for users to author shapes using the Leaflet Draw
 tags:
   - plugins
 ---
-<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-draw/v0.2.2/leaflet.draw.css' rel='stylesheet' />
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-draw/v0.2.2/leaflet.draw.js'></script>
+<link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-draw/v0.2.2/leaflet.draw.css' rel='stylesheet' />
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-draw/v0.2.2/leaflet.draw.js'></script>
 
 <div id='map'></div>
 

--- a/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-draw.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-draw.html
@@ -7,8 +7,8 @@ description: Add drawing tools for users to author shapes using the Leaflet Draw
 tags:
   - plugins
 ---
-<link href='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-draw/v0.2.2/leaflet.draw.css' rel='stylesheet' />
-<script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-draw/v0.2.2/leaflet.draw.js'></script>
+<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-draw/v0.2.2/leaflet.draw.css' rel='stylesheet' />
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-draw/v0.2.2/leaflet.draw.js'></script>
 
 <div id='map'></div>
 

--- a/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-fullscreen.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-fullscreen.html
@@ -7,8 +7,8 @@ description: Add a control to enable a map to be in full screen mode.
 tags:
   - plugins
 ---
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-fullscreen/v0.0.3/Leaflet.fullscreen.min.js'></script>
-<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-fullscreen/v0.0.3/leaflet.fullscreen.css' rel='stylesheet' />
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-fullscreen/v0.0.3/Leaflet.fullscreen.min.js'></script>
+<link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-fullscreen/v0.0.3/leaflet.fullscreen.css' rel='stylesheet' />
 
 <div id='map'></div>
 

--- a/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-fullscreen.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-fullscreen.html
@@ -7,8 +7,8 @@ description: Add a control to enable a map to be in full screen mode.
 tags:
   - plugins
 ---
-<script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-fullscreen/v0.0.3/Leaflet.fullscreen.min.js'></script>
-<link href='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-fullscreen/v0.0.3/leaflet.fullscreen.css' rel='stylesheet' />
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-fullscreen/v0.0.3/Leaflet.fullscreen.min.js'></script>
+<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-fullscreen/v0.0.3/leaflet.fullscreen.css' rel='stylesheet' />
 
 <div id='map'></div>
 

--- a/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-geodesy.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-geodesy.html
@@ -7,7 +7,7 @@ description: Generate true <a href='http://en.wikipedia.org/wiki/Geodesic'>geode
 tags:
   - plugins
 ---
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-geodesy/v0.1.0/leaflet-geodesy.js'></script>
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-geodesy/v0.1.0/leaflet-geodesy.js'></script>
 
 <style>
 .ui-form {

--- a/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-geodesy.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-geodesy.html
@@ -7,7 +7,7 @@ description: Generate true <a href='http://en.wikipedia.org/wiki/Geodesic'>geode
 tags:
   - plugins
 ---
-<script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-geodesy/v0.1.0/leaflet-geodesy.js'></script>
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-geodesy/v0.1.0/leaflet-geodesy.js'></script>
 
 <style>
 .ui-form {

--- a/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-hash.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-hash.html
@@ -7,7 +7,7 @@ description: When a map is panned or zoomed, add the coordinates to the URL.
 tags:
   - plugins
 ---
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-hash/v0.2.1/leaflet-hash.js'></script>
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-hash/v0.2.1/leaflet-hash.js'></script>
 <div id='map'></div>
 
 <script>

--- a/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-hash.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-hash.html
@@ -7,7 +7,7 @@ description: When a map is panned or zoomed, add the coordinates to the URL.
 tags:
   - plugins
 ---
-<script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-hash/v0.2.1/leaflet-hash.js'></script>
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-hash/v0.2.1/leaflet-hash.js'></script>
 <div id='map'></div>
 
 <script>

--- a/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-heat-markers.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-heat-markers.html
@@ -3,11 +3,11 @@ layout: example
 categories: example/v1.0.0
 version: v1.0.0
 title: Heatmap from markers
-description: Using  marker data that <a href='{{site.tileApi}}/v3/examples.map-zr0njcqy/page.html'>looks like this</a>, create a heat map from it showing concentrations.
+description: Using  marker data that <a href='{{site.tileapi}}/v3/examples.map-zr0njcqy/page.html'>looks like this</a>, create a heat map from it showing concentrations.
 tags:
   - plugins
 ---
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-heat/v0.1.0/leaflet-heat.js'></script>
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-heat/v0.1.0/leaflet-heat.js'></script>
 <div id='map'></div>
 
 <script>

--- a/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-heat-markers.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-heat-markers.html
@@ -3,7 +3,7 @@ layout: example
 categories: example/v1.0.0
 version: v1.0.0
 title: Heatmap from markers
-description: Using  marker data that <a href='{{site.tileapi}}/v3/examples.map-zr0njcqy/page.html'>looks like this</a>, create a heat map from it showing concentrations.
+description: Using  marker data that <a href='https://api.tiles.mapbox.com/v3/examples.map-zr0njcqy/page.html'>looks like this</a>, create a heat map from it showing concentrations.
 tags:
   - plugins
 ---

--- a/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-heat-markers.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-heat-markers.html
@@ -3,11 +3,11 @@ layout: example
 categories: example/v1.0.0
 version: v1.0.0
 title: Heatmap from markers
-description: Using  marker data that <a href='https://a.tiles.mapbox.com/v3/examples.map-zr0njcqy/page.html'>looks like this</a>, create a heat map from it showing concentrations.
+description: Using  marker data that <a href='{{site.tileApi}}/v3/examples.map-zr0njcqy/page.html'>looks like this</a>, create a heat map from it showing concentrations.
 tags:
   - plugins
 ---
-<script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-heat/v0.1.0/leaflet-heat.js'></script>
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-heat/v0.1.0/leaflet-heat.js'></script>
 <div id='map'></div>
 
 <script>

--- a/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-heat.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-heat.html
@@ -7,7 +7,7 @@ description: Initially draw heatmap data on a map and allow a users mouse moveme
 tags:
   - plugins
 ---
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-heat/v0.1.0/leaflet-heat.js'></script>
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-heat/v0.1.0/leaflet-heat.js'></script>
 <div id='map'></div>
 
 <!-- Example data. -->

--- a/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-heat.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-heat.html
@@ -7,7 +7,7 @@ description: Initially draw heatmap data on a map and allow a users mouse moveme
 tags:
   - plugins
 ---
-<script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-heat/v0.1.0/leaflet-heat.js'></script>
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-heat/v0.1.0/leaflet-heat.js'></script>
 <div id='map'></div>
 
 <!-- Example data. -->

--- a/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-image.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-image.html
@@ -7,7 +7,7 @@ description: Zoom and pan around a map then take a screenshot as an image.
 tags:
   - plugins
 ---
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-image/v0.0.3/leaflet-image.js'></script>
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-image/v0.0.3/leaflet-image.js'></script>
 
 <style>
 .ui-button {

--- a/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-image.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-image.html
@@ -7,7 +7,7 @@ description: Zoom and pan around a map then take a screenshot as an image.
 tags:
   - plugins
 ---
-<script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-image/v0.0.3/leaflet-image.js'></script>
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-image/v0.0.3/leaflet-image.js'></script>
 
 <style>
 .ui-button {

--- a/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-label.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-label.html
@@ -7,8 +7,8 @@ description: Custom tooltips on hover with the Leaflet Label plugin.
 tags:
   - plugins
 ---
-<script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-label/v0.2.1/leaflet.label.js'></script>
-<link href='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-label/v0.2.1/leaflet.label.css' rel='stylesheet' />
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-label/v0.2.1/leaflet.label.js'></script>
+<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-label/v0.2.1/leaflet.label.css' rel='stylesheet' />
 <div id='map'></div>
 
 <script>

--- a/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-label.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-label.html
@@ -7,8 +7,8 @@ description: Custom tooltips on hover with the Leaflet Label plugin.
 tags:
   - plugins
 ---
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-label/v0.2.1/leaflet.label.js'></script>
-<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-label/v0.2.1/leaflet.label.css' rel='stylesheet' />
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-label/v0.2.1/leaflet.label.js'></script>
+<link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-label/v0.2.1/leaflet.label.css' rel='stylesheet' />
 <div id='map'></div>
 
 <script>

--- a/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-locatecontrol.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-locatecontrol.html
@@ -7,10 +7,10 @@ description: Add a find me control that sets the map view to the current coordin
 tags:
   - plugins
 ---
-<script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-locatecontrol/v0.24.0/L.Control.Locate.js'></script>
-<link href='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-locatecontrol/v0.24.0/L.Control.Locate.css' rel='stylesheet' />
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-locatecontrol/v0.24.0/L.Control.Locate.js'></script>
+<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-locatecontrol/v0.24.0/L.Control.Locate.css' rel='stylesheet' />
 <!--[if lt IE 9]>
-<link href='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-locatecontrol/v0.21.0/L.Control.Locate.ie.css' rel='stylesheet' />
+<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-locatecontrol/v0.21.0/L.Control.Locate.ie.css' rel='stylesheet' />
 <![endif]-->
 
 <style>

--- a/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-locatecontrol.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-locatecontrol.html
@@ -7,10 +7,10 @@ description: Add a find me control that sets the map view to the current coordin
 tags:
   - plugins
 ---
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-locatecontrol/v0.24.0/L.Control.Locate.js'></script>
-<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-locatecontrol/v0.24.0/L.Control.Locate.css' rel='stylesheet' />
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-locatecontrol/v0.24.0/L.Control.Locate.js'></script>
+<link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-locatecontrol/v0.24.0/L.Control.Locate.css' rel='stylesheet' />
 <!--[if lt IE 9]>
-<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-locatecontrol/v0.21.0/L.Control.Locate.ie.css' rel='stylesheet' />
+<link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-locatecontrol/v0.21.0/L.Control.Locate.ie.css' rel='stylesheet' />
 <![endif]-->
 
 <style>

--- a/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-markercluster.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-markercluster.html
@@ -8,9 +8,9 @@ tags:
   - plugins
 ---
 
-<script src='//api.tiles.mapbox.com/mapbox.js/plugins/leaflet-markercluster/v0.4.0/leaflet.markercluster.js'></script>
-<link href='//api.tiles.mapbox.com/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.css' rel='stylesheet' />
-<link href='//api.tiles.mapbox.com/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.Default.css' rel='stylesheet' />
+<script src={{site.tileapi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/leaflet.markercluster.js'></script>
+<link href={{site.tileapi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.css' rel='stylesheet' />
+<link href={{site.tileapi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.Default.css' rel='stylesheet' />
 
 <!-- Example data. -->
 <script src="{{site.baseurl}}/assets/data/realworld.388.js"></script>

--- a/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-minimap.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-minimap.html
@@ -7,8 +7,8 @@ description: Display a smaller navigable map using the Leaflet-MiniMap plugin.
 tags:
   - plugins
 ---
-<script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-minimap/v1.0.0/Control.MiniMap.js'></script>
-<link href='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-minimap/v1.0.0/Control.MiniMap.css' rel='stylesheet' />
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-minimap/v1.0.0/Control.MiniMap.js'></script>
+<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-minimap/v1.0.0/Control.MiniMap.css' rel='stylesheet' />
 
 <div id='map'></div>
 

--- a/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-minimap.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-minimap.html
@@ -7,8 +7,8 @@ description: Display a smaller navigable map using the Leaflet-MiniMap plugin.
 tags:
   - plugins
 ---
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-minimap/v1.0.0/Control.MiniMap.js'></script>
-<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-minimap/v1.0.0/Control.MiniMap.css' rel='stylesheet' />
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-minimap/v1.0.0/Control.MiniMap.js'></script>
+<link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-minimap/v1.0.0/Control.MiniMap.css' rel='stylesheet' />
 
 <div id='map'></div>
 

--- a/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-osm.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-osm.html
@@ -9,7 +9,7 @@ tags:
 ---
 <!-- jQuery is required for this example. Uncomment this line -->
 <!-- <script src='https://code.jquery.com/jquery-1.11.0.min.js'></script> -->
-<script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-osm/v0.1.0/leaflet-osm.js'></script>
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-osm/v0.1.0/leaflet-osm.js'></script>
 
 <div id='map'></div>
 <script>

--- a/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-osm.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-osm.html
@@ -9,7 +9,7 @@ tags:
 ---
 <!-- jQuery is required for this example. Uncomment this line -->
 <!-- <script src='https://code.jquery.com/jquery-1.11.0.min.js'></script> -->
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-osm/v0.1.0/leaflet-osm.js'></script>
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-osm/v0.1.0/leaflet-osm.js'></script>
 
 <div id='map'></div>
 <script>

--- a/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-zoomslider.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-zoomslider.html
@@ -8,8 +8,8 @@ tags:
   - ui
   - plugins
 ---
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-zoomslider/v0.7.0/L.Control.Zoomslider.js'></script>
-<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-zoomslider/v0.7.0/L.Control.Zoomslider.css' rel='stylesheet' />
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-zoomslider/v0.7.0/L.Control.Zoomslider.js'></script>
+<link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-zoomslider/v0.7.0/L.Control.Zoomslider.css' rel='stylesheet' />
 
 <style>
 /* Adjustments to account for mapbox.css box-sizing rules */

--- a/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-zoomslider.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-zoomslider.html
@@ -8,8 +8,8 @@ tags:
   - ui
   - plugins
 ---
-<script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-zoomslider/v0.7.0/L.Control.Zoomslider.js'></script>
-<link href='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-zoomslider/v0.7.0/L.Control.Zoomslider.css' rel='stylesheet' />
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-zoomslider/v0.7.0/L.Control.Zoomslider.js'></script>
+<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-zoomslider/v0.7.0/L.Control.Zoomslider.css' rel='stylesheet' />
 
 <style>
 /* Adjustments to account for mapbox.css box-sizing rules */

--- a/docs/_posts/examples/v1.0.0/0100-01-01-markercluster-with-mapbox-data.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-markercluster-with-mapbox-data.html
@@ -7,8 +7,8 @@ description: Cluster markers from a Mapbox featureLayer using MarkerClusterGroup
 tags:
   - plugins
 ---
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/leaflet.markercluster.js'></script>
-<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.css' rel='stylesheet' />
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/leaflet.markercluster.js'></script>
+<link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.css' rel='stylesheet' />
 <link href='https:////api.tiles.mapbox.com/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.Default.css' rel='stylesheet' />
 
 <div id='map'></div>

--- a/docs/_posts/examples/v1.0.0/0100-01-01-markercluster-with-mapbox-data.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-markercluster-with-mapbox-data.html
@@ -7,8 +7,8 @@ description: Cluster markers from a Mapbox featureLayer using MarkerClusterGroup
 tags:
   - plugins
 ---
-<script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-markercluster/v0.4.0/leaflet.markercluster.js'></script>
-<link href='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.css' rel='stylesheet' />
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/leaflet.markercluster.js'></script>
+<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.css' rel='stylesheet' />
 <link href='https:////api.tiles.mapbox.com/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.Default.css' rel='stylesheet' />
 
 <div id='map'></div>

--- a/docs/_posts/examples/v1.0.0/0100-01-01-markercluster-with-mapbox-data.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-markercluster-with-mapbox-data.html
@@ -9,7 +9,7 @@ tags:
 ---
 <script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/leaflet.markercluster.js'></script>
 <link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.css' rel='stylesheet' />
-<link href='https:////api.tiles.mapbox.com/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.Default.css' rel='stylesheet' />
+<link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.Default.css' rel='stylesheet' />
 
 <div id='map'></div>
 

--- a/docs/_posts/examples/v1.0.0/0100-01-01-markers-from-csv-custom-style.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-markers-from-csv-custom-style.html
@@ -7,7 +7,7 @@ description: Customize colors and icons of markers based on attributes in import
 tags:
   - omnivore
 ---
-<script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
 
 <div id='map'></div>
 

--- a/docs/_posts/examples/v1.0.0/0100-01-01-markers-from-csv-custom-style.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-markers-from-csv-custom-style.html
@@ -7,7 +7,7 @@ description: Customize colors and icons of markers based on attributes in import
 tags:
   - omnivore
 ---
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
 
 <div id='map'></div>
 

--- a/docs/_posts/examples/v1.0.0/0100-01-01-markers-from-csv.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-markers-from-csv.html
@@ -7,7 +7,7 @@ description: Using Leaflet Omnivore, Load and parse a CSV file containing latitu
 tags:
   - omnivore
 ---
-<script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
 
 <div id='map'></div>
 

--- a/docs/_posts/examples/v1.0.0/0100-01-01-markers-from-csv.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-markers-from-csv.html
@@ -7,7 +7,7 @@ description: Using Leaflet Omnivore, Load and parse a CSV file containing latitu
 tags:
   - omnivore
 ---
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
 
 <div id='map'></div>
 

--- a/docs/_posts/examples/v1.0.0/0100-01-01-omnivore-csv-simplestyle.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-omnivore-csv-simplestyle.html
@@ -7,7 +7,7 @@ description: Using Leaflet Omnivore and L.mapbox.featureLayer, apply style defin
 tags:
   - omnivore
 ---
-<script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
 
 <div id='map'></div>
 

--- a/docs/_posts/examples/v1.0.0/0100-01-01-omnivore-csv-simplestyle.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-omnivore-csv-simplestyle.html
@@ -7,7 +7,7 @@ description: Using Leaflet Omnivore and L.mapbox.featureLayer, apply style defin
 tags:
   - omnivore
 ---
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
 
 <div id='map'></div>
 

--- a/docs/_posts/examples/v1.0.0/0100-01-01-omnivore-custom-layer.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-omnivore-custom-layer.html
@@ -7,7 +7,7 @@ description: Pass additional data as a third argument in addition to what's load
 tags:
   - omnivore
 ---
-<script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
 
 <div id='map'></div>
 

--- a/docs/_posts/examples/v1.0.0/0100-01-01-omnivore-custom-layer.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-omnivore-custom-layer.html
@@ -7,7 +7,7 @@ description: Pass additional data as a third argument in addition to what's load
 tags:
   - omnivore
 ---
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
 
 <div id='map'></div>
 

--- a/docs/_posts/examples/v1.0.0/0100-01-01-omnivore-gpx.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-omnivore-gpx.html
@@ -7,7 +7,7 @@ description: Load and parse GPX data as a layer on a map.
 tags:
   - omnivore
 ---
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
 
 <div id='map'></div>
 

--- a/docs/_posts/examples/v1.0.0/0100-01-01-omnivore-gpx.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-omnivore-gpx.html
@@ -7,7 +7,7 @@ description: Load and parse GPX data as a layer on a map.
 tags:
   - omnivore
 ---
-<script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
 
 <div id='map'></div>
 

--- a/docs/_posts/examples/v1.0.0/0100-01-01-omnivore-kml-tooltip.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-omnivore-kml-tooltip.html
@@ -8,7 +8,7 @@ tags:
   - features
   - omnivore
 ---
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
 
 <div id='map'></div>
 

--- a/docs/_posts/examples/v1.0.0/0100-01-01-omnivore-kml-tooltip.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-omnivore-kml-tooltip.html
@@ -8,7 +8,7 @@ tags:
   - features
   - omnivore
 ---
-<script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
 
 <div id='map'></div>
 

--- a/docs/_posts/examples/v1.0.0/0100-01-01-omnivore-kml.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-omnivore-kml.html
@@ -7,7 +7,7 @@ description: Load and parse KML data
 tags:
   - omnivore
 ---
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
 
 <div id='map'></div>
 

--- a/docs/_posts/examples/v1.0.0/0100-01-01-omnivore-kml.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-omnivore-kml.html
@@ -7,7 +7,7 @@ description: Load and parse KML data
 tags:
   - omnivore
 ---
-<script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
 
 <div id='map'></div>
 

--- a/docs/_posts/examples/v1.0.0/0100-01-01-omnivore-topojson.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-omnivore-topojson.html
@@ -7,7 +7,7 @@ description: Loading and parsing TopoJSON data with Leaflet-Omnivore
 tags:
   - omnivore
 ---
-<script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
 
 <div id='map'></div>
 

--- a/docs/_posts/examples/v1.0.0/0100-01-01-omnivore-topojson.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-omnivore-topojson.html
@@ -7,7 +7,7 @@ description: Loading and parsing TopoJSON data with Leaflet-Omnivore
 tags:
   - omnivore
 ---
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
 
 <div id='map'></div>
 

--- a/docs/_posts/examples/v1.0.0/0100-01-01-omnivore-wkt.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-omnivore-wkt.html
@@ -7,7 +7,7 @@ description: Loading and parsing WKT data with Leaflet-Omnivore
 tags:
   - omnivore
 ---
-<script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
 
 <div id='map'></div>
 

--- a/docs/_posts/examples/v1.0.0/0100-01-01-omnivore-wkt.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-omnivore-wkt.html
@@ -7,7 +7,7 @@ description: Loading and parsing WKT data with Leaflet-Omnivore
 tags:
   - omnivore
 ---
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
 
 <div id='map'></div>
 

--- a/docs/_posts/examples/v1.0.0/0100-01-01-point-in-polygon.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-point-in-polygon.html
@@ -34,7 +34,7 @@ tags:
   columns, and they must be similarly named.
 -->
 
-<script src='//api.tiles.mapbox.com/mapbox.js/plugins/leaflet-pip/v0.0.2/leaflet-pip.js'></script>
+<script src={{site.tileapi}}/mapbox.js/plugins/leaflet-pip/v0.0.2/leaflet-pip.js'></script>
 <div id='map'></div>
 <div id='state' class='state'></div>
 <script>

--- a/docs/_posts/examples/v1.0.0/0100-01-01-show-polygon-area.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-show-polygon-area.html
@@ -10,9 +10,9 @@ tags:
   - plugins
 ---
 
-<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-draw/v0.2.2/leaflet.draw.css' rel='stylesheet' />
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-draw/v0.2.2/leaflet.draw.js'></script>
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-geodesy/v0.1.0/leaflet-geodesy.js'></script>
+<link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-draw/v0.2.2/leaflet.draw.css' rel='stylesheet' />
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-draw/v0.2.2/leaflet.draw.js'></script>
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-geodesy/v0.1.0/leaflet-geodesy.js'></script>
 
 <div id='map'></div>
 

--- a/docs/_posts/examples/v1.0.0/0100-01-01-show-polygon-area.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-show-polygon-area.html
@@ -10,9 +10,9 @@ tags:
   - plugins
 ---
 
-<link href='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-draw/v0.2.2/leaflet.draw.css' rel='stylesheet' />
-<script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-draw/v0.2.2/leaflet.draw.js'></script>
-<script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-geodesy/v0.1.0/leaflet-geodesy.js'></script>
+<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-draw/v0.2.2/leaflet.draw.css' rel='stylesheet' />
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-draw/v0.2.2/leaflet.draw.js'></script>
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-geodesy/v0.1.0/leaflet-geodesy.js'></script>
 
 <div id='map'></div>
 

--- a/docs/_posts/examples/v1.0.0/0100-01-01-static-map-from-bounds-with-geo-viewport.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-static-map-from-bounds-with-geo-viewport.html
@@ -12,7 +12,7 @@ tags:
 <img id='static-map'></div>
 
 <!-- include the geo-viewport plugin -->
-<script src='https://api.tiles.mapbox.com/mapbox.js/plugins/geo-viewport/v0.1.1/geo-viewport.js'></script>
+<script src='{{site.tileApi}}/mapbox.js/plugins/geo-viewport/v0.1.1/geo-viewport.js'></script>
 
 <script>
 // This is an example using geo-viewport. See the full docs for full details
@@ -35,7 +35,7 @@ var vp = geoViewport.viewport(bounds, size);
 // Construct a static map url
 // https://www.mapbox.com/developers/api/static/
 document.getElementById('static-map').src =
-    'https://api.tiles.mapbox.com/v3/examples.map-zr0njcqy/' +
+    '{{site.tileApi}}/v3/examples.map-zr0njcqy/' +
     vp.center.join(',') + ',' +
     vp.zoom + '/' +
     size.join('x') + '.png';

--- a/docs/_posts/examples/v1.0.0/0100-01-01-static-map-from-bounds-with-geo-viewport.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-static-map-from-bounds-with-geo-viewport.html
@@ -12,7 +12,7 @@ tags:
 <img id='static-map'></div>
 
 <!-- include the geo-viewport plugin -->
-<script src='{{site.tileApi}}/mapbox.js/plugins/geo-viewport/v0.1.1/geo-viewport.js'></script>
+<script src='{{site.tileapi}}/mapbox.js/plugins/geo-viewport/v0.1.1/geo-viewport.js'></script>
 
 <script>
 // This is an example using geo-viewport. See the full docs for full details
@@ -35,7 +35,7 @@ var vp = geoViewport.viewport(bounds, size);
 // Construct a static map url
 // https://www.mapbox.com/developers/api/static/
 document.getElementById('static-map').src =
-    '{{site.tileApi}}/v3/examples.map-zr0njcqy/' +
+    '{{site.tileapi}}/v3/examples.map-zr0njcqy/' +
     vp.center.join(',') + ',' +
     vp.zoom + '/' +
     size.join('x') + '.png';

--- a/docs/_posts/examples/v1.0.0/0100-01-01-static-map-from-geojson-with-geo-viewport.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-static-map-from-geojson-with-geo-viewport.html
@@ -9,8 +9,8 @@ tags:
 ---
 <img id='static-map'></div>
 
-<script src='https://api.tiles.mapbox.com/mapbox.js/plugins/geo-viewport/v0.1.1/geo-viewport.js'></script>
-<script src='https://api.tiles.mapbox.com/mapbox.js/plugins/geojson-extent/v0.0.1/geojson-extent.js'></script>
+<script src='{{site.tileApi}}/mapbox.js/plugins/geo-viewport/v0.1.1/geo-viewport.js'></script>
+<script src='{{site.tileApi}}/mapbox.js/plugins/geojson-extent/v0.0.1/geojson-extent.js'></script>
 <script>
 
 // This is an example using geojson-extent. See the full docs for full details
@@ -63,7 +63,7 @@ for (var i = 0; i < sfAndDc.features.length; i++) {
 // Construct a static map url
 // https://www.mapbox.com/developers/api/static/
 document.getElementById('static-map').src =
-    'https://api.tiles.mapbox.com/v3/examples.map-i86nkdio/' +
+    '{{site.tileApi}}/v3/examples.map-i86nkdio/' +
     pins.join(',') + '/' +
     vp.center.join(',') + ',' +
     vp.zoom + '/' +

--- a/docs/_posts/examples/v1.0.0/0100-01-01-static-map-from-geojson-with-geo-viewport.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-static-map-from-geojson-with-geo-viewport.html
@@ -9,8 +9,8 @@ tags:
 ---
 <img id='static-map'></div>
 
-<script src='{{site.tileApi}}/mapbox.js/plugins/geo-viewport/v0.1.1/geo-viewport.js'></script>
-<script src='{{site.tileApi}}/mapbox.js/plugins/geojson-extent/v0.0.1/geojson-extent.js'></script>
+<script src='{{site.tileapi}}/mapbox.js/plugins/geo-viewport/v0.1.1/geo-viewport.js'></script>
+<script src='{{site.tileapi}}/mapbox.js/plugins/geojson-extent/v0.0.1/geojson-extent.js'></script>
 <script>
 
 // This is an example using geojson-extent. See the full docs for full details
@@ -63,7 +63,7 @@ for (var i = 0; i < sfAndDc.features.length; i++) {
 // Construct a static map url
 // https://www.mapbox.com/developers/api/static/
 document.getElementById('static-map').src =
-    '{{site.tileApi}}/v3/examples.map-i86nkdio/' +
+    '{{site.tileapi}}/v3/examples.map-i86nkdio/' +
     pins.join(',') + '/' +
     vp.center.join(',') + ',' +
     vp.zoom + '/' +

--- a/docs/_posts/examples/v1.0.0/0100-01-01-toggling-ui.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-toggling-ui.html
@@ -7,9 +7,9 @@ description: Enable or disable map UI controls.
 tags:
   - ui
 ---
-<link href='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-fullscreen/v0.0.3/leaflet.fullscreen.css' rel='stylesheet' />
-<script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-fullscreen/v0.0.3/Leaflet.fullscreen.min.js'></script>
-<script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-hash/v0.2.1/leaflet-hash.js'></script>
+<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-fullscreen/v0.0.3/leaflet.fullscreen.css' rel='stylesheet' />
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-fullscreen/v0.0.3/Leaflet.fullscreen.min.js'></script>
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-hash/v0.2.1/leaflet-hash.js'></script>
 
 <style>
 .menu-ui {

--- a/docs/_posts/examples/v1.0.0/0100-01-01-toggling-ui.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-toggling-ui.html
@@ -7,9 +7,9 @@ description: Enable or disable map UI controls.
 tags:
   - ui
 ---
-<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-fullscreen/v0.0.3/leaflet.fullscreen.css' rel='stylesheet' />
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-fullscreen/v0.0.3/Leaflet.fullscreen.min.js'></script>
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-hash/v0.2.1/leaflet-hash.js'></script>
+<link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-fullscreen/v0.0.3/leaflet.fullscreen.css' rel='stylesheet' />
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-fullscreen/v0.0.3/Leaflet.fullscreen.min.js'></script>
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-hash/v0.2.1/leaflet-hash.js'></script>
 
 <style>
 .menu-ui {

--- a/docs/_posts/plugins/0100-01-01-arcjs.html
+++ b/docs/_posts/plugins/0100-01-01-arcjs.html
@@ -8,6 +8,6 @@ tag:
     -bsd
 license: BSD
 snippet: |
-  <script src='https://api.tiles.mapbox.com/mapbox.js/plugins/arc.js/v0.1.0/arc.js'></script>
+  <script src='{{site.tileApi}}/mapbox.js/plugins/arc.js/v0.1.0/arc.js'></script>
 code: https://github.com/springmeyer/arc.js
 ---

--- a/docs/_posts/plugins/0100-01-01-arcjs.html
+++ b/docs/_posts/plugins/0100-01-01-arcjs.html
@@ -7,7 +7,6 @@ description: Draw great circles and geographical arcs
 tag:
     -bsd
 license: BSD
-snippet: |
-  <script src='{{site.tileapi}}/mapbox.js/plugins/arc.js/v0.1.0/arc.js'></script>
 code: https://github.com/springmeyer/arc.js
 ---
+<script src='{{site.tileapi}}/mapbox.js/plugins/arc.js/v0.1.0/arc.js'></script>

--- a/docs/_posts/plugins/0100-01-01-arcjs.html
+++ b/docs/_posts/plugins/0100-01-01-arcjs.html
@@ -8,6 +8,6 @@ tag:
     -bsd
 license: BSD
 snippet: |
-  <script src='{{site.tileApi}}/mapbox.js/plugins/arc.js/v0.1.0/arc.js'></script>
+  <script src='{{site.tileapi}}/mapbox.js/plugins/arc.js/v0.1.0/arc.js'></script>
 code: https://github.com/springmeyer/arc.js
 ---

--- a/docs/_posts/plugins/0100-01-01-geo-viewport.html
+++ b/docs/_posts/plugins/0100-01-01-geo-viewport.html
@@ -7,7 +7,7 @@ description: Transforms a bounding box into a zoom and centerpoint combination, 
 tags:
   - bsd
 snippet: |
-  <script src='https://api.tiles.mapbox.com/mapbox.js/plugins/geo-viewport/v0.1.1/geo-viewport.js'></script>
+  <script src='{{site.tileApi}}/mapbox.js/plugins/geo-viewport/v0.1.1/geo-viewport.js'></script>
 code: https://github.com/mapbox/geo-viewport
 license: ISC
 ---

--- a/docs/_posts/plugins/0100-01-01-geo-viewport.html
+++ b/docs/_posts/plugins/0100-01-01-geo-viewport.html
@@ -6,8 +6,7 @@ prefix: static-map-from-bounds-with-geo-viewport
 description: Transforms a bounding box into a zoom and centerpoint combination, useful for combination with our Static Maps web service
 tags:
   - bsd
-snippet: |
-  <script src='{{site.tileapi}}/mapbox.js/plugins/geo-viewport/v0.1.1/geo-viewport.js'></script>
 code: https://github.com/mapbox/geo-viewport
 license: ISC
 ---
+<script src='{{site.tileapi}}/mapbox.js/plugins/geo-viewport/v0.1.1/geo-viewport.js'></script>

--- a/docs/_posts/plugins/0100-01-01-geo-viewport.html
+++ b/docs/_posts/plugins/0100-01-01-geo-viewport.html
@@ -7,7 +7,7 @@ description: Transforms a bounding box into a zoom and centerpoint combination, 
 tags:
   - bsd
 snippet: |
-  <script src='{{site.tileApi}}/mapbox.js/plugins/geo-viewport/v0.1.1/geo-viewport.js'></script>
+  <script src='{{site.tileapi}}/mapbox.js/plugins/geo-viewport/v0.1.1/geo-viewport.js'></script>
 code: https://github.com/mapbox/geo-viewport
 license: ISC
 ---

--- a/docs/_posts/plugins/0100-01-01-geojson-extent.html
+++ b/docs/_posts/plugins/0100-01-01-geojson-extent.html
@@ -7,7 +7,7 @@ description: Calculate the bounding box of a GeoJSON object
 tags:
   - bsd
 snippet: |
-  <script src='https://api.tiles.mapbox.com/mapbox.js/plugins/geojson-extent/v0.0.1/geojson-extent.js'></script>
+  <script src='{{site.tileApi}}/mapbox.js/plugins/geojson-extent/v0.0.1/geojson-extent.js'></script>
 code: https://github.com/mapbox/geojson-extent
 license: ISC
 ---

--- a/docs/_posts/plugins/0100-01-01-geojson-extent.html
+++ b/docs/_posts/plugins/0100-01-01-geojson-extent.html
@@ -6,8 +6,7 @@ prefix: static-map-from-geojson-with-geo-viewport
 description: Calculate the bounding box of a GeoJSON object
 tags:
   - bsd
-snippet: |
-  <script src='{{site.tileapi}}/mapbox.js/plugins/geojson-extent/v0.0.1/geojson-extent.js'></script>
 code: https://github.com/mapbox/geojson-extent
 license: ISC
 ---
+<script src='{{site.tileapi}}/mapbox.js/plugins/geojson-extent/v0.0.1/geojson-extent.js'></script>

--- a/docs/_posts/plugins/0100-01-01-geojson-extent.html
+++ b/docs/_posts/plugins/0100-01-01-geojson-extent.html
@@ -7,7 +7,7 @@ description: Calculate the bounding box of a GeoJSON object
 tags:
   - bsd
 snippet: |
-  <script src='{{site.tileApi}}/mapbox.js/plugins/geojson-extent/v0.0.1/geojson-extent.js'></script>
+  <script src='{{site.tileapi}}/mapbox.js/plugins/geojson-extent/v0.0.1/geojson-extent.js'></script>
 code: https://github.com/mapbox/geojson-extent
 license: ISC
 ---

--- a/docs/_posts/plugins/0100-01-01-leaflet-draw.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-draw.html
@@ -7,8 +7,8 @@ description: Adds a toolbar that allows users to draw points, lines, and polygon
 tags:
   - bsd
 snippet: |
-  <script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-draw/v0.2.2/leaflet.draw.js'></script>
-  <link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-draw/v0.2.2/leaflet.draw.css' rel='stylesheet' />
+  <script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-draw/v0.2.2/leaflet.draw.js'></script>
+  <link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-draw/v0.2.2/leaflet.draw.css' rel='stylesheet' />
 code: https://github.com/Leaflet/Leaflet.draw
 license: BSD
 ---

--- a/docs/_posts/plugins/0100-01-01-leaflet-draw.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-draw.html
@@ -6,9 +6,8 @@ prefix: leaflet-draw
 description: Adds a toolbar that allows users to draw points, lines, and polygons on the map.
 tags:
   - bsd
-snippet: |
-  <script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-draw/v0.2.2/leaflet.draw.js'></script>
-  <link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-draw/v0.2.2/leaflet.draw.css' rel='stylesheet' />
 code: https://github.com/Leaflet/Leaflet.draw
 license: BSD
 ---
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-draw/v0.2.2/leaflet.draw.js'></script>
+<link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-draw/v0.2.2/leaflet.draw.css' rel='stylesheet' />

--- a/docs/_posts/plugins/0100-01-01-leaflet-draw.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-draw.html
@@ -7,8 +7,8 @@ description: Adds a toolbar that allows users to draw points, lines, and polygon
 tags:
   - bsd
 snippet: |
-  <script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-draw/v0.2.2/leaflet.draw.js'></script>
-  <link href='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-draw/v0.2.2/leaflet.draw.css' rel='stylesheet' />
+  <script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-draw/v0.2.2/leaflet.draw.js'></script>
+  <link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-draw/v0.2.2/leaflet.draw.css' rel='stylesheet' />
 code: https://github.com/Leaflet/Leaflet.draw
 license: BSD
 ---

--- a/docs/_posts/plugins/0100-01-01-leaflet-fullscreen.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-fullscreen.html
@@ -7,8 +7,8 @@ description: Adds a button to your map that enables it to fill the screen using 
 tags:
   - bsd
 snippet: |
-  <script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-fullscreen/v0.0.3/Leaflet.fullscreen.min.js'></script>
-  <link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-fullscreen/v0.0.3/leaflet.fullscreen.css' rel='stylesheet' />
+  <script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-fullscreen/v0.0.3/Leaflet.fullscreen.min.js'></script>
+  <link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-fullscreen/v0.0.3/leaflet.fullscreen.css' rel='stylesheet' />
 code: https://github.com/mapbox/leaflet.fullscreen
 license: BSD
 ---

--- a/docs/_posts/plugins/0100-01-01-leaflet-fullscreen.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-fullscreen.html
@@ -6,9 +6,8 @@ prefix: leaflet-fullscreen
 description: Adds a button to your map that enables it to fill the screen using the HTML5 Fullscreen API.
 tags:
   - bsd
-snippet: |
-  <script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-fullscreen/v0.0.3/Leaflet.fullscreen.min.js'></script>
-  <link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-fullscreen/v0.0.3/leaflet.fullscreen.css' rel='stylesheet' />
 code: https://github.com/mapbox/leaflet.fullscreen
 license: BSD
 ---
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-fullscreen/v0.0.3/Leaflet.fullscreen.min.js'></script>
+<link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-fullscreen/v0.0.3/leaflet.fullscreen.css' rel='stylesheet' />

--- a/docs/_posts/plugins/0100-01-01-leaflet-fullscreen.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-fullscreen.html
@@ -7,8 +7,8 @@ description: Adds a button to your map that enables it to fill the screen using 
 tags:
   - bsd
 snippet: |
-  <script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-fullscreen/v0.0.3/Leaflet.fullscreen.min.js'></script>
-  <link href='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-fullscreen/v0.0.3/leaflet.fullscreen.css' rel='stylesheet' />
+  <script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-fullscreen/v0.0.3/Leaflet.fullscreen.min.js'></script>
+  <link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-fullscreen/v0.0.3/leaflet.fullscreen.css' rel='stylesheet' />
 code: https://github.com/mapbox/leaflet.fullscreen
 license: BSD
 ---

--- a/docs/_posts/plugins/0100-01-01-leaflet-geodesy.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-geodesy.html
@@ -7,7 +7,7 @@ description: Supports drawing geodesic circles and measuring real area of vector
 tags:
   - bsd
 snippet: |
-  <script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-geodesy/v0.1.0/leaflet-geodesy.js'></script>
+  <script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-geodesy/v0.1.0/leaflet-geodesy.js'></script>
 code: https://github.com/mapbox/leaflet-geodesy
 license: BSD
 ---

--- a/docs/_posts/plugins/0100-01-01-leaflet-geodesy.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-geodesy.html
@@ -7,7 +7,7 @@ description: Supports drawing geodesic circles and measuring real area of vector
 tags:
   - bsd
 snippet: |
-  <script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-geodesy/v0.1.0/leaflet-geodesy.js'></script>
+  <script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-geodesy/v0.1.0/leaflet-geodesy.js'></script>
 code: https://github.com/mapbox/leaflet-geodesy
 license: BSD
 ---

--- a/docs/_posts/plugins/0100-01-01-leaflet-geodesy.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-geodesy.html
@@ -6,8 +6,7 @@ prefix: leaflet-geodesy
 description: Supports drawing geodesic circles and measuring real area of vectors
 tags:
   - bsd
-snippet: |
-  <script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-geodesy/v0.1.0/leaflet-geodesy.js'></script>
 code: https://github.com/mapbox/leaflet-geodesy
 license: BSD
 ---
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-geodesy/v0.1.0/leaflet-geodesy.js'></script>

--- a/docs/_posts/plugins/0100-01-01-leaflet-hash.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-hash.html
@@ -6,8 +6,7 @@ prefix: leaflet-hash
 description: Adds information to the URL in your browser that makes it easy to link to specific map views.
 tags:
   - bsd
-snippet: |
-  <script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-hash/v0.2.1/leaflet-hash.js'></script>
 code: https://github.com/mlevans/leaflet-hash
 license: BSD
 ---
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-hash/v0.2.1/leaflet-hash.js'></script>

--- a/docs/_posts/plugins/0100-01-01-leaflet-hash.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-hash.html
@@ -7,7 +7,7 @@ description: Adds information to the URL in your browser that makes it easy to l
 tags:
   - bsd
 snippet: |
-  <script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-hash/v0.2.1/leaflet-hash.js'></script>
+  <script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-hash/v0.2.1/leaflet-hash.js'></script>
 code: https://github.com/mlevans/leaflet-hash
 license: BSD
 ---

--- a/docs/_posts/plugins/0100-01-01-leaflet-hash.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-hash.html
@@ -7,7 +7,7 @@ description: Adds information to the URL in your browser that makes it easy to l
 tags:
   - bsd
 snippet: |
-  <script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-hash/v0.2.1/leaflet-hash.js'></script>
+  <script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-hash/v0.2.1/leaflet-hash.js'></script>
 code: https://github.com/mlevans/leaflet-hash
 license: BSD
 ---

--- a/docs/_posts/plugins/0100-01-01-leaflet-heat.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-heat.html
@@ -7,7 +7,7 @@ description: Creates a heatmap visualization from a set of points.
 tags:
   - bsd
 snippet: |
-  <script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-heat/v0.1.0/leaflet-heat.js'></script>
+  <script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-heat/v0.1.0/leaflet-heat.js'></script>
 code: https://github.com/Leaflet/Leaflet.heat
 license: BSD
 ---

--- a/docs/_posts/plugins/0100-01-01-leaflet-heat.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-heat.html
@@ -6,8 +6,7 @@ prefix: leaflet-heat
 description: Creates a heatmap visualization from a set of points.
 tags:
   - bsd
-snippet: |
-  <script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-heat/v0.1.0/leaflet-heat.js'></script>
 code: https://github.com/Leaflet/Leaflet.heat
 license: BSD
 ---
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-heat/v0.1.0/leaflet-heat.js'></script>

--- a/docs/_posts/plugins/0100-01-01-leaflet-heat.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-heat.html
@@ -7,7 +7,7 @@ description: Creates a heatmap visualization from a set of points.
 tags:
   - bsd
 snippet: |
-  <script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-heat/v0.1.0/leaflet-heat.js'></script>
+  <script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-heat/v0.1.0/leaflet-heat.js'></script>
 code: https://github.com/Leaflet/Leaflet.heat
 license: BSD
 ---

--- a/docs/_posts/plugins/0100-01-01-leaflet-image.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-image.html
@@ -7,7 +7,6 @@ description: Export images out of Leaflet maps without a server component.
 tag:
     -bsd
 license: BSD 2-Clause
-snippet: |
-  <script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-image/v0.0.3/leaflet-image.js'></script>
 code: https://github.com/mapbox/leaflet-image
 ---
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-image/v0.0.3/leaflet-image.js'></script>

--- a/docs/_posts/plugins/0100-01-01-leaflet-image.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-image.html
@@ -8,6 +8,6 @@ tag:
     -bsd
 license: BSD 2-Clause
 snippet: |
-  <script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-image/v0.0.3/leaflet-image.js'></script>
+  <script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-image/v0.0.3/leaflet-image.js'></script>
 code: https://github.com/mapbox/leaflet-image
 ---

--- a/docs/_posts/plugins/0100-01-01-leaflet-image.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-image.html
@@ -8,6 +8,6 @@ tag:
     -bsd
 license: BSD 2-Clause
 snippet: |
-  <script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-image/v0.0.3/leaflet-image.js'></script>
+  <script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-image/v0.0.3/leaflet-image.js'></script>
 code: https://github.com/mapbox/leaflet-image
 ---

--- a/docs/_posts/plugins/0100-01-01-leaflet-label.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-label.html
@@ -7,8 +7,8 @@ description: Adds labels to markers and other vector layers that can be shown wh
 tags:
   - mit
 snippet: |
-  <script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-label/v0.2.1/leaflet.label.js'></script>
-  <link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-label/v0.2.1/leaflet.label.css' rel='stylesheet' />
+  <script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-label/v0.2.1/leaflet.label.js'></script>
+  <link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-label/v0.2.1/leaflet.label.css' rel='stylesheet' />
 code: https://github.com/Leaflet/Leaflet.label
 license: MIT
 ---

--- a/docs/_posts/plugins/0100-01-01-leaflet-label.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-label.html
@@ -7,8 +7,8 @@ description: Adds labels to markers and other vector layers that can be shown wh
 tags:
   - mit
 snippet: |
-  <script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-label/v0.2.1/leaflet.label.js'></script>
-  <link href='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-label/v0.2.1/leaflet.label.css' rel='stylesheet' />
+  <script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-label/v0.2.1/leaflet.label.js'></script>
+  <link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-label/v0.2.1/leaflet.label.css' rel='stylesheet' />
 code: https://github.com/Leaflet/Leaflet.label
 license: MIT
 ---

--- a/docs/_posts/plugins/0100-01-01-leaflet-label.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-label.html
@@ -6,9 +6,8 @@ prefix: leaflet-label
 description: Adds labels to markers and other vector layers that can be shown when hovering over that item or bound to other JavaScript events.
 tags:
   - mit
-snippet: |
-  <script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-label/v0.2.1/leaflet.label.js'></script>
-  <link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-label/v0.2.1/leaflet.label.css' rel='stylesheet' />
 code: https://github.com/Leaflet/Leaflet.label
 license: MIT
 ---
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-label/v0.2.1/leaflet.label.js'></script>
+<link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-label/v0.2.1/leaflet.label.css' rel='stylesheet' />

--- a/docs/_posts/plugins/0100-01-01-leaflet-locate.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-locate.html
@@ -7,10 +7,10 @@ description: Adds a button to your map that finds the user's location using the 
 tags:
   - mit
 snippet: |
-  <script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-locatecontrol/v0.24.0/L.Control.Locate.js'></script>
-  <link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-locatecontrol/v0.24.0/L.Control.Locate.css' rel='stylesheet' />
+  <script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-locatecontrol/v0.24.0/L.Control.Locate.js'></script>
+  <link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-locatecontrol/v0.24.0/L.Control.Locate.css' rel='stylesheet' />
   <!--[if lt IE 9]>
-    <link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-locatecontrol/v0.21.0/L.Control.Locate.ie.css' rel='stylesheet' />
+    <link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-locatecontrol/v0.21.0/L.Control.Locate.ie.css' rel='stylesheet' />
   <![endif]-->
 code: https://github.com/domoritz/leaflet-locatecontrol
 license: MIT

--- a/docs/_posts/plugins/0100-01-01-leaflet-locate.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-locate.html
@@ -6,12 +6,11 @@ prefix: leaflet-locatecontrol
 description: Adds a button to your map that finds the user's location using the HTML5 Geolocation API.
 tags:
   - mit
-snippet: |
-  <script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-locatecontrol/v0.24.0/L.Control.Locate.js'></script>
-  <link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-locatecontrol/v0.24.0/L.Control.Locate.css' rel='stylesheet' />
-  <!--[if lt IE 9]>
-    <link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-locatecontrol/v0.21.0/L.Control.Locate.ie.css' rel='stylesheet' />
-  <![endif]-->
 code: https://github.com/domoritz/leaflet-locatecontrol
 license: MIT
 ---
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-locatecontrol/v0.24.0/L.Control.Locate.js'></script>
+<link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-locatecontrol/v0.24.0/L.Control.Locate.css' rel='stylesheet' />
+<!--[if lt IE 9]>
+  <link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-locatecontrol/v0.21.0/L.Control.Locate.ie.css' rel='stylesheet' />
+<![endif]-->

--- a/docs/_posts/plugins/0100-01-01-leaflet-locate.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-locate.html
@@ -7,10 +7,10 @@ description: Adds a button to your map that finds the user's location using the 
 tags:
   - mit
 snippet: |
-  <script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-locatecontrol/v0.24.0/L.Control.Locate.js'></script>
-  <link href='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-locatecontrol/v0.24.0/L.Control.Locate.css' rel='stylesheet' />
+  <script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-locatecontrol/v0.24.0/L.Control.Locate.js'></script>
+  <link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-locatecontrol/v0.24.0/L.Control.Locate.css' rel='stylesheet' />
   <!--[if lt IE 9]>
-    <link href='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-locatecontrol/v0.21.0/L.Control.Locate.ie.css' rel='stylesheet' />
+    <link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-locatecontrol/v0.21.0/L.Control.Locate.ie.css' rel='stylesheet' />
   <![endif]-->
 code: https://github.com/domoritz/leaflet-locatecontrol
 license: MIT

--- a/docs/_posts/plugins/0100-01-01-leaflet-markercluster.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-markercluster.html
@@ -7,9 +7,9 @@ description: Groups nearby markers into clusters to unclutter the map. Clicking 
 tags:
   - mit
 snippet: |
-  <script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/leaflet.markercluster.js'></script>
-  <link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.css' rel='stylesheet' />
-  <link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.Default.css' rel='stylesheet' />
+  <script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/leaflet.markercluster.js'></script>
+  <link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.css' rel='stylesheet' />
+  <link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.Default.css' rel='stylesheet' />
 code: https://github.com/Leaflet/Leaflet.markercluster
 license: MIT
 ---

--- a/docs/_posts/plugins/0100-01-01-leaflet-markercluster.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-markercluster.html
@@ -6,10 +6,9 @@ prefix: leaflet-markercluster
 description: Groups nearby markers into clusters to unclutter the map. Clicking a cluster reveals all the markers in that area.
 tags:
   - mit
-snippet: |
-  <script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/leaflet.markercluster.js'></script>
-  <link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.css' rel='stylesheet' />
-  <link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.Default.css' rel='stylesheet' />
 code: https://github.com/Leaflet/Leaflet.markercluster
 license: MIT
 ---
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/leaflet.markercluster.js'></script>
+<link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.css' rel='stylesheet' />
+<link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.Default.css' rel='stylesheet' />

--- a/docs/_posts/plugins/0100-01-01-leaflet-markercluster.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-markercluster.html
@@ -7,9 +7,9 @@ description: Groups nearby markers into clusters to unclutter the map. Clicking 
 tags:
   - mit
 snippet: |
-  <script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-markercluster/v0.4.0/leaflet.markercluster.js'></script>
-  <link href='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.css' rel='stylesheet' />
-  <link href='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.Default.css' rel='stylesheet' />
+  <script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/leaflet.markercluster.js'></script>
+  <link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.css' rel='stylesheet' />
+  <link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.Default.css' rel='stylesheet' />
 code: https://github.com/Leaflet/Leaflet.markercluster
 license: MIT
 ---

--- a/docs/_posts/plugins/0100-01-01-leaflet-minimap.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-minimap.html
@@ -7,8 +7,8 @@ description: Provides an small overview map that gives context for the current m
 tags:
   - bsd
 snippet: |
-  <script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-minimap/v1.0.0/Control.MiniMap.js'></script>
-  <link href='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-minimap/v1.0.0/Control.MiniMap.css' rel='stylesheet' />
+  <script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-minimap/v1.0.0/Control.MiniMap.js'></script>
+  <link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-minimap/v1.0.0/Control.MiniMap.css' rel='stylesheet' />
 code: https://github.com/Norkart/Leaflet-MiniMap
 license: BSD
 ---

--- a/docs/_posts/plugins/0100-01-01-leaflet-minimap.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-minimap.html
@@ -6,9 +6,8 @@ prefix: leaflet-minimap
 description: Provides an small overview map that gives context for the current map view
 tags:
   - bsd
-snippet: |
-  <script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-minimap/v1.0.0/Control.MiniMap.js'></script>
-  <link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-minimap/v1.0.0/Control.MiniMap.css' rel='stylesheet' />
 code: https://github.com/Norkart/Leaflet-MiniMap
 license: BSD
 ---
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-minimap/v1.0.0/Control.MiniMap.js'></script>
+<link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-minimap/v1.0.0/Control.MiniMap.css' rel='stylesheet' />

--- a/docs/_posts/plugins/0100-01-01-leaflet-minimap.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-minimap.html
@@ -7,8 +7,8 @@ description: Provides an small overview map that gives context for the current m
 tags:
   - bsd
 snippet: |
-  <script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-minimap/v1.0.0/Control.MiniMap.js'></script>
-  <link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-minimap/v1.0.0/Control.MiniMap.css' rel='stylesheet' />
+  <script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-minimap/v1.0.0/Control.MiniMap.js'></script>
+  <link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-minimap/v1.0.0/Control.MiniMap.css' rel='stylesheet' />
 code: https://github.com/Norkart/Leaflet-MiniMap
 license: BSD
 ---

--- a/docs/_posts/plugins/0100-01-01-leaflet-omnivore.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-omnivore.html
@@ -7,8 +7,7 @@ example: markers-from-csv/
 description: Loads and parses KML, CSV, GPX, GeoJSON, and TopoJSON formats
 tags:
   - bsd
-snippet: |
-  <script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
 code: https://github.com/mapbox/leaflet-omnivore
 license: BSD
 ---
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>

--- a/docs/_posts/plugins/0100-01-01-leaflet-omnivore.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-omnivore.html
@@ -8,7 +8,7 @@ description: Loads and parses KML, CSV, GPX, GeoJSON, and TopoJSON formats
 tags:
   - bsd
 snippet: |
-  <script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
+  <script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
 code: https://github.com/mapbox/leaflet-omnivore
 license: BSD
 ---

--- a/docs/_posts/plugins/0100-01-01-leaflet-omnivore.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-omnivore.html
@@ -8,7 +8,7 @@ description: Loads and parses KML, CSV, GPX, GeoJSON, and TopoJSON formats
 tags:
   - bsd
 snippet: |
-  <script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
+  <script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
 code: https://github.com/mapbox/leaflet-omnivore
 license: BSD
 ---

--- a/docs/_posts/plugins/0100-01-01-leaflet-osm.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-osm.html
@@ -7,7 +7,7 @@ description: A convenient way of rendering tiles and vector data from OpenStreet
 tags:
   - bsd
 snippet: |
-    <script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-osm/v0.1.0/leaflet-osm.js'></script>
+    <script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-osm/v0.1.0/leaflet-osm.js'></script>
 code: https://github.com/jfirebaugh/leaflet-osm
 license: BSD
 ---

--- a/docs/_posts/plugins/0100-01-01-leaflet-osm.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-osm.html
@@ -6,8 +6,7 @@ prefix: leaflet-osm
 description: A convenient way of rendering tiles and vector data from OpenStreetMap.org.
 tags:
   - bsd
-snippet: |
-    <script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-osm/v0.1.0/leaflet-osm.js'></script>
 code: https://github.com/jfirebaugh/leaflet-osm
 license: BSD
 ---
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-osm/v0.1.0/leaflet-osm.js'></script>

--- a/docs/_posts/plugins/0100-01-01-leaflet-osm.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-osm.html
@@ -7,7 +7,7 @@ description: A convenient way of rendering tiles and vector data from OpenStreet
 tags:
   - bsd
 snippet: |
-    <script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-osm/v0.1.0/leaflet-osm.js'></script>
+    <script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-osm/v0.1.0/leaflet-osm.js'></script>
 code: https://github.com/jfirebaugh/leaflet-osm
 license: BSD
 ---

--- a/docs/_posts/plugins/0100-01-01-leaflet-pip.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-pip.html
@@ -7,7 +7,7 @@ description: Supports point-in-polygon queries
 tags:
   - bsd
 snippet: |
-  <script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-pip/v0.0.2/leaflet-pip.js'></script>
+  <script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-pip/v0.0.2/leaflet-pip.js'></script>
 code: https://github.com/mapbox/leaflet-pip
 license: BSD
 ---

--- a/docs/_posts/plugins/0100-01-01-leaflet-pip.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-pip.html
@@ -6,8 +6,7 @@ prefix: point-in-polygon
 description: Supports point-in-polygon queries
 tags:
   - bsd
-snippet: |
-  <script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-pip/v0.0.2/leaflet-pip.js'></script>
 code: https://github.com/mapbox/leaflet-pip
 license: BSD
 ---
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-pip/v0.0.2/leaflet-pip.js'></script>

--- a/docs/_posts/plugins/0100-01-01-leaflet-pip.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-pip.html
@@ -7,7 +7,7 @@ description: Supports point-in-polygon queries
 tags:
   - bsd
 snippet: |
-  <script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-pip/v0.0.2/leaflet-pip.js'></script>
+  <script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-pip/v0.0.2/leaflet-pip.js'></script>
 code: https://github.com/mapbox/leaflet-pip
 license: BSD
 ---

--- a/docs/_posts/plugins/0100-01-01-leaflet-zoomslider.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-zoomslider.html
@@ -7,8 +7,8 @@ description: Adds a vertical slider that allows for greater control when picking
 tags:
   - bsd
 snippet: |
-  <script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-zoomslider/v0.7.0/L.Control.Zoomslider.js'></script>
-  <link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-zoomslider/v0.7.0/L.Control.Zoomslider.css' rel='stylesheet' />
+  <script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-zoomslider/v0.7.0/L.Control.Zoomslider.js'></script>
+  <link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-zoomslider/v0.7.0/L.Control.Zoomslider.css' rel='stylesheet' />
 code: https://github.com/kartena/Leaflet.zoomslider
 license: BSD
 ---

--- a/docs/_posts/plugins/0100-01-01-leaflet-zoomslider.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-zoomslider.html
@@ -7,8 +7,8 @@ description: Adds a vertical slider that allows for greater control when picking
 tags:
   - bsd
 snippet: |
-  <script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-zoomslider/v0.7.0/L.Control.Zoomslider.js'></script>
-  <link href='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-zoomslider/v0.7.0/L.Control.Zoomslider.css' rel='stylesheet' />
+  <script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-zoomslider/v0.7.0/L.Control.Zoomslider.js'></script>
+  <link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-zoomslider/v0.7.0/L.Control.Zoomslider.css' rel='stylesheet' />
 code: https://github.com/kartena/Leaflet.zoomslider
 license: BSD
 ---

--- a/docs/_posts/plugins/0100-01-01-leaflet-zoomslider.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-zoomslider.html
@@ -6,9 +6,8 @@ prefix: leaflet-zoomslider
 description: Adds a vertical slider that allows for greater control when picking a zoom level.
 tags:
   - bsd
-snippet: |
-  <script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-zoomslider/v0.7.0/L.Control.Zoomslider.js'></script>
-  <link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-zoomslider/v0.7.0/L.Control.Zoomslider.css' rel='stylesheet' />
 code: https://github.com/kartena/Leaflet.zoomslider
 license: BSD
 ---
+<script src='{{site.tileapi}}/mapbox.js/plugins/leaflet-zoomslider/v0.7.0/L.Control.Zoomslider.js'></script>
+<link href='{{site.tileapi}}/mapbox.js/plugins/leaflet-zoomslider/v0.7.0/L.Control.Zoomslider.css' rel='stylesheet' />

--- a/docs/plugins/index.html
+++ b/docs/plugins/index.html
@@ -16,7 +16,7 @@ title: Plugins
     </div>
   </div>
   <div class='col12 quiet-scroll fill-light'>
-<pre id='snippet-{{forloop.index}}' class='pad2 prettyprint'>{{ plugin.snippet | replace:'&','&amp;' | replace:'<','&lt;' | replace:'>', '&gt;'}}</pre>
+<pre id='snippet-{{forloop.index}}' class='pad2 prettyprint'>{{ plugin.content | replace:'&','&amp;' | replace:'<','&lt;' | replace:'>', '&gt;'}}</pre>
   </div>
 </div>
 {% endfor %}


### PR DESCRIPTION
The primary purpose of this is to make the docs configurable for different hostnames for [offline](https://github.com/mapbox/offline). Changing `tileapi` in _config.yml will update links and code in current documentation. This also standardizes URLs -- to this point they've been inconsistent in the documentation between `http` & `https`, `a.tiles.mapbox.com` & `api.tiles.mapbox.com`.

Other changes that had to be made: 
- Moved content from YAML front matter (`snippet`) to body in plugins; updated plugins/index.html accordingly
- Removed large blocks of `{% raw %}`/`{% endraw %}` and replaced only where necessary (`{{name}}` in L.mapbox.template) -- this was preventing {{site.tileapi}} from rendering (and 3 instances of {{site.defaultid}} that had slipped through in 1.5.0 documentation); changed generate.js accordingly
