### PR TITLE
Es6 imports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var leaflet = require('./leaflet');
 require('./mapbox');
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,4 @@
-require('./leaflet');
+var leaflet = require('./leaflet');
 require('./mapbox');
+
+module.exports = leaflet;

--- a/src/leaflet.js
+++ b/src/leaflet.js
@@ -1,1 +1,1 @@
-window.L = require('leaflet/dist/leaflet-src');
+module.exports = window.L = require('leaflet/dist/leaflet-src');


### PR DESCRIPTION
Fixes #1007

This allows you to use `import L from 'mapbox.js'` or `var L = require('mapbox.js')`.
