### PR TITLE
Exporting images directory in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,8 @@
   "name": "mapbox.js",
   "main": [
     "mapbox.css",
-    "mapbox.js"
+    "mapbox.js",
+    "images/*"
   ],
   "version": "",
   "homepage": "https://github.com/mapbox/mapbox.js",


### PR DESCRIPTION
Gulp assets pipeline is not able to see images directory because it is not in bower.json main section. Added it there.
