### PR TITLE
Fix locate example

### DIFF
--- a/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-locatecontrol.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-locatecontrol.html
@@ -7,7 +7,7 @@ description: Add a find me control that sets the map view to the current coordin
 tags:
   - plugins
 ---
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-locatecontrol/v0.42.0/L.Control.Locate.js'></script>
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-locatecontrol/v0.42.0/L.Control.Locate.min.js'></script>
 <link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-locatecontrol/v0.42.0/L.Control.Locate.css' rel='stylesheet' />
 <!--[if lt IE 9]>
 <link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-locatecontrol/v0.42.0/L.Control.Locate.ie.css' rel='stylesheet' />

--- a/docs/_posts/plugins/0100-01-01-leaflet-locate.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-locate.html
@@ -9,7 +9,7 @@ tags:
 code: https://github.com/domoritz/leaflet-locatecontrol
 license: MIT
 ---
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-locatecontrol/v0.42.0/L.Control.Locate.js'></script>
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-locatecontrol/v0.42.0/L.Control.Locate.min.js'></script>
 <link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-locatecontrol/v0.42.0/L.Control.Locate.css' rel='stylesheet' />
 <!--[if lt IE 9]>
   <link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-locatecontrol/v0.42.0/L.Control.Locate.ie.css' rel='stylesheet' />


### PR DESCRIPTION
- Corrects Leaflet-locate plugin CDN URL
- Updates Mapbox.js Leaflet-locate example with new URL

Closes this issue: https://github.com/mapbox/mapbox.js-plugins/issues/25
