### PR TITLE
Rotate mapbox.js token

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -161,7 +161,7 @@ footer:
   <script>
   window.mapbox_api = '{{site.api}}';
   window.mapbox_tileApi = '{{site.tileApi}}';
-  window.mapbox_accessToken = '{{site.accessToken}}' || 'pk.eyJ1IjoibWFwYm94IiwiYSI6ImNpamVuY3cxbzAwMG12ZGx4cGljbGtqMGUifQ.vpDqms08MBqoRgp667Yz5Q'
+  window.mapbox_accessToken = '{{site.accessToken}}' || 'pk.eyJ1IjoibWFwYm94IiwiYSI6ImNpbG12cDRhdzY3MW52Nm0wZjNpcjU5dHQifQ.iqDtzEiaRJCuv1ZqBvecXQ'
   if (typeof L !== 'undefined' && L.mapbox.VERSION[0] === '2') {
       L.mapbox.accessToken = window.mapbox_accessToken;
       L.mapbox.config.FORCE_HTTPS = true;


### PR DESCRIPTION
This PR rotates the access token used by default in the Mapbox.js examples. cc @jfirebaugh @tmcw @mick @sbma44 
