### PR TITLE
Do not update geocoder control results on special keys

### DIFF
--- a/src/geocoder_control.js
+++ b/src/geocoder_control.js
@@ -187,7 +187,7 @@ var GeocoderControl = L.Control.extend({
     },
 
     _autocomplete: function(e) {
-        if (this.specialKeyCodes.indexOf(e.keyCode) != -1) return;
+        if (this.specialKeyCodes.indexOf(e.keyCode) !== -1) return;
         if (!this.options.autocomplete) return;
         if (this._input.value === '') return this._updateAutocomplete();
         this.geocoder.query({

--- a/src/geocoder_control.js
+++ b/src/geocoder_control.js
@@ -6,6 +6,9 @@ var geocoder = require('./geocoder'),
 var GeocoderControl = L.Control.extend({
     includes: L.Mixin.Events,
 
+    //tab, esc, left, right, enter, up, down
+    specialKeyCodes: [9, 27, 37, 39, 13, 38, 40],
+
     options: {
         proximity: true,
         position: 'topleft',
@@ -183,7 +186,8 @@ var GeocoderControl = L.Control.extend({
         }, this._updateSubmit);
     },
 
-    _autocomplete: function() {
+    _autocomplete: function(e) {
+        if (this.specialKeyCodes.indexOf(e.keyCode) != -1) return;
         if (!this.options.autocomplete) return;
         if (this._input.value === '') return this._updateAutocomplete();
         this.geocoder.query({


### PR DESCRIPTION
A small change that prevents geocoder control from autocompleting (and update and re-render results) when special key (like escape, tab, enter, arrow keys) was pressed.
