### PR TITLE
Fix styleLayer with no style response

### DIFF
--- a/src/style_layer.js
+++ b/src/style_layer.js
@@ -24,28 +24,29 @@ var StyleLayer = L.TileLayer.extend({
     _getAttribution: function(_) {
         var styleURL = format_url.style(_, this.options && this.options.accessToken);
         request(styleURL, L.bind(function(err, style) {
-            if (err) {
+            if (err || !style) {
                 util.log('could not load Mapbox style at ' + styleURL);
                 this.fire('error', {error: err});
-            }
-            var sources = [];
-            for (var id in style.sources) {
-                var source = style.sources[id].url.split('mapbox://')[1];
-                sources.push(source);
-            }
-            request(format_url.tileJSON(sources.join(), this.options.accessToken), L.bind(function(err, json) {
-                if (err) {
-                    util.log('could not load TileJSON at ' + _);
-                    this.fire('error', {error: err});
-                } else if (json) {
-                    util.strict(json, 'object');
-
-                    this.options.attribution = this.options.sanitizer(json.attribution);
-
-                    this._tilejson = json;
-                    this.fire('ready');
+            } else {
+                var sources = [];
+                for (var id in style.sources) {
+                    var source = style.sources[id].url.split('mapbox://')[1];
+                    sources.push(source);
                 }
-            }, this));
+                request(format_url.tileJSON(sources.join(), this.options.accessToken), L.bind(function(err, json) {
+                    if (err) {
+                        util.log('could not load TileJSON at ' + _);
+                        this.fire('error', {error: err});
+                    } else if (json) {
+                        util.strict(json, 'object');
+
+                        this.options.attribution = this.options.sanitizer(json.attribution);
+
+                        this._tilejson = json;
+                        this.fire('ready');
+                    }
+                }, this));
+            }
         }, this));
     },
 

--- a/test/spec/style_layer.js
+++ b/test/spec/style_layer.js
@@ -76,6 +76,21 @@ describe('L.mapbox.styleLayer', function() {
                 expect(layer.options.attribution).to.equal('');
             });
         });
+
+        it('should error if no style', function(done) {
+            var layer = L.mapbox.styleLayer('mapbox://styles/mapbox/streets-v8');
+            layer.on('error', function() {
+                done();
+            });
+
+            server.respondWith('GET', 'https://a.tiles.mapbox.com/styles/v1/mapbox/streets-v8?access_token=key',
+                [200, { "Content-Type": "application/json" }, JSON.stringify(null)]);
+            server.respond();
+
+            server.respondWith('GET', 'http://a.tiles.mapbox.com/v4/mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v6.json?access_token=key',
+                [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.tileJSON_street_terrain)]);
+            server.respond();
+        });
     });
 
     describe('#getTileUrl', function() {


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox.js/issues/1160

In some cases, a style is requested but an error nor style is returned. In this case, we should bail early and not try to render the map. 

Couple of thoughts:
1. the `err` object returned will be null. This seems a little funny, I guess we just need error to fire. We're following this pattern in a [few places](https://github.com/mapbox/mapbox.js/blob/mb-pages/src/geocoder_control.js#L104-L105). Happy to construct an error object if necessary. 
2. It'd be great to find a map that consistently fails as I'm curious as to how we can not return a map and also an error. Only thing I can think of is a backend error like `504` that might slip by the `if err` check.

/cc @jfirebaugh @tmcw 
