### PR TITLE
Fix broken image icon link in rotating marker example, update staging token

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 url: https://122e4e-mapbox.global.ssl.fastly.net
 api: https://122e4e-mapbox.global.ssl.fastly.net/core
 tileApi: https://api-maps-staging.tilestream.net
-accessToken: pk.eyJ1Ijoia3ppbGxhIiwiYSI6ImNpZ2k2aTVjbDAwMjhzemtwYXF1aHp5OXQifQ.PWraxV5gKPndqm_Cf-R8Zg
+accessToken: pk.eyJ1IjoibWFwYm94IiwiYSI6ImNpZ3BqeDZlcDAwMDBzcmt1YnQ1OTM4cTEifQ.54XwgUSkvlmB7gHW4vWJ3w
 source: docs
 permalink: /:categories/:title
 baseurl: /mapbox.js

--- a/docs/_posts/examples/v1.0.0/0100-01-01-rotating-controlling-marker.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-rotating-controlling-marker.html
@@ -39,8 +39,9 @@ var map = L.mapbox.map('map', 'mapbox.emerald', {
 }).setView([37.9, -77],4);
 
 var marker = L.rotatedMarker(new L.LatLng(37.9, -77), {
-  icon: L.icon({
-    iconUrl: 'https://www.mapbox.com/maki/renders/airport-24@2x.png',
+  icon: L.divIcon({
+    className: 'svg-marker',
+    html: '<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 15 15"><path d="M15 6.818V8.5l-6.5-1-.318 4.773L11 14v1l-3.5-.682L4 15v-1l2.818-1.727L6.5 7.5 0 8.5V6.818L6.5 4.5v-3s0-1.5 1-1.5 1 1.5 1 1.5v2.818l6.5 2.5z"/></svg>',
     iconSize: [24, 24],
   }),
   draggable: true


### PR DESCRIPTION
Fixes broken image in the rotating and controllable marker example by swapping link to a hosted icon from a previous version of Maki for an embedded SVG `divIcon`. 

![image](https://cloud.githubusercontent.com/assets/2365503/15490564/207064e8-2137-11e6-8a58-1cca42c59b37.png)

✨ 

![image](https://cloud.githubusercontent.com/assets/2365503/15490613/a4d0aec8-2137-11e6-82f9-e5da5f330282.png)

Also updates staging access token. 
