### PR TITLE
Add condition for l-map-class links in doc

### DIFF
--- a/_docs/generate.js
+++ b/_docs/generate.js
@@ -68,6 +68,8 @@ function transformLinks(line, relative) {
             var replacement;
             if (content.match(/event$/)) {
                 replacement = 'l-event-objects';
+            } else if (content.match(/map-options$/)) {
+                replacement='l-map-class'
             } else {
                 replacement = 'l-' + content.replace(/\-.*/g, '').replace('#', '');
             }

--- a/docs/_posts/api/0200-01-01-v2.1.9-all.html
+++ b/docs/_posts/api/0200-01-01-v2.1.9-all.html
@@ -1053,7 +1053,7 @@ var map = L.map('map', {
 	<tr>
 		<td><code><b>L.map</b>(
 			<nobr>&lt;HTMLElement|String&gt; <i>id</i>,</nobr>
-			<nobr>&lt;<a href="#l-map">Map options</a>&gt; <i>options?</i> )</nobr>
+			<nobr>&lt;<a href="#l-map-class">Map options</a>&gt; <i>options?</i> )</nobr>
 		</code></td>
 
 

--- a/docs/_posts/api/v2.1.9/0200-01-01-l-map-class.html
+++ b/docs/_posts/api/v2.1.9/0200-01-01-l-map-class.html
@@ -27,7 +27,7 @@ var map = L.map('map', {
 	<tr>
 <td><code><b>L.map</b>(
 <nobr>&lt;HTMLElement|String&gt; <i>id</i>,</nobr>
-<nobr>&lt;<a href="/mapbox.js/api/v2.1.9/l-map">Map options</a>&gt; <i>options?</i> )</nobr>
+<nobr>&lt;<a href="/mapbox.js/api/v2.1.9/l-map-class">Map options</a>&gt; <i>options?</i> )</nobr>
 </code></td>
 
 


### PR DESCRIPTION
- Adds condition to `generate.js` for `l-map-class`, which breaks the rest of the convention for link replacement in docs generation
- Adds updated links to all `v2.1.9` docs
