### PR TITLE
Update leaflet attribution to latest

### DIFF
--- a/docs/_posts/examples/v1.0.0/0100-01-01-plain-leaflet.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-plain-leaflet.html
@@ -12,7 +12,7 @@ tags:
 <script>
 // Replace 'mapbox.streets' with your map id.
 var mapboxTiles = L.tileLayer('{{site.tileApi}}/v4/mapbox.streets/{z}/{x}/{y}.png?access_token=' + L.mapbox.accessToken, {
-    attribution: '<a href="http://www.mapbox.com/about/maps/" target="_blank">Terms &amp; Feedback</a>'
+    attribution: '© <a href="https://www.mapbox.com/map-feedback/">Mapbox</a> © <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 });
 
 var map = L.map('map')


### PR DESCRIPTION
Per https://github.com/mapbox/mapbox.js/pull/1120#issuecomment-190973961, updates Leaflet attribution to be in line with https://www.mapbox.com/mapbox.js/example/v1.0.0/plain-leaflet/. 

cc: @jfirebaugh 
