### PR TITLE
Adds support for types to geocoder.query()

### DIFF
--- a/src/geocoder.js
+++ b/src/geocoder.js
@@ -40,6 +40,19 @@ module.exports = function(url, options) {
 
         var url = L.Util.template(geocoder.getURL(), {query: query});
 
+        if (isObject && _.types) {
+            if (isArray(_.types)) {
+                var typesString = '';
+                _.types.forEach(function (type, i) {
+                    typesString += type;
+                    if (i !== _.types.length - 1) typesString += ',';
+                });
+                url += '&types=' + typesString;
+            } else {
+                url += '&types=' + _.types;
+            }
+        }
+
         if (isObject && _.proximity) {
             var proximity = L.latLng(_.proximity);
             url += '&proximity=' + proximity.lng + ',' + proximity.lat;

--- a/src/geocoder.js
+++ b/src/geocoder.js
@@ -42,12 +42,7 @@ module.exports = function(url, options) {
 
         if (isObject && _.types) {
             if (isArray(_.types)) {
-                var typesString = '';
-                _.types.forEach(function (type, i) {
-                    typesString += type;
-                    if (i !== _.types.length - 1) typesString += ',';
-                });
-                url += '&types=' + typesString;
+                url += '&types=' + _.types.join();
             } else {
                 url += '&types=' + _.types;
             }

--- a/test/spec/geocoder.js
+++ b/test/spec/geocoder.js
@@ -23,6 +23,14 @@ describe('L.mapbox.geocoder', function() {
             expect(g.queryURL({query: ['austin', 'houston'], proximity: L.latLng(10, 15)}))
                 .to.eql('http://a.tiles.mapbox.com/v4/geocode/mapbox.places/austin;houston.json?access_token=key&proximity=15,10');
         });
+
+        it('supports types', function() {
+            var g = L.mapbox.geocoder('mapbox.places');
+            expect(g.queryURL({query: ['austin', 'houston'], types: 'place'}))
+                .to.eql('http://a.tiles.mapbox.com/v4/geocode/mapbox.places/austin;houston.json?access_token=key&types=place');
+            expect(g.queryURL({query: ['austin', 'houston'], types: ['place', 'address']}))
+                .to.eql('http://a.tiles.mapbox.com/v4/geocode/mapbox.places/austin;houston.json?access_token=key&types=place,address');
+        });
     });
 
     describe('#query', function() {


### PR DESCRIPTION
This PR adds support for types to geocoder.query() - types can be a string or an array of strings, passed in the same manner as `query` and `proximity`.
