### PR TITLE
add stylelayer example

### DIFF
--- a/docs/_posts/examples/v1.0.0/0100-01-01-stylelayer.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-stylelayer.html
@@ -3,7 +3,7 @@ layout: example
 categories: example/v1.0.0
 version: v1.0.0
 title: styleLayer
-description: Display a Mapbox-hosted style created in Mapbox Studio
+description: Display a Mapbox style created in Mapbox Studio
 tags:
   - studio
   - style
@@ -15,6 +15,6 @@ tags:
 var map = L.mapbox.map('map')
     .setView([38.97416, -95.23252], 15);
 
-// Use styleLayer to a Mapbox-hosted style created in Mapbox Studio
+// Use styleLayer to a Mapbox style created in Mapbox Studio
 L.mapbox.styleLayer('mapbox://styles/mapbox/emerald-v8').addTo(map);
 </script>

--- a/docs/_posts/examples/v1.0.0/0100-01-01-stylelayer.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-stylelayer.html
@@ -2,12 +2,10 @@
 layout: example
 categories: example/v1.0.0
 version: v1.0.0
-title: styleLayer
-description: Display a Mapbox style created in Mapbox Studio
+title: Add styles made with Mapbox Studio using styleLayer
+description: Display a style created in Mapbox Studio
 tags:
-  - studio
-  - style
-  - GL
+  - layers
 ---
 <div id='map' class='dark'></div>
 

--- a/docs/_posts/examples/v1.0.0/0100-01-01-stylelayer.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-stylelayer.html
@@ -1,0 +1,20 @@
+---
+layout: example
+categories: example/v1.0.0
+version: v1.0.0
+title: styleLayer
+description: Display a Mapbox-hosted style created in Mapbox Studio
+tags:
+  - studio
+  - style
+  - GL
+---
+<div id='map' class='dark'></div>
+
+<script>
+var map = L.mapbox.map('map')
+    .setView([38.97416, -95.23252], 15);
+
+// Use styleLayer to a Mapbox-hosted style created in Mapbox Studio
+L.mapbox.styleLayer('mapbox://styles/mapbox/emerald-v8').addTo(map);
+</script>


### PR DESCRIPTION
_Pending a new release incorporating https://github.com/mapbox/mapbox.js/pull/1108._ 

As per https://github.com/mapbox/mapbox.js/pull/1108/files, adds a new example demonstrating how to display a Mapbox Studio style in Mapbox.js using `styleLayer`. 

Addresses https://github.com/mapbox/mapbox.js/issues/1110. 

cc @bsudekum @lyzidiamond 
