### PR TITLE
add comment to circleMarker example re units

### DIFF
--- a/docs/_posts/examples/v1.0.0/0100-01-01-featurelayer-to-pointtolayer.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-featurelayer-to-pointtolayer.html
@@ -54,6 +54,8 @@ var geojson = {
 // to pass in the features properties and geometry
 L.mapbox.featureLayer(geojson, {
     pointToLayer: function(feature, latlon) {
+        // L.circleMarker() draws a circle with fixed radius in pixels. 
+        // To draw a circle overlay with a radius in meters, use L.circle()
         return L.circleMarker(latlon, {radius: feature.properties.radius});
     }
 }).addTo(map);


### PR DESCRIPTION
Add a comment to clarify that circleMarker is drawn in pixels, not map units. 
