### PR TITLE
fix for old documentation redirects. doesnt break links on new versions

### DIFF
--- a/docs/_layouts/api.html
+++ b/docs/_layouts/api.html
@@ -10,7 +10,7 @@ layout: pages
 {% if page.splash %}
 {{site.baseurl}}/api/{{site.mapboxjs}}/
 {% else %}
-{{site.baseurl}}/api/{{site.mapboxjs}}/{{page.url | split:'/' | last}}/
+{{site.baseurl}}/api/{{site.mapboxjs}}/
 {% endif %}
 {% endcapture %}
 


### PR DESCRIPTION
In the mapbox js api docs the redirect for older versions is broken (https://github.com/mapbox/mapbox.js/issues/883). this fixes that.
