### PR TITLE
Dedupe /v4 out of config url if manually set

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,12 +1,12 @@
 url: https://122e4e-mapbox.global.ssl.fastly.net
 api: https://122e4e-mapbox.global.ssl.fastly.net/core
 tileApi: https://api-maps-staging.tilestream.net
-accessToken: pk.eyJ1IjoibWFwYm94IiwiYSI6IlhHVkZmaW8ifQ.xZAqdcP-Qiv0PaMCmw6LoA
+accessToken: pk.eyJ1Ijoia3ppbGxhIiwiYSI6ImNpZ2k2aTVjbDAwMjhzemtwYXF1aHp5OXQifQ.PWraxV5gKPndqm_Cf-R8Zg
 source: docs
 permalink: /:categories/:title
 baseurl: /mapbox.js
 highlighter: pygments
-mapboxjs: v2.2.2
+mapboxjs: v2.2.3
 mapboxjsbase: /mapbox.js/dist
 defaultid: 'mapbox.streets'
 rdiscount:

--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ source: docs
 permalink: /:categories/:title
 baseurl: /mapbox.js
 highlighter: pygments
-mapboxjs: v2.2.3
+mapboxjs: v2.2.2
 mapboxjsbase: /mapbox.js/dist
 defaultid: 'mapbox.streets'
 rdiscount:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Mapbox",
   "name": "mapbox.js",
   "description": "mapbox javascript api",
-  "version": "2.2.3-dev",
+  "version": "2.2.3",
   "homepage": "http://mapbox.com/",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Mapbox",
   "name": "mapbox.js",
   "description": "mapbox javascript api",
-  "version": "2.2.2",
+  "version": "2.2.3-dev",
   "homepage": "http://mapbox.com/",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Mapbox",
   "name": "mapbox.js",
   "description": "mapbox javascript api",
-  "version": "2.2.3",
+  "version": "2.2.2",
   "homepage": "http://mapbox.com/",
   "repository": {
     "type": "git",

--- a/src/config.js
+++ b/src/config.js
@@ -1,8 +1,8 @@
 'use strict';
 
 module.exports = {
-    HTTP_URL: 'http://a.tiles.mapbox.com',
-    HTTPS_URL: 'https://a.tiles.mapbox.com',
+    HTTP_URL: 'http://a.tiles.mapbox.com/v4',
+    HTTPS_URL: 'https://a.tiles.mapbox.com/v4',
     FORCE_HTTPS: false,
     REQUIRE_ACCESS_TOKEN: true
 };

--- a/src/format_url.js
+++ b/src/format_url.js
@@ -12,8 +12,7 @@ module.exports = function(path, accessToken) {
     }
 
     var url = (document.location.protocol === 'https:' || config.FORCE_HTTPS) ? config.HTTPS_URL : config.HTTP_URL;
-    var vDupe = url.match('\/v[0-9]');
-    url = (vDupe !== null) ? url.split(vDupe[0])[0] : url;
+    url = url.replace(/\/v4$/, '');
     url += path;
     url += url.indexOf('?') !== -1 ? '&access_token=' : '?access_token=';
 

--- a/src/format_url.js
+++ b/src/format_url.js
@@ -12,7 +12,8 @@ module.exports = function(path, accessToken) {
     }
 
     var url = (document.location.protocol === 'https:' || config.FORCE_HTTPS) ? config.HTTPS_URL : config.HTTP_URL;
-    url = (url.indexOf('/v4')) ? url.split('/v4')[0] : url;
+    var vDupe = url.match('\/v[0-9]');
+    url = (vDupe !== null) ? url.split(vDupe[0])[0] : url;
     url += path;
     url += url.indexOf('?') !== -1 ? '&access_token=' : '?access_token=';
 

--- a/src/format_url.js
+++ b/src/format_url.js
@@ -12,6 +12,7 @@ module.exports = function(path, accessToken) {
     }
 
     var url = (document.location.protocol === 'https:' || config.FORCE_HTTPS) ? config.HTTPS_URL : config.HTTP_URL;
+    path = (path.indexOf('/v4')) ? path.split('/v4')[0] : path;
     url += path;
     url += url.indexOf('?') !== -1 ? '&access_token=' : '?access_token=';
 

--- a/src/format_url.js
+++ b/src/format_url.js
@@ -12,7 +12,7 @@ module.exports = function(path, accessToken) {
     }
 
     var url = (document.location.protocol === 'https:' || config.FORCE_HTTPS) ? config.HTTPS_URL : config.HTTP_URL;
-    path = (path.indexOf('/v4')) ? path.split('/v4')[0] : path;
+    url = (url.indexOf('/v4')) ? url.split('/v4')[0] : url;
     url += path;
     url += url.indexOf('?') !== -1 ? '&access_token=' : '?access_token=';
 

--- a/test/index.html
+++ b/test/index.html
@@ -26,6 +26,7 @@
   </script>
   <script src="helper.js"></script>
 
+  <script src="spec/format_url.js"></script>
   <script src="spec/marker.js"></script>
   <script src="spec/map.js"></script>
   <script src="spec/tile_layer.js"></script>

--- a/test/spec/format_url.js
+++ b/test/spec/format_url.js
@@ -10,40 +10,42 @@ describe("format_url", function() {
     });
 
     it('returns a v4 URL with access_token parameter', function() {
-        expect(internals.format_url('/v4/user.map.json')).to.equal('http://a.tiles.mapbox.com/v4/user.map.json?access_token=key')
+        expect(internals.url('/v4/user.map.json')).to.equal('http://a.tiles.mapbox.com/v4/user.map.json?access_token=key')
     });
 
     it('uses provided access token', function() {
-        expect(internals.format_url('/v4/user.map.json', 'token')).to.equal('http://a.tiles.mapbox.com/v4/user.map.json?access_token=token')
+        expect(internals.url('/v4/user.map.json', 'token')).to.equal('http://a.tiles.mapbox.com/v4/user.map.json?access_token=token')
     });
 
     it('throws an error if no access token is provided', function() {
         L.mapbox.accessToken = null;
-        expect(function() { internals.format_url('/v4/user.map.json') }).to.throwError('An API access token is required to use Mapbox.js.');
+        expect(function() { internals.url('/v4/user.map.json') }).to.throwError('An API access token is required to use Mapbox.js.');
     });
 
     it('throws an error if a secret access token is provided', function() {
         L.mapbox.accessToken = 'sk.abc.123';
-        expect(function() { internals.format_url('/v4/user.map.json') }).to.throwError('Use a public access token (pk.*) with Mapbox.js.');
+        expect(function() { internals.url('/v4/user.map.json') }).to.throwError('Use a public access token (pk.*) with Mapbox.js.');
     });
 
     it('dedupes version out of custom set url', function() {
-        L.mapbox.config.HTTPS_URL = 'https://api-maps-staging.tilestream.net/v4';
-        expect(internals.format_url('/v4/ludacris.map.json')).to.equal('https://api-maps-staging.tilestream.net/v4/ludacris.map.json?access_token=key');
+        internals.config.FORCE_HTTPS = true;
+        internals.config.HTTPS_URL = 'https://api-maps-staging.tilestream.net/v4';
+        expect(internals.url('/v4/ludacris.map.json')).to.equal('https://api-maps-staging.tilestream.net/v4/ludacris.map.json?access_token=key');
+        internals.config.HTTPS_URL = 'https://a.tiles.mapbox.com';
     });
 
     describe('.tileJSON', function() {
         it('returns the input when passed a URL', function() {
-            expect(internals.format_url.tileJSON('http://a.tiles.mapbox.com/v3/user.map.json')).to.equal('http://a.tiles.mapbox.com/v3/user.map.json')
+            expect(internals.url.tileJSON('http://a.tiles.mapbox.com/v3/user.map.json')).to.equal('http://a.tiles.mapbox.com/v3/user.map.json')
         });
 
         it('returns a v4 URL with access_token parameter', function() {
-            expect(internals.format_url.tileJSON('user.map')).to.equal('http://a.tiles.mapbox.com/v4/user.map.json?access_token=key')
+            expect(internals.url.tileJSON('user.map')).to.equal('http://a.tiles.mapbox.com/v4/user.map.json?access_token=key')
         });
 
         it('appends &secure and uses https when FORCE_HTTPS is set', function() {
             internals.config.FORCE_HTTPS = true;
-            expect(internals.format_url.tileJSON('user.map')).to.equal('https://a.tiles.mapbox.com/v4/user.map.json?access_token=key&secure');
+            expect(internals.url.tileJSON('user.map')).to.equal('https://a.tiles.mapbox.com/v4/user.map.json?access_token=key&secure');
         });
     });
 });

--- a/test/spec/format_url.js
+++ b/test/spec/format_url.js
@@ -27,6 +27,11 @@ describe("format_url", function() {
         expect(function() { internals.format_url('/v4/user.map.json') }).to.throwError('Use a public access token (pk.*) with Mapbox.js.');
     });
 
+    it('dedupes version out of custom set url', function() {
+        L.mapbox.config.HTTPS_URL = 'https://api-maps-staging.tilestream.net/v4';
+        expect(internals.format_url('/v4/ludacris.map.json')).to.equal('https://api-maps-staging.tilestream.net/v4/ludacris.map.json?access_token=key');
+    });
+
     describe('.tileJSON', function() {
         it('returns the input when passed a URL', function() {
             expect(internals.format_url.tileJSON('http://a.tiles.mapbox.com/v3/user.map.json')).to.equal('http://a.tiles.mapbox.com/v3/user.map.json')


### PR DESCRIPTION
Introduced by https://github.com/mapbox/mapbox.js/pull/1063

Related ticket: https://github.com/mapbox/mapbox.js/issues/1074

This blocks rolling a new mapbox.js with geocoder updates and upgrading mapbox.js in atlas

@tmcw wanna review and help me deploy. maybe I should add a test for this?
