### PR TITLE
Remove z-index rule to .leaflet-pane

### DIFF
--- a/test/manual/layers.html
+++ b/test/manual/layers.html
@@ -16,7 +16,7 @@
         list-style: none;
         margin: 0;
         padding: 0;
-        z-index: 100;
+        z-index: 1;
     }
 
     #map-ui a {

--- a/test/manual/panes.html
+++ b/test/manual/panes.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='UTF-8'/>
+  <link rel="stylesheet" href="../../dist/mapbox.css"/>
+  <link rel="stylesheet" href="embed.css"/>
+  <script src="../../dist/mapbox.js"></script>
+  <script src="access_token.js"></script>
+  <script src='http://leafletjs.com/examples/map-panes/eu-countries.js'></script>
+</head>
+<body>
+<div id='map'></div>
+<script>
+  var map = L.mapbox.map('map').setView([0, -0], 3);
+
+	map.createPane('labels');
+	map.getPane('labels').style.zIndex = 650;
+	map.getPane('labels').style.pointerEvents = 'none';
+
+	var cartodbAttribution = '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>';
+
+	var positron = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png', {
+		attribution: cartodbAttribution
+	}).addTo(map);
+
+	var positronLabels = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}.png', {
+		attribution: cartodbAttribution,
+		pane: 'labels'
+	}).addTo(map);
+
+	geojson = L.geoJson(euCountries).addTo(map);
+
+	geojson.eachLayer(function (layer) {
+		layer.bindPopup(layer.feature.properties.name);
+	});
+</script>
+</body>
+</html>

--- a/theme/style.css
+++ b/theme/style.css
@@ -140,7 +140,6 @@
 .leaflet-map-pane canvas { z-index: 1; }
 .leaflet-map-pane svg    { z-index: 2; }
 
-.leaflet-pane         { z-index:4; }
 .leaflet-tile-pane    { z-index:2; }
 .leaflet-overlay-pane { z-index:4; }
 .leaflet-shadow-pane  { z-index:5; }


### PR DESCRIPTION
`leaflet-pane` is applied to not only each layer element (which bear their own
z-index rules) but also to the parent container for them. This lead to
ordering issues where custom interfaces over top a map now need agressive
z-index rules and consequently broke examples.

This commit drops the z-index applied to this general classname. It's carry
over from Leaflet/Leaflet#3591 which appears to be a little half hearted.

cc @tmcw @mourner 
