### PR TITLE
Handle bbox option in geocode.js and add relevant test

### DIFF
--- a/src/geocoder.js
+++ b/src/geocoder.js
@@ -64,6 +64,14 @@ module.exports = function(url, options) {
                 }
             }
 
+            if (_.bbox) {
+                if (isArray(_.bbox)) {
+                    url += '&bbox=' + _.bbox.join();
+                } else {
+                    url += '&bbox=' + _.bbox;
+                }
+            }
+
             if (_.proximity) {
                 var proximity = roundTo(L.latLng(_.proximity), 3);
                 url += '&proximity=' + proximity.lng + ',' + proximity.lat;

--- a/test/spec/geocoder.js
+++ b/test/spec/geocoder.js
@@ -28,6 +28,13 @@ describe('L.mapbox.geocoder', function() {
                 .to.eql('http://a.tiles.mapbox.com/geocoding/v5/mapbox.places/austin;houston.json?access_token=key&country=us');
         });
 
+        it('supports bbox option', function() {
+            var g = L.mapbox.geocoder('mapbox.places');
+            expect(g.queryURL({query: ['austin', 'houston'], bbox: [ -104.0458814, 26.0696823, -93.7347459, 36.4813628 ]}))
+                .to.eql('http://a.tiles.mapbox.com/geocoding/v5/mapbox.places/
+                    austin;houston.json?access_token=key&bbox='-104.0458814,26.0696823,-93.7347459,36.4813628');
+        });
+
         it('supports autocomplete option', function() {
             var g = L.mapbox.geocoder('mapbox.places');
             expect(g.queryURL({query: ['austin', 'houston'], country: 'us', autocomplete: false}))


### PR DESCRIPTION
This is relevant to issue #1198. On line 50 of src/geocoder.js, inside of the geocoder.queryURL method, each of the possible options to be fed into the query string are handled. bbox, despite being a possible option that the API does understand, wasn't accounted for here and, in turn, not passed to the query. This PR fixes that.

Test has been added too.