### PR TITLE
Change API URL to api.mapbox.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Managed as Markdown in `API.md`, following the standards in `DOCUMENTING.md`
 Recommended usage is via the Mapbox CDN:
 
 ```html
-<script src='https://api.tiles.mapbox.com/mapbox.js/v2.2.1/mapbox.js'></script>
-<link href='https://api.tiles.mapbox.com/mapbox.js/v2.2.1/mapbox.css' rel='stylesheet' />
+<script src='https://api.mapbox.com/mapbox.js/v2.2.1/mapbox.js'></script>
+<link href='https://api.mapbox.com/mapbox.js/v2.2.1/mapbox.css' rel='stylesheet' />
 ```
 
 The `mapbox.js` file includes the Leaflet library. Alternatively, you can use `mapbox.standalone.js`, which does not include Leaflet (you will have to provide it yourself).

--- a/_config.mb-pages.yml
+++ b/_config.mb-pages.yml
@@ -1,6 +1,6 @@
 url: https://www.mapbox.com
 api: https://www.mapbox.com/core
-tileApi: https://api.tiles.mapbox.com
+tileApi: https://api.mapbox.com
 source: docs
 permalink: /:categories/:title
 baseurl: /mapbox.js

--- a/docs/_posts/examples/v1.0.0/0100-01-01-filtering-marker-clusters.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-filtering-marker-clusters.html
@@ -7,9 +7,9 @@ description: Show only filtered markers in marker clusters
 tags:
   - cluster
 ---
-<script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-markercluster/v0.4.0/leaflet.markercluster.js'></script>
-<link href='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.css' rel='stylesheet' />
-<link href='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.Default.css' rel='stylesheet' />
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/leaflet.markercluster.js'></script>
+<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.css' rel='stylesheet' />
+<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.Default.css' rel='stylesheet' />
 
 <style>
 #colors {

--- a/docs/_posts/examples/v1.0.0/0100-01-01-plain-leaflet.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-plain-leaflet.html
@@ -11,7 +11,7 @@ tags:
 
 <script>
 // Replace 'mapbox.streets' with your map id.
-var mapboxTiles = L.tileLayer('https://{s}.tiles.mapbox.com/v4/mapbox.streets/{z}/{x}/{y}.png?access_token=' + L.mapbox.accessToken, {
+var mapboxTiles = L.tileLayer('{{site.tileApi}}/v4/mapbox.streets/{z}/{x}/{y}.png?access_token=' + L.mapbox.accessToken, {
     attribution: '<a href="http://www.mapbox.com/about/maps/" target="_blank">Terms &amp; Feedback</a>'
 });
 

--- a/docs/_posts/examples/v1.0.0/0100-01-01-turf-concave.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-turf-concave.html
@@ -8,7 +8,7 @@ tags:
   - turf
 ---
 
-<script src='https://api.tiles.mapbox.com/mapbox.js/plugins/turf/v2.0.2/turf.min.js'></script>
+<script src='{{site.tileApi}}/mapbox.js/plugins/turf/v2.0.2/turf.min.js'></script>
 <div id='map'></div>
 <script>
 var map = L.mapbox.map('map', 'examples.map-zr0njcqy');

--- a/docs/_posts/examples/v1.0.0/0100-01-01-turf.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-turf.html
@@ -8,7 +8,7 @@ tags:
   - turf
 ---
 
-<script src='https://api.tiles.mapbox.com/mapbox.js/plugins/turf/v2.0.2/turf.min.js'></script>
+<script src='{{site.tileApi}}/mapbox.js/plugins/turf/v2.0.2/turf.min.js'></script>
 <div id='map'></div>
 <script>
 var map = L.mapbox.map('map', 'examples.map-zr0njcqy');


### PR DESCRIPTION
Per https://github.com/mapbox/hey/issues/4544, updates the `_config.mb-pages.yml` so the `tileApi` points to `https://api.mapbox.com`.

/cc @geografa 
