### PR TITLE
Update DC markers examples to new ID

### DIFF
--- a/docs/_posts/examples/v1.0.0/0100-01-01-centering-markers.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-centering-markers.html
@@ -10,7 +10,7 @@ tags:
 ---
 <div id='map'></div>
 <script>
-    var map = L.mapbox.map('map', 'examples.map-zr0njcqy');
+    var map = L.mapbox.map('map', 'mapbox.dc-markers');
 
     map.featureLayer.on('click', function(e) {
         map.panTo(e.layer.getLatLng());

--- a/docs/_posts/examples/v1.0.0/0100-01-01-connecting-markers-by-a-line.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-connecting-markers-by-a-line.html
@@ -10,7 +10,7 @@ tags:
 <div id='map'></div>
 
 <script>
-var map = L.mapbox.map('map', 'examples.map-zr0njcqy');
+var map = L.mapbox.map('map', 'mapbox.dc-markers');
 
 // Wait until the marker layer is loaded in order to build a list of possible
 // types. If you are doing this with another featureLayer, you should change

--- a/docs/_posts/examples/v1.0.0/0100-01-01-cycle-markers.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-cycle-markers.html
@@ -10,7 +10,7 @@ tags:
 <div id='map'></div>
 
 <script>
-var map = L.mapbox.map('map', 'examples.map-zr0njcqy');
+var map = L.mapbox.map('map', 'mapbox.dc-markers');
 
 // Open popup when user mouses over a marker
 map.featureLayer.on('ready', function(e) {

--- a/docs/_posts/examples/v1.0.0/0100-01-01-features-from-another-map.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-features-from-another-map.html
@@ -15,7 +15,7 @@ var map = L.mapbox.map('map', 'mapbox.emerald');
 
 // Here we load the features.json from another project
 // to use with the map initialized above.
-var features = L.mapbox.featureLayer('examples.map-zr0njcqy').addTo(map);
+var features = L.mapbox.featureLayer('mapbox.dc-markers').addTo(map);
 
 // When the features are loaded, make sure
 // the basemap display's the same geographical coordinates.

--- a/docs/_posts/examples/v1.0.0/0100-01-01-filtering-markers.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-filtering-markers.html
@@ -53,7 +53,7 @@ tags:
 <div id='map'></div>
 
 <script>
-    var map = L.mapbox.map('map', 'examples.map-zr0njcqy'),
+    var map = L.mapbox.map('map', 'mapbox.dc-markers'),
         food = document.getElementById('filter-food'),
         all = document.getElementById('filter-all');
 

--- a/docs/_posts/examples/v1.0.0/0100-01-01-marker-list-click.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-marker-list-click.html
@@ -31,7 +31,7 @@ tags:
 <div id='map'></div>
 <ul id='marker-list'></ul>
 <script>
-  var map = L.mapbox.map('map', 'examples.map-zr0njcqy');
+  var map = L.mapbox.map('map', 'mapbox.dc-markers');
   var markerList = document.getElementById('marker-list');
 
   map.featureLayer.on('ready', function(e) {

--- a/docs/_posts/examples/v1.0.0/0100-01-01-multiple-marker-filters.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-multiple-marker-filters.html
@@ -22,7 +22,7 @@ tags:
 <nav id='filters' class='filter-ui'></nav>
 <div id='map'></div>
 <script>
-var map = L.mapbox.map('map', 'examples.map-zr0njcqy');
+var map = L.mapbox.map('map', 'mapbox.dc-markers');
 
 // Find and store a variable reference to the list of filters.
 var filters = document.getElementById('filters');

--- a/docs/_posts/examples/v1.0.0/0100-01-01-non-exclusive-markers.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-non-exclusive-markers.html
@@ -31,7 +31,7 @@ tags:
 <div id='map'></div>
 
 <script>
-var map = L.mapbox.map('map', 'examples.map-zr0njcqy');
+var map = L.mapbox.map('map', 'mapbox.dc-markers');
 var filters = document.getElementById('filters');
 var checkboxes = document.getElementsByClassName('filter');
 

--- a/docs/_posts/examples/v1.0.0/0100-01-01-open-popup-externally.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-open-popup-externally.html
@@ -21,7 +21,7 @@ tags:
 <button id='open-popup' class='ui-control'>open popup</button>
 
 <script>
-var map = L.mapbox.map('map', 'examples.map-zr0njcqy');
+var map = L.mapbox.map('map', 'mapbox.dc-markers');
 
 // Wait until the markers are loaded, so we know that `map.featureLayer.eachLayer`
 // will actually go over each marker.

--- a/docs/_posts/examples/v1.0.0/0100-01-01-show-marker-as-label.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-show-marker-as-label.html
@@ -11,7 +11,7 @@ tags:
 <div id='map'></div>
 
 <script>
-var map = L.mapbox.map('map', 'examples.map-2k9d7u0c')
+var map = L.mapbox.map('map', 'mapbox.satellite')
     .setView([38.89399, -77.03659], 13);
 
 map.tileLayer.setOpacity(0.2);
@@ -28,7 +28,7 @@ var gj = L.geoJson(null, {
     }
 }).addTo(map);
 
-L.mapbox.featureLayer('examples.map-zr0njcqy')
+L.mapbox.featureLayer('mapbox.dc-markers')
     .on('ready', function(e) {
         gj.addData(this.getGeoJSON());
     });


### PR DESCRIPTION
We have a new, non-`examples` ID for the maps with the DC nightlife markers. This PR replaces those IDs in examples.
