### PR TITLE
Add L.mapbox.styleLayer

### DIFF
--- a/src/format_url.js
+++ b/src/format_url.js
@@ -41,3 +41,14 @@ module.exports.tileJSON = function(urlOrMapID, accessToken) {
 
     return url;
 };
+
+
+module.exports.style = function(styleURL, accessToken) {
+    if (styleURL.indexOf('mapbox://styles/') === -1) throw new Error('Incorrectly formatted Mapbox style at ' + styleURL);
+
+    var ownerIDStyle = styleURL.split('mapbox://styles/')[1];
+    var url = module.exports('/styles/v1/' + ownerIDStyle, accessToken)
+        .replace('http://', 'https://');
+
+    return url;
+};

--- a/src/mapbox.js
+++ b/src/mapbox.js
@@ -8,7 +8,8 @@ var geocoderControl = require('./geocoder_control'),
     tileLayer = require('./tile_layer'),
     infoControl = require('./info_control'),
     map = require('./map'),
-    gridLayer = require('./grid_layer');
+    gridLayer = require('./grid_layer'),
+    styleLayer = require('./style_layer');
 
 L.mapbox = module.exports = {
     VERSION: require('../package.json').version,
@@ -17,6 +18,8 @@ L.mapbox = module.exports = {
     simplestyle: require('./simplestyle'),
     tileLayer: tileLayer.tileLayer,
     TileLayer: tileLayer.TileLayer,
+    styleLayer: styleLayer.styleLayer,
+    StyleLayer: styleLayer.StyleLayer,
     infoControl: infoControl.infoControl,
     InfoControl: infoControl.InfoControl,
     shareControl: shareControl.shareControl,

--- a/src/style_layer.js
+++ b/src/style_layer.js
@@ -1,0 +1,81 @@
+'use strict';
+
+var util = require('./util');
+var format_url = require('./format_url');
+var request = require('./request');
+
+var StyleLayer = L.TileLayer.extend({
+
+    options: {
+        sanitizer: require('sanitize-caja')
+    },
+
+    initialize: function(_, options) {
+        L.TileLayer.prototype.initialize.call(this, undefined, options);
+
+        this.options.tiles = this._formatTileURL(_);
+        this.options.tileSize = 512;
+        this.options.zoomOffset = -1;
+        this.options.tms = false;
+
+        this._getAttribution(_);
+    },
+
+    _getAttribution: function(_) {
+        var styleURL = format_url.style(_, this.options && this.options.accessToken);
+        request(styleURL, L.bind(function(err, style) {
+            if (err) {
+                util.log('could not load Mapbox style at ' + styleURL);
+                this.fire('error', {error: err});
+            }
+            var sources = [];
+            for (var id in style.sources) {
+                var source = style.sources[id].url.split('mapbox://')[1];
+                sources.push(source);
+            }
+            request(format_url.tileJSON(sources.join(), this.options.accessToken), L.bind(function(err, json) {
+                if (err) {
+                    util.log('could not load TileJSON at ' + _);
+                    this.fire('error', {error: err});
+                } else if (json) {
+                    util.strict(json, 'object');
+
+                    this.options.attribution = this.options.sanitizer(json.attribution);
+
+                    this._tilejson = json;
+                    this.fire('ready');
+                }
+            }, this));
+        }, this));
+    },
+
+    // disable the setUrl function, which is not available on mapbox tilelayers
+    setUrl: null,
+
+    _formatTileURL: function(style) {
+        var retina = L.Browser.retina ? '@2x' : '';
+        if (typeof style === 'string') {
+            if (style.indexOf('mapbox://styles/') === -1) {
+                util.log('Incorrectly formatted Mapbox style at ' + style);
+                this.fire('error');
+            }
+            var ownerIDStyle = style.split('mapbox://styles/')[1];
+            return format_url('/styles/v1/' + ownerIDStyle + '/tiles/{z}/{x}/{y}' + retina, this.options.accessToken);
+        } else if (typeof style === 'object') {
+            return format_url('/styles/v1/' + style.owner + '/' + style.id + '/tiles/{z}/{x}/{y}' + retina, this.options.accessToken);
+        }
+    },
+
+    // this is an exception to mapbox.js naming rules because it's called
+    // by `L.map`
+    getTileUrl: function(tilePoint) {
+        var templated = L.Util.template(this.options.tiles, tilePoint);
+        return templated;
+    }
+});
+
+module.exports.StyleLayer = StyleLayer;
+
+module.exports.styleLayer = function(_, options) {
+    return new StyleLayer(_, options);
+};

--- a/test/helper.js
+++ b/test/helper.js
@@ -230,6 +230,574 @@ helpers.tileJSON_improvemap = {
     "webpage": "http://a.tiles.mapbox.com/v3/examples.h8e9h88l/page.html"
 };
 
+helpers.tileJSON_street_terrain = {
+    "attribution": "<a href=\"https://www.mapbox.com/about/maps/\" target=\"_blank\">&copy; Mapbox</a> <a href=\"http://www.openstreetmap.org/about/\" target=\"_blank\">&copy; OpenStreetMap</a> <a class=\"mapbox-improve-map\" href=\"https://www.mapbox.com/map-feedback/\" target=\"_blank\">Improve this map</a>",
+    "bounds": [-180, -85.0511, 180, 85.0511],
+    "center": [0, 0, 0],
+    "format": "pbf",
+    "maxzoom": 15,
+    "minzoom": 0,
+    "name": "Mapbox Streets V6 + Vector Terrain V2",
+    "scheme": "xyz",
+    "tilejson": "2.0.0",
+    "tiles": ["http://a.tiles.mapbox.com/v4/mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v6/{z}/{x}/{y}.vector.pbf?access_token=pk.eyJ1IjoiYm9iYnlzdWQiLCJhIjoiTi16MElIUSJ9.Clrqck--7WmHeqqvtFdYig", "http://b.tiles.mapbox.com/v4/mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v6/{z}/{x}/{y}.vector.pbf?access_token=pk.eyJ1IjoiYm9iYnlzdWQiLCJhIjoiTi16MElIUSJ9.Clrqck--7WmHeqqvtFdYig"],
+    "vector_layers": [{
+        "description": "Generalized landcover classification",
+        "fields": {
+            "class": "One of: wood, scrub, grass, crop, snow"
+        },
+        "id": "landcover",
+        "maxzoom": 22,
+        "minzoom": 0,
+        "source": "mapbox.mapbox-terrain-v2"
+    }, {
+        "description": "",
+        "fields": {
+            "class": "One of: shadow, highlight",
+            "level": "Brightness %. One of: 94, 90, 89, 78, 67, 56"
+        },
+        "id": "hillshade",
+        "maxzoom": 22,
+        "minzoom": 0,
+        "source": "mapbox.mapbox-terrain-v2"
+    }, {
+        "description": "Elevation contour polygons",
+        "fields": {
+            "ele": "Integer. The elevation of the contour in meters",
+            "index": "Indicator for every 2nd, 5th, or 10th contour. Coastlines are given -1. One of: 2, 5, 10, -1, null"
+        },
+        "id": "contour",
+        "maxzoom": 22,
+        "minzoom": 0,
+        "source": "mapbox.mapbox-terrain-v2"
+    }, {
+        "description": "",
+        "fields": {
+            "class": "One of: park, cemetery, hospital, school, industrial, parking, pitch, piste, agriculture, wood, scrub, grass, sand, rock, glacier",
+            "osm_id": "Unique OSM ID number",
+            "type": "OSM tag, more specific than class"
+        },
+        "id": "landuse",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {
+            "class": "One of: river, canal, stream, stream_intermittent, ditch, drain",
+            "osm_id": "Unique OSM ID number",
+            "type": "One of: river, canal, stream, ditch, drain"
+        },
+        "id": "waterway",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {
+            "osm_id": "Unique OSM ID number"
+        },
+        "id": "water",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {
+            "osm_id": "Unique OSM ID number",
+            "type": "One of: runway, taxiway, apron"
+        },
+        "id": "aeroway",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {
+            "class": "One of: fence, hedge, cliff, gate, land",
+            "osm_id": "Unique OSM ID number"
+        },
+        "id": "barrier_line",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {
+            "osm_id": "Unique OSM ID number"
+        },
+        "id": "building",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {
+            "class": "One of: wetland, wetland_noveg",
+            "osm_id": "Unique OSM ID number"
+        },
+        "id": "landuse_overlay",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {
+            "class": "One of: motorway, motorway_link, main, street, street_limited, service, driveway, path, major_rail, minor_rail",
+            "layer": "Number used for ordering overlapping tunnels. May be any integer, but most common values are -1 to -5",
+            "oneway": "Number. Oneway roads are 1, all others are 0",
+            "osm_id": "Unique OSM ID number",
+            "type": "The value of the tunnel's highway tag"
+        },
+        "id": "tunnel",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {
+            "class": "One of: motorway, motorway_link, main, street, street_limited, service, driveway, path, major_rail, minor_rail",
+            "oneway": "Number. Oneway roads are 1, all others are 0",
+            "osm_id": "Unique OSM ID number",
+            "type": "The value of the road's highway tag"
+        },
+        "id": "road",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {
+            "class": "One of: motorway, motorway_link, main, street, street_limited, service, driveway, path, major_rail, minor_rail, aerialway",
+            "layer": "Number used for ordering overlapping bridges. May be any integer, but most common values are 1 to 5",
+            "oneway": "Number. Oneway bridges are 1, all others are 0",
+            "osm_id": "Unique OSM ID number",
+            "type": "The value of the bridge's highway tag"
+        },
+        "id": "bridge",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {
+            "admin_level": "The OSM administrative level of the boundary. One of: 2, 3, 4",
+            "disputed": "Number. Disputed boundaries are 1, all others are 0",
+            "maritime": "Number. Maritime boundaries are 1, all others are 0"
+        },
+        "id": "admin",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {
+            "code": "ISO 3166-1 Alpha-2 code",
+            "name": "Local name of the country",
+            "name_de": "German name of the country",
+            "name_en": "English name of the country",
+            "name_es": "Spanish name of the country",
+            "name_fr": "French name of the country",
+            "name_ru": "Russian name of the country",
+            "name_zh": "Chinese name of the country",
+            "osm_id": "Unique OSM ID number",
+            "parent": "ISO 3166-1 Alpha-2 code of the administering/parent state, if any",
+            "scalerank": "Number, 1-6. Useful for styling text sizes",
+            "type": "One of: country, territory, disputed territory, sar"
+        },
+        "id": "country_label",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {
+            "labelrank": "Number, 1-6. Useful for styling text sizes",
+            "name": "Local or international name of the water body",
+            "name_de": "German name of the water body",
+            "name_en": "English name of the water body",
+            "name_es": "Spanish name of the water body",
+            "name_fr": "French name of the water body",
+            "name_ru": "Russian name of the water body",
+            "name_zh": "Chinese name of the water body",
+            "placement": "One of: point, line"
+        },
+        "id": "marine_label",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {
+            "abbr": "Abbreviated state name",
+            "area": "The area of the state in kilometers²",
+            "name": "Local name of the state",
+            "name_de": "German name of the state",
+            "name_en": "English name of the state",
+            "name_es": "Spanish name of the state",
+            "name_fr": "French name of the state",
+            "name_ru": "Russian name of the state",
+            "name_zh": "Chinese name of the state",
+            "osm_id": "Unique OSM ID number"
+        },
+        "id": "state_label",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {
+            "capital": "Admin level the city is a capital of, if any. One of: 2, 3, 4, null",
+            "ldir": "A hint for label placement at low zoom levels. One of: N, E, S, W, NE, SE, SW, NW, null",
+            "localrank": "Number. Priority relative to nearby places. Useful for limiting label density",
+            "name": "Local name of the place",
+            "name_de": "German name of the place",
+            "name_en": "English name of the place",
+            "name_es": "Spanish name of the place",
+            "name_fr": "French name of the place",
+            "name_ru": "Russian name of the place",
+            "name_zh": "Chinese name of the place",
+            "osm_id": "Unique OSM ID number",
+            "scalerank": "Number, 0-9 or null. Useful for styling text & marker sizes",
+            "type": "One of: city, town, village, hamlet, suburb, neighbourhood"
+        },
+        "id": "place_label",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {
+            "area": "The area of the water polygon in Mercator meters²",
+            "name": "Local name of the water body",
+            "name_de": "German name of the water body",
+            "name_en": "English name of the water body",
+            "name_es": "Spanish name of the water body",
+            "name_fr": "French name of the water body",
+            "name_ru": "Russian name of the water body",
+            "name_zh": "Chinese name of the water body",
+            "osm_id": "Unique OSM ID number"
+        },
+        "id": "water_label",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {
+            "address": "Street address of the POI",
+            "localrank": "Number. Priority relative to nearby POIs. Useful for limiting label density",
+            "maki": "The name of the Maki icon that should be used for the POI",
+            "name": "Local name of the POI",
+            "name_de": "German name of the POI",
+            "name_en": "English name of the POI",
+            "name_es": "Spanish name of the POI",
+            "name_fr": "French name of the POI",
+            "name_ru": "Russian name of the POI",
+            "name_zh": "Chinese name of the POI",
+            "network": "For rail stations, the network(s) that the station serves. Useful for icon styling",
+            "osm_id": "Unique OSM ID number",
+            "ref": "Short reference code, if any",
+            "scalerank": "Number. 1-4. Useful for styling icon sizes and minimum zoom levels",
+            "type": "The original OSM tag value",
+            "website": "URL of the POI"
+        },
+        "id": "poi_label",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {
+            "class": "One of: motorway, motorway_link, main, street, street_limited, service, driveway, path",
+            "len": "Number. Length of the road segment in Mercator meters",
+            "localrank": "Number. Used for shield points only. Priority relative to nearby shields. Useful for limiting shield density",
+            "name": "Local name of the road",
+            "name_de": "German name of the road",
+            "name_en": "English name of the road",
+            "name_es": "Spanish name of the road",
+            "name_fr": "French name of the road",
+            "name_ru": "Russian name of the road",
+            "name_zh": "Chinese name of the road",
+            "osm_id": "Unique OSM ID number",
+            "ref": "Route number of the road",
+            "reflen": "Number. How many characters long the ref tag is. Useful for shield styling",
+            "shield": "The shield style to use. One of: default, mx-federal, mx-state, us-highway, us-highway-alternate, us-highway-business, us-highway-duplex, us-interstate, us-interstate-business, us-interstate-duplex, us-interstate-truck, us-state"
+        },
+        "id": "road_label",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {
+            "class": "One of: river, canal, stream, stream_intermittent",
+            "name": "Local name of the waterway",
+            "name_de": "German name of the waterway",
+            "name_en": "English name of the waterway",
+            "name_es": "Spanish name of the waterway",
+            "name_fr": "French name of the waterway",
+            "name_ru": "Russian name of the waterway",
+            "name_zh": "Chinese name of the waterway",
+            "osm_id": "Unique OSM ID number",
+            "type": "One of: river, canal, stream"
+        },
+        "id": "waterway_label",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {
+            "house_num": "House number",
+            "osm_id": "Unique OSM ID number"
+        },
+        "id": "housenum_label",
+        "source": "mapbox.mapbox-streets-v6"
+    }]
+};
+
+helpers.tileJSON_satellite_streets = {
+    "attribution": "<a href=\"https://www.mapbox.com/about/maps/\" target=\"_blank\">&copy; Mapbox</a> <a href=\"http://www.openstreetmap.org/about/\" target=\"_blank\">&copy; OpenStreetMap</a> <a class=\"mapbox-improve-map\" href=\"https://www.mapbox.com/map-feedback/\" target=\"_blank\">Improve this map</a> <a href=\"https://www.digitalglobe.com/\" target=\"_blank\">&copy; DigitalGlobe</a>",
+    "autoscale": true,
+    "bounds": [-180, -85, 180, 85],
+    "center": [0, 0, 0],
+    "format": "pbf",
+    "maxzoom": 19,
+    "minzoom": 0,
+    "name": "Watermask + Satellite (open) + Satellite + Mapbox Streets V6",
+    "scheme": "xyz",
+    "tilejson": "2.0.0",
+    "tiles": ["http://a.tiles.mapbox.com/v4/mapbox.mapbox-streets-v6,mapbox.satellite/{z}/{x}/{y}.vector.pbf?access_token=pk.eyJ1IjoiYm9iYnlzdWQiLCJhIjoiTi16MElIUSJ9.Clrqck--7WmHeqqvtFdYig", "http://b.tiles.mapbox.com/v4/mapbox.mapbox-streets-v6,mapbox.satellite/{z}/{x}/{y}.vector.pbf?access_token=pk.eyJ1IjoiYm9iYnlzdWQiLCJhIjoiTi16MElIUSJ9.Clrqck--7WmHeqqvtFdYig"],
+    "vector_layers": [{
+        "description": "",
+        "fields": {
+            "class": "One of: park, cemetery, hospital, school, industrial, parking, pitch, piste, agriculture, wood, scrub, grass, sand, rock, glacier",
+            "osm_id": "Unique OSM ID number",
+            "type": "OSM tag, more specific than class"
+        },
+        "id": "landuse",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {
+            "class": "One of: river, canal, stream, stream_intermittent, ditch, drain",
+            "osm_id": "Unique OSM ID number",
+            "type": "One of: river, canal, stream, ditch, drain"
+        },
+        "id": "waterway",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {
+            "osm_id": "Unique OSM ID number"
+        },
+        "id": "water",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {
+            "osm_id": "Unique OSM ID number",
+            "type": "One of: runway, taxiway, apron"
+        },
+        "id": "aeroway",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {
+            "class": "One of: fence, hedge, cliff, gate, land",
+            "osm_id": "Unique OSM ID number"
+        },
+        "id": "barrier_line",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {
+            "osm_id": "Unique OSM ID number"
+        },
+        "id": "building",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {
+            "class": "One of: wetland, wetland_noveg",
+            "osm_id": "Unique OSM ID number"
+        },
+        "id": "landuse_overlay",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {
+            "class": "One of: motorway, motorway_link, main, street, street_limited, service, driveway, path, major_rail, minor_rail",
+            "layer": "Number used for ordering overlapping tunnels. May be any integer, but most common values are -1 to -5",
+            "oneway": "Number. Oneway roads are 1, all others are 0",
+            "osm_id": "Unique OSM ID number",
+            "type": "The value of the tunnel's highway tag"
+        },
+        "id": "tunnel",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {
+            "class": "One of: motorway, motorway_link, main, street, street_limited, service, driveway, path, major_rail, minor_rail",
+            "oneway": "Number. Oneway roads are 1, all others are 0",
+            "osm_id": "Unique OSM ID number",
+            "type": "The value of the road's highway tag"
+        },
+        "id": "road",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {
+            "class": "One of: motorway, motorway_link, main, street, street_limited, service, driveway, path, major_rail, minor_rail, aerialway",
+            "layer": "Number used for ordering overlapping bridges. May be any integer, but most common values are 1 to 5",
+            "oneway": "Number. Oneway bridges are 1, all others are 0",
+            "osm_id": "Unique OSM ID number",
+            "type": "The value of the bridge's highway tag"
+        },
+        "id": "bridge",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {
+            "admin_level": "The OSM administrative level of the boundary. One of: 2, 3, 4",
+            "disputed": "Number. Disputed boundaries are 1, all others are 0",
+            "maritime": "Number. Maritime boundaries are 1, all others are 0"
+        },
+        "id": "admin",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {
+            "code": "ISO 3166-1 Alpha-2 code",
+            "name": "Local name of the country",
+            "name_de": "German name of the country",
+            "name_en": "English name of the country",
+            "name_es": "Spanish name of the country",
+            "name_fr": "French name of the country",
+            "name_ru": "Russian name of the country",
+            "name_zh": "Chinese name of the country",
+            "osm_id": "Unique OSM ID number",
+            "parent": "ISO 3166-1 Alpha-2 code of the administering/parent state, if any",
+            "scalerank": "Number, 1-6. Useful for styling text sizes",
+            "type": "One of: country, territory, disputed territory, sar"
+        },
+        "id": "country_label",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {
+            "labelrank": "Number, 1-6. Useful for styling text sizes",
+            "name": "Local or international name of the water body",
+            "name_de": "German name of the water body",
+            "name_en": "English name of the water body",
+            "name_es": "Spanish name of the water body",
+            "name_fr": "French name of the water body",
+            "name_ru": "Russian name of the water body",
+            "name_zh": "Chinese name of the water body",
+            "placement": "One of: point, line"
+        },
+        "id": "marine_label",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {
+            "abbr": "Abbreviated state name",
+            "area": "The area of the state in kilometers²",
+            "name": "Local name of the state",
+            "name_de": "German name of the state",
+            "name_en": "English name of the state",
+            "name_es": "Spanish name of the state",
+            "name_fr": "French name of the state",
+            "name_ru": "Russian name of the state",
+            "name_zh": "Chinese name of the state",
+            "osm_id": "Unique OSM ID number"
+        },
+        "id": "state_label",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {
+            "capital": "Admin level the city is a capital of, if any. One of: 2, 3, 4, null",
+            "ldir": "A hint for label placement at low zoom levels. One of: N, E, S, W, NE, SE, SW, NW, null",
+            "localrank": "Number. Priority relative to nearby places. Useful for limiting label density",
+            "name": "Local name of the place",
+            "name_de": "German name of the place",
+            "name_en": "English name of the place",
+            "name_es": "Spanish name of the place",
+            "name_fr": "French name of the place",
+            "name_ru": "Russian name of the place",
+            "name_zh": "Chinese name of the place",
+            "osm_id": "Unique OSM ID number",
+            "scalerank": "Number, 0-9 or null. Useful for styling text & marker sizes",
+            "type": "One of: city, town, village, hamlet, suburb, neighbourhood"
+        },
+        "id": "place_label",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {
+            "area": "The area of the water polygon in Mercator meters²",
+            "name": "Local name of the water body",
+            "name_de": "German name of the water body",
+            "name_en": "English name of the water body",
+            "name_es": "Spanish name of the water body",
+            "name_fr": "French name of the water body",
+            "name_ru": "Russian name of the water body",
+            "name_zh": "Chinese name of the water body",
+            "osm_id": "Unique OSM ID number"
+        },
+        "id": "water_label",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {
+            "address": "Street address of the POI",
+            "localrank": "Number. Priority relative to nearby POIs. Useful for limiting label density",
+            "maki": "The name of the Maki icon that should be used for the POI",
+            "name": "Local name of the POI",
+            "name_de": "German name of the POI",
+            "name_en": "English name of the POI",
+            "name_es": "Spanish name of the POI",
+            "name_fr": "French name of the POI",
+            "name_ru": "Russian name of the POI",
+            "name_zh": "Chinese name of the POI",
+            "network": "For rail stations, the network(s) that the station serves. Useful for icon styling",
+            "osm_id": "Unique OSM ID number",
+            "ref": "Short reference code, if any",
+            "scalerank": "Number. 1-4. Useful for styling icon sizes and minimum zoom levels",
+            "type": "The original OSM tag value",
+            "website": "URL of the POI"
+        },
+        "id": "poi_label",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {
+            "class": "One of: motorway, motorway_link, main, street, street_limited, service, driveway, path",
+            "len": "Number. Length of the road segment in Mercator meters",
+            "localrank": "Number. Used for shield points only. Priority relative to nearby shields. Useful for limiting shield density",
+            "name": "Local name of the road",
+            "name_de": "German name of the road",
+            "name_en": "English name of the road",
+            "name_es": "Spanish name of the road",
+            "name_fr": "French name of the road",
+            "name_ru": "Russian name of the road",
+            "name_zh": "Chinese name of the road",
+            "osm_id": "Unique OSM ID number",
+            "ref": "Route number of the road",
+            "reflen": "Number. How many characters long the ref tag is. Useful for shield styling",
+            "shield": "The shield style to use. One of: default, mx-federal, mx-state, us-highway, us-highway-alternate, us-highway-business, us-highway-duplex, us-interstate, us-interstate-business, us-interstate-duplex, us-interstate-truck, us-state"
+        },
+        "id": "road_label",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {
+            "class": "One of: river, canal, stream, stream_intermittent",
+            "name": "Local name of the waterway",
+            "name_de": "German name of the waterway",
+            "name_en": "English name of the waterway",
+            "name_es": "Spanish name of the waterway",
+            "name_fr": "French name of the waterway",
+            "name_ru": "Russian name of the waterway",
+            "name_zh": "Chinese name of the waterway",
+            "osm_id": "Unique OSM ID number",
+            "type": "One of: river, canal, stream"
+        },
+        "id": "waterway_label",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {
+            "house_num": "House number",
+            "osm_id": "Unique OSM ID number"
+        },
+        "id": "housenum_label",
+        "source": "mapbox.mapbox-streets-v6"
+    }, {
+        "description": "",
+        "fields": {},
+        "id": "mapbox_satellite_full",
+        "source": "mapbox.satellite-full"
+    }, {
+        "fields": {},
+        "id": "mapbox_satellite_plus",
+        "source": "mapbox.satellite-plus"
+    }, {
+        "description": "",
+        "fields": {},
+        "id": "mapbox_satellite_open",
+        "source": "mapbox.satellite-open"
+    }, {
+        "fields": {},
+        "id": "mapbox_satellite_watermask",
+        "source": "mapbox.satellite-watermask"
+    }]
+}
+
 helpers.tileJSON_autoscale = {
   "webpage": "http://a.tiles.mapbox.com/v3/tmcw.map-oitj0si5/page.html",
   "tiles": [

--- a/test/index.html
+++ b/test/index.html
@@ -30,6 +30,7 @@
   <script src="spec/marker.js"></script>
   <script src="spec/map.js"></script>
   <script src="spec/tile_layer.js"></script>
+  <script src="spec/style_layer.js"></script>
   <script src="spec/feature_layer.js"></script>
   <script src="spec/legend_control.js"></script>
   <script src="spec/geocoder.js"></script>

--- a/test/manual/style_layer.html
+++ b/test/manual/style_layer.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='UTF-8'/>
+  <link rel="stylesheet" href="../../dist/mapbox.css"/>
+  <meta name='viewport' content='initial-scale=1.0 maximum-scale=1.0'>
+  <link rel="stylesheet" href="embed.css"/>
+  <script src="../../dist/mapbox.js"></script>
+  <script src="access_token.js"></script>
+</head>
+<body>
+<div id='map'></div>
+<script type='text/javascript'>
+    var map = L.mapbox.map('map')
+        .setView([40, -74.50], 9);
+
+    L.mapbox.styleLayer('mapbox://styles/mapbox/streets-v8').addTo(map);
+</script>
+</body>
+</html>

--- a/test/spec/format_url.js
+++ b/test/spec/format_url.js
@@ -48,4 +48,10 @@ describe("format_url", function() {
             expect(internals.url.tileJSON('user.map')).to.equal('https://a.tiles.mapbox.com/v4/user.map.json?access_token=key&secure');
         });
     });
+
+    describe('.style', function() {
+        it('returns a style url with access_token parameter', function() {
+            expect(internals.url.style('mapbox://styles/bobbysud/cifr15emd00007zlzxjew2rar')).to.equal('https://a.tiles.mapbox.com/styles/v1/bobbysud/cifr15emd00007zlzxjew2rar?access_token=key')
+        });
+    });
 });

--- a/test/spec/style_layer.js
+++ b/test/spec/style_layer.js
@@ -1,0 +1,108 @@
+describe('L.mapbox.styleLayer', function() {
+    var server;
+
+    beforeEach(function() {
+        server = sinon.fakeServer.create();
+    });
+
+    afterEach(function() {
+        server.restore();
+    });
+
+    describe('Constructor', function() {
+
+        it('sets attribution', function(done) {
+            var layer = L.mapbox.styleLayer('mapbox://styles/mapbox/streets-v8');
+            layer.on('ready', function(e) {
+                expect(layer.options.attribution).to.equal('<a href="https://www.mapbox.com/about/maps/" target="_blank">&copy; Mapbox</a> <a href="http://www.openstreetmap.org/about/" target="_blank">&copy; OpenStreetMap</a> <a class="mapbox-improve-map" href="https://www.mapbox.com/map-feedback/" target="_blank">Improve this map</a>');
+                done();
+            });
+
+            server.respondWith('GET', 'https://a.tiles.mapbox.com/styles/v1/mapbox/streets-v8?access_token=key',
+                [200, { "Content-Type": "application/json" }, JSON.stringify({"sources":{"composite":{"url":"mapbox://mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v6","type":"vector"}}})]);
+            server.respond();
+
+            server.respondWith('GET', 'http://a.tiles.mapbox.com/v4/mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v6.json?access_token=key',
+                [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.tileJSON_street_terrain)]);
+            server.respond();
+        });
+
+        it('sets attribution', function(done) {
+            var layer = L.mapbox.styleLayer('mapbox://styles/mapbox/satellite-hybrid-v8');
+            layer.on('ready', function(e) {
+                expect(layer.options.attribution).to.equal('<a href="https://www.mapbox.com/about/maps/" target="_blank">&copy; Mapbox</a> <a href="http://www.openstreetmap.org/about/" target="_blank">&copy; OpenStreetMap</a> <a class="mapbox-improve-map" href="https://www.mapbox.com/map-feedback/" target="_blank">Improve this map</a> <a href="https://www.digitalglobe.com/" target="_blank">&copy; DigitalGlobe</a>');
+                done();
+            });
+
+            server.respondWith('GET', 'https://a.tiles.mapbox.com/styles/v1/mapbox/satellite-hybrid-v8?access_token=key',
+                [200, { "Content-Type": "application/json" }, JSON.stringify({"sources":{"mapbox":{"url":"mapbox://mapbox.mapbox-streets-v6","type":"vector"},"satellite":{"url":"mapbox://mapbox.satellite","type":"raster","tileSize":256}}})]);
+            server.respond();
+
+            server.respondWith('GET', 'http://a.tiles.mapbox.com/v4/mapbox.mapbox-streets-v6,mapbox.satellite.json?access_token=key',
+                [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.tileJSON_satellite_streets)]);
+            server.respond();
+        });
+
+        it('tms option is always false', function() {
+            var layer = L.mapbox.styleLayer('mapbox://styles/mapbox/streets-v8', {
+                tms: true
+            });
+            layer.on('ready', function(e) {
+                expect(layer.options.tms).to.equal(false);
+            });
+        });
+
+        it('tileSize is always 512', function() {
+            var layer = L.mapbox.styleLayer('mapbox://styles/mapbox/streets-v8', {
+                tileSize: 256
+            });
+            layer.on('ready', function(e) {
+                expect(layer.options.tileSize).to.equal(512);
+            });
+        });
+
+        it('zoomOffset is always -1', function() {
+            var layer = L.mapbox.styleLayer('mapbox://styles/mapbox/streets-v8', {
+                zoomOffset: 0
+            });
+            layer.on('ready', function(e) {
+                expect(layer.options.zoomOffset).to.equal(-1);
+            });
+        });
+
+        it('sanitizes attribution', function() {
+            var layer = L.mapbox.styleLayer('mapbox://styles/mapbox/streets-v8', {attribution: '<script>alert("test")</script>'});
+            layer.on('ready', function(e) {
+                expect(layer.options.attribution).to.equal('');
+            });
+        });
+    });
+
+    describe('#getTileUrl', function() {
+        var retina;
+
+        beforeEach(function() {
+            retina = L.Browser.retina;
+            L.Browser.retina = false;
+        });
+
+        afterEach(function() {
+            L.Browser.retina = retina;
+        });
+
+        it('generates valid tile requests', function() {
+            var layer = L.mapbox.styleLayer('mapbox://styles/bobbysud/cifr15emd00007zlzxjew2rar');
+            expect(layer.getTileUrl({x: 0, y: 0, z: 0})).to.equal('http://a.tiles.mapbox.com/styles/v1/bobbysud/cifr15emd00007zlzxjew2rar/tiles/0/0/0?access_token=key');
+            expect(layer.getTileUrl({x: 1, y: 0, z: 0})).to.equal('http://a.tiles.mapbox.com/styles/v1/bobbysud/cifr15emd00007zlzxjew2rar/tiles/0/1/0?access_token=key');
+            expect(layer.getTileUrl({x: 2, y: 0, z: 0})).to.equal('http://a.tiles.mapbox.com/styles/v1/bobbysud/cifr15emd00007zlzxjew2rar/tiles/0/2/0?access_token=key');
+            expect(layer.getTileUrl({x: 3, y: 0, z: 0})).to.equal('http://a.tiles.mapbox.com/styles/v1/bobbysud/cifr15emd00007zlzxjew2rar/tiles/0/3/0?access_token=key');
+            expect(layer.getTileUrl({x: 4, y: 0, z: 0})).to.equal('http://a.tiles.mapbox.com/styles/v1/bobbysud/cifr15emd00007zlzxjew2rar/tiles/0/4/0?access_token=key');
+        });
+
+        it('requests @2x tiles on retina', function() {
+            L.Browser.retina = true;
+            var layer = L.mapbox.styleLayer('mapbox://styles/bobbysud/cifr15emd00007zlzxjew2rar');
+            expect(layer.getTileUrl({x: 0, y: 0, z: 0})).to.equal('http://a.tiles.mapbox.com/styles/v1/bobbysud/cifr15emd00007zlzxjew2rar/tiles/0/0/0@2x?access_token=key');
+        });
+    });
+});


### PR DESCRIPTION
This adds the ability to add a style id in place of a mapid and get raster tiles of that style. Some notes:
- tiles must always be configured with [these options](https://github.com/mapbox/mapbox.js/compare/styles#diff-e1b538b03ec4f0f4fdced9f144bf186bR37)
- I added the ability to add the whole style object in place of the id [here](https://github.com/mapbox/mapbox.js/compare/styles#diff-e1b538b03ec4f0f4fdced9f144bf186bR64). I'm not sure if this makes sense because it will not be configurable at run time.
- The name `styleLayer` is still up for debate

Tests are failing because options are not properly set, any insight on this would be appreciated.

/cc @jfirebaugh @tmcw 
