### PR TITLE
Include mapbox.css in the main entry

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,9 @@
 {
   "name": "mapbox.js",
-  "main": "mapbox.js",
+  "main": [
+    "mapbox.css",
+    "mapbox.js"
+  ],
   "version": "",
   "homepage": "https://github.com/mapbox/mapbox.js",
   "authors": ["Mapbox"],


### PR DESCRIPTION
This allows tools like wiredep to automatically inject all the mapbox resources into a web page.
