### PR TITLE
Never apply simplestyle rules to circle or circlemarker instances

### DIFF
--- a/src/feature_layer.js
+++ b/src/feature_layer.js
@@ -93,14 +93,16 @@ var FeatureLayer = L.FeatureGroup.extend({
                 },
                 layer = L.GeoJSON.geometryToLayer(json, pointToLayer),
                 popupHtml = marker.createPopup(json, this.options.sanitizer),
-                style = this.options.style;
+                style = this.options.style,
+                defaultStyle = style === simplestyle.style;
 
             if (style && 'setStyle' in layer &&
+                // if the style method is the simplestyle default, then
                 // never style L.Circle or L.CircleMarker because
                 // simplestyle has no rules over them, only over geometry
                 // primitives directly from GeoJSON
-                !(layer instanceof L.Circle ||
-                  layer instanceof L.CircleMarker)) {
+                (!(defaultStyle && (layer instanceof L.Circle ||
+                  layer instanceof L.CircleMarker)))) {
                 if (typeof style === 'function') {
                     style = style(json);
                 }

--- a/src/feature_layer.js
+++ b/src/feature_layer.js
@@ -95,7 +95,12 @@ var FeatureLayer = L.FeatureGroup.extend({
                 popupHtml = marker.createPopup(json, this.options.sanitizer),
                 style = this.options.style;
 
-            if (style && 'setStyle' in layer) {
+            if (style && 'setStyle' in layer &&
+                // never style L.Circle or L.CircleMarker because
+                // simplestyle has no rules over them, only over geometry
+                // primitives directly from GeoJSON
+                !(layer instanceof L.Circle ||
+                  layer instanceof L.CircleMarker)) {
                 if (typeof style === 'function') {
                     style = style(json);
                 }


### PR DESCRIPTION
Fixes #991 

This makes the rule that

**L.circleMarker or L.circle layers produced by a pointToLayer method are immune to any style overrides**

This is a somewhat narrow fix to #991 but I think it's safe & good because
- simplestyle-spec only applies to geometry primitives & raster markers. circles and circle markers do not fit into either category

/cc @lyzidiamond 
