### PR TITLE
Fixes error on local usage of mapbox css - Makes img link in CSS an explicit url instead of relative

### DIFF
--- a/theme/style.css
+++ b/theme/style.css
@@ -399,7 +399,7 @@
 .map-tooltip .close,
 .mapbox-icon {
   opacity: .75;
-  background-image:url(./images/icons-000000@2x.png);
+  background-image:url(https://api.tiles.mapbox.com/mapbox.js/v2.1.4/images/icons-000000@2x.png);
   background-repeat:no-repeat;
   background-size:26px 260px;
   }


### PR DESCRIPTION
Right now if you use mapboxjs and mapboxcss locally instead of through the CDN it works well, but it gives one error trying to load this img: `/images/icons-000000@2x.png`. It would require anyone using mapbox css locally to add a directory called `images/` in their css directory and then download that icon set and put it in there. So by making it the link to the icon an explicit link instead of relative, we can use mapbox css locally without also needing to download that file, the css will just get the icon from your tile server.
