### PR TITLE
fix CSS in Choropleth legend example

### DIFF
--- a/docs/_posts/examples/v1.0.0/0100-01-01-choropleth.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-choropleth.html
@@ -11,6 +11,10 @@ tags:
 <div id='map'></div>
 
 <style>
+.map-legend ul {
+  list-style: none;
+  padding-left: 0;
+  }
 .map-legend .swatch {
   width:20px;
   height:20px;


### PR DESCRIPTION
Per #878 and a HS ticket, I updated the CSS to turn off the list-style:

![image](https://cloud.githubusercontent.com/assets/2180540/12266031/b29ce8f0-b90e-11e5-8d45-c46aaad88ee8.png)
