### PR TITLE
Remove examples/redirects/v0.6.7

### DIFF
--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-auto.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-auto.html
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: /example/v1.0.0/
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-centering-markers.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-centering-markers.html
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: /example/v1.0.0/
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-custom-marker-tooltip.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-custom-marker-tooltip.html
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: /example/v1.0.0/
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-custom-marker.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-custom-marker.html
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: /example/v1.0.0/
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-cycle-markers.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-cycle-markers.html
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: /example/v1.0.0/
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-disable-zooming-and-panning.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-disable-zooming-and-panning.html
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: /example/v1.0.0/
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-easing.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-easing.html
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect: /example/v0.6.7/easing/
-categories: example
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-external-layers.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-external-layers.html
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: /example/v1.0.0/
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-external-marker-tooltip.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-external-marker-tooltip.html
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect: /example/v0.6.7/external-marker-toolip/
-categories: example
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-geocoding.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-geocoding.html
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: /example/v1.0.0/
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-geolocation.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-geolocation.html
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: /example/v1.0.0/
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-interactive-custom-template.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-interactive-custom-template.html
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect: /example/v0.6.7/interactive-custom-template/
-categories: example
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-interactive-external.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-interactive-external.html
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect: /example/v0.6.7/interactive-external/
-categories: example
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-interactive-layer-mapbox-layer.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-interactive-layer-mapbox-layer.html
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect: /example/v0.6.7/interactive-layer-mapbox-layer/
-categories: example
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-interactive-layer.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-interactive-layer.html
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect: /example/v0.6.7/interactive-layer/
-categories: example
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-layers.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-layers.html
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: /example/v1.0.0/
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-linking-to-external-data.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-linking-to-external-data.html
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: /example/v1.0.0/
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-listing-markers-in-view.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-listing-markers-in-view.html
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: /example/v1.0.0/
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-load.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-load.html
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect: /example/v0.6.7/load/
-categories: example
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-marker-movement.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-marker-movement.html
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: /example/v1.0.0/
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-markers-load.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-markers-load.html
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect: /example/v0.6.7/markers-load/
-categories: example
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-mouse-position.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-mouse-position.html
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: /example/v1.0.0/
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-navigating-to-marker-urls.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-navigating-to-marker-urls.html
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect: /example/v0.6.7/navigating-to-marker-urls/
-categories: example
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-non-exclusive-markers.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-non-exclusive-markers.html
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: /example/v1.0.0/
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-opacity.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-opacity.html
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: /example/v1.0.0/
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-optimal-easing.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-optimal-easing.html
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect: /example/v0.6.7/optimal-easing/
-categories: example
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-pan-and-vertical-zoom.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-pan-and-vertical-zoom.html
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: /example/v1.0.0/
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-retina.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-retina.html
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: /example/v1.0.0/
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-simple-filtering.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-simple-filtering.html
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: /example/v1.0.0/
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-simple-map.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-simple-map.html
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: /example/v1.0.0/
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-single-marker.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-single-marker.html
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: /example/v1.0.0/
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-swipe-layers.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-swipe-layers.html
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect: /example/v0.6.7/swipe-layers/
-categories: example
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-ui.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-ui.html
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect: /example/v0.6.7/ui/
-categories: example
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-vectors-with-d3.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-vectors-with-d3.html
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect: /example/v0.6.7/vectors-with-d3/
-categories: example
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-wms.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-wms.html
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: /example/v1.0.0/
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-youtube-embed.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-youtube-embed.html
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: /example/v1.0.0/
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-zoom-bar.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-zoom-bar.html
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: /example/v1.0.0/
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-zoom-lense.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-zoom-lense.html
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: /example/v1.0.0/
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-01-zoomer-style.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-01-zoomer-style.html
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect: /example/v0.6.7/zoomer-style/
-categories: example
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-02-marker-csv.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-02-marker-csv.html
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect: /example/v0.6.7/marker-csv/
-categories: example
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-02-toggling-ui.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-02-toggling-ui.html
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: /example/v1.0.0/
----

--- a/docs/_posts/examples/redirects/v0.6.7/0100-01-03-timeline.html
+++ b/docs/_posts/examples/redirects/v0.6.7/0100-01-03-timeline.html
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect: /example/v0.6.7/timeline/
-categories: example
----


### PR DESCRIPTION
These old title's show up in mapbox.com/help search and rather than fiddling around with limiting them in swiftype I think we should just remove them from the project. 
