### PR TITLE
Add mapbox directions in plugin listing and as an example.

### DIFF
--- a/docs/_posts/examples/v1.0.0/0100-01-01-mapbox-directions.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-mapbox-directions.html
@@ -1,0 +1,84 @@
+---
+layout: example
+categories: example/v1.0.0
+version: v1.0.0
+title: Mapbox Directions
+description: Use the mapbox-directions.js plugin to show results from the Mapbox Directions API
+tags:
+  - plugins
+  - mapbox-directions
+---
+<style>
+#inputs,
+#errors,
+#directions {
+    position: absolute;
+    width: 33.3333%;
+    max-width: 300px;
+    min-width: 200px;
+}
+
+#inputs {
+    z-index: 10;
+    top: 10px;
+    left: 10px;
+}
+
+#directions {
+    z-index: 99;
+    background: rgba(0,0,0,.8);
+    top: 0;
+    right: 0;
+    bottom: 0;
+    overflow: auto;
+}
+
+#errors {
+    z-index: 8;
+    opacity: 0;
+    padding: 10px;
+    border-radius: 0 0 3px 3px;
+    background: rgba(0,0,0,.25);
+    top: 90px;
+    left: 10px;
+}
+
+</style>
+
+<script src='{{site.tileapi}}/mapbox.js/plugins/mapbox-directions.js/v0.0.1/mapbox.directions.js'></script>
+<link rel='stylesheet' href='{{site.tileapi}}/mapbox.js/plugins/mapbox-directions.js/v0.0.1/mapbox.directions.css' type='text/css' />
+
+<div id='map'></div>
+<div id='inputs'></div>
+<div id='errors'></div>
+<div id='directions'>
+  <div id='routes'></div>
+  <div id='instructions'></div>
+</div>
+<script>
+var map = L.mapbox.map('map', 'examples.map-i86nkdio', {
+    zoomControl: false
+}).setView([40, -74.50], 9);
+
+// move the attribution control out of the way
+map.attributionControl.setPosition('bottomleft');
+
+// create the initial directions object, from which the layer
+// and inputs will pull data.
+var directions = L.mapbox.directions();
+
+var directionsLayer = L.mapbox.directions.layer(directions)
+    .addTo(map);
+
+var directionsInputControl = L.mapbox.directions.inputControl('inputs', directions)
+    .addTo(map);
+
+var directionsErrorsControl = L.mapbox.directions.errorsControl('errors', directions)
+    .addTo(map);
+
+var directionsRoutesControl = L.mapbox.directions.routesControl('routes', directions)
+    .addTo(map);
+
+var directionsInstructionsControl = L.mapbox.directions.instructionsControl('instructions', directions)
+    .addTo(map);
+</script>

--- a/docs/_posts/plugins/0100-01-01-mapbox-directions.html
+++ b/docs/_posts/plugins/0100-01-01-mapbox-directions.html
@@ -1,0 +1,13 @@
+---
+layout: default
+categories: plugin
+title: mapbox-directions.js
+prefix: mapbox-directions
+description: Draw and drive routes with the Mapbox Directions API
+tags:
+  - bsd
+code: https://github.com/mapbox/mapbox-directions.js
+license: BSD
+---
+<script src='{{site.tileapi}}/mapbox.js/plugins/mapbox-directions.js/v0.0.1/mapbox.directions.js'></script>
+<link href='{{site.tileapi}}/mapbox.js/plugins/mapbox-directions.js/v0.0.1/mapbox.directions.css' rel='stylesheet' type='text/css' />


### PR DESCRIPTION
Good to go except that the api token that examples get isn't directions-enabled.
