### PR TITLE
handle tile url with no format in tile.json files

### DIFF
--- a/src/tile_layer.js
+++ b/src/tile_layer.js
@@ -45,8 +45,12 @@ var TileLayer = L.TileLayer.extend({
     _setTileJSON: function(json) {
         util.strict(json, 'object');
 
-        this.options.format = this.options.format ||
-            json.tiles[0].match(formatPattern)[1];
+        if (!this.options.format) {
+          var match = json.tiles[0].match(formatPattern);
+          if (match) {
+              this.options.format = match[1];
+          }
+        }
 
         L.extend(this.options, {
             tiles: json.tiles,
@@ -74,7 +78,7 @@ var TileLayer = L.TileLayer.extend({
             url = tiles[index];
 
         var templated = L.Util.template(url, tilePoint);
-        if (!templated) {
+        if (!templated || !this.options.format) {
             return templated;
         } else {
             return templated.replace(formatPattern,

--- a/test/helper.js
+++ b/test/helper.js
@@ -919,6 +919,20 @@ helpers.tileJSON_jpg = {
     "tiles":["http://a.tiles.mapbox.com/v3/examples.map-8ced9urs/{z}/{x}/{y}.jpg"]
 };
 
+helpers.tileJSON_noformat = {
+    "bounds":[-180,-85.0511,180,85.0511],
+    "center":[-98.976,39.386,4],
+    "description":"Bird species of North America, gridded by species count.",
+    "id":"examples.map-8ced9urs",
+    "maxzoom":17,
+    "minzoom":0,
+    "name":"Bird species",
+    "private":true,
+    "scheme":"xyz",
+    "tilejson":"2.0.0",
+    "tiles":["http://domain.example/path/{z}/{x}/{y}"]
+};
+
 helpers.geoJson = {
     type: 'FeatureCollection',
     features: [{

--- a/test/spec/tile_layer.js
+++ b/test/spec/tile_layer.js
@@ -148,5 +148,10 @@ describe("L.mapbox.tileLayer", function() {
             var layer = L.mapbox.tileLayer(helpers.tileJSON).setFormat('jpg70');
             expect(layer.getTileUrl({x: 0, y: 0, z: 0})).to.equal('http://a.tiles.mapbox.com/v3/examples.map-8ced9urs/0/0/0@2x.jpg70');
         });
+        it("requests tiles with no format", function() {
+            L.Browser.retina = true;
+            var layer = L.mapbox.tileLayer(helpers.tileJSON_noformat);
+            expect(layer.getTileUrl({x: 0, y: 0, z: 0})).to.equal('http://domain.example/path/0/0/0');
+        });
     });
 });


### PR DESCRIPTION
if one of the urls in a tile.json tiles array doesn't have a format suffix then mapbox throws an error when it tries to load the tile.json