### PR TITLE
Grammar fix, no need to be dark

### DIFF
--- a/docs/_posts/examples/v1.0.0/0100-01-01-stylelayer.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-stylelayer.html
@@ -7,12 +7,12 @@ description: Display a style created in Mapbox Studio
 tags:
   - layers
 ---
-<div id='map' class='dark'></div>
+<div id='map'></div>
 
 <script>
 var map = L.mapbox.map('map')
     .setView([38.97416, -95.23252], 15);
 
-// Use styleLayer to a Mapbox style created in Mapbox Studio
+// Use styleLayer to add a Mapbox style created in Mapbox Studio
 L.mapbox.styleLayer('mapbox://styles/mapbox/emerald-v8').addTo(map);
 </script>


### PR DESCRIPTION
Fixes a grammar mistake and removes the `dark` class from the map container. I don't think this is necessary for the example.
