### PR TITLE
Allow pointToLayer to be configured for FeatureLayer

### DIFF
--- a/src/feature_layer.js
+++ b/src/feature_layer.js
@@ -88,9 +88,10 @@ var FeatureLayer = L.FeatureGroup.extend({
         } else if (this.options.filter(json)) {
 
             var opts = {accessToken: this.options.accessToken},
-                layer = L.GeoJSON.geometryToLayer(json, function(feature, latlon) {
-                    return marker.style(feature, latlon, opts);
-                }),
+                pointToLayer = this.options.pointToLayer || function(feature, latlon) {
+                  return marker.style(feature, latlon, opts);
+                },
+                layer = L.GeoJSON.geometryToLayer(json, pointToLayer),
                 popupHtml = marker.createPopup(json, this.options.sanitizer);
 
             if ('setStyle' in layer) {

--- a/test/spec/feature_layer.js
+++ b/test/spec/feature_layer.js
@@ -180,4 +180,15 @@ describe('L.mapbox.featureLayer', function() {
 
         expect(layer.getLayers()[0]._popup._content).to.match(/<script>/);
     });
+
+    it('supports a pointToLayer option', function() {
+      var layer  = L.mapbox.featureLayer(unsanitary, {
+            pointToLayer: function (feature, lonlat) {
+              return L.circleMarker(lonlat);
+            }
+          }),
+          marker = layer.getLayers()[0];
+
+        expect(marker instanceof L.Circle).to.equal(true);
+    });
 });


### PR DESCRIPTION
Added a `pointToLayer` option to the `FeatureLayer` options.

The use case driving this was that I had a FeatureLayer and I wanted to switch the normal markers for CircleMarkers.  This can now be done like:

``` js
L.mapbox.featureLayer(geoJSON, {
  pointToLayer: function(feature, lonlat) {
    return L.circleMarker(lonlat);
  }
})
```
