### PR TITLE
Allow style to be configured for FeatureLayer

### DIFF
--- a/src/feature_layer.js
+++ b/src/feature_layer.js
@@ -92,10 +92,18 @@ var FeatureLayer = L.FeatureGroup.extend({
                   return marker.style(feature, latlon, opts);
                 },
                 layer = L.GeoJSON.geometryToLayer(json, pointToLayer),
-                popupHtml = marker.createPopup(json, this.options.sanitizer);
+                popupHtml = marker.createPopup(json, this.options.sanitizer),
+                style = this.options.style;
 
             if ('setStyle' in layer) {
-                layer.setStyle(simplestyle.style(json));
+                if (typeof style === 'function') {
+                    style = style(json);
+                }
+                if (style) {
+                    layer.setStyle(style);
+                } else {
+                    layer.setStyle(simplestyle.style(json));
+                }
             }
 
             layer.feature = json;

--- a/test/spec/feature_layer.js
+++ b/test/spec/feature_layer.js
@@ -145,6 +145,58 @@ describe('L.mapbox.featureLayer', function() {
         });
     });
 
+    describe("supports a style option", function() {
+        it('styles polygons as a function', function(done) {
+            var layer  = L.mapbox.featureLayer(helpers.geoJsonPoly, {
+                style: function (feature) {
+                    return {fillColor: 'blue'};
+                }
+            });
+            layer.eachLayer(function(l) {
+                expect(l.options.fillColor).to.eql('blue');
+                done();
+            });
+        });
+
+        it('styles polygons as an object', function(done) {
+            var layer  = L.mapbox.featureLayer(helpers.geoJsonPoly, {
+                style: {fillColor: 'blue'}
+            });
+            layer.eachLayer(function(l) {
+                expect(l.options.fillColor).to.eql('blue');
+                done();
+            });
+        });
+
+        it('also works with pointToLayer as a function', function(done) {
+            var layer  = L.mapbox.featureLayer(helpers.geoJson, {
+                pointToLayer: function (feature, lonlat) {
+                  return L.circleMarker(lonlat);
+                },
+                style: function (feature) {
+                    return {fillColor: 'blue'};
+                }
+            });
+            layer.eachLayer(function(l) {
+                expect(l.options.fillColor).to.eql('blue');
+                done();
+            });
+        });
+
+        it('also works with pointToLayer as an object', function(done) {
+            var layer  = L.mapbox.featureLayer(helpers.geoJson, {
+                pointToLayer: function (feature, lonlat) {
+                  return L.circleMarker(lonlat);
+                },
+                style: {fillColor: 'blue'}
+            });
+            layer.eachLayer(function(l) {
+                expect(l.options.fillColor).to.eql('blue');
+                done();
+            });
+        });
+    });
+
     var unsanitary = {
         type: 'Feature',
         properties: {


### PR DESCRIPTION
This allows setting the style of pointToLayer or L.Path layers.
The style option can be an object or a function that returns an object.
Similar to how L.geoJson works.

Tests are included.
