### PR TITLE
Fix "disable zooming and panning" example

### DIFF
--- a/docs/_posts/examples/v1.0.0/0100-01-01-disable-zooming-panning.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-disable-zooming-panning.html
@@ -19,6 +19,7 @@ map.dragging.disable();
 map.touchZoom.disable();
 map.doubleClickZoom.disable();
 map.scrollWheelZoom.disable();
+map.keyboard.disable();
 
 // Disable tap handler, if present.
 if (map.tap) map.tap.disable();


### PR DESCRIPTION
User pointed out that this line was missing from the example. cc @jfirebaugh @tmcw 
