### PR TITLE
update swipe layers example for 3.0.1

### DIFF
--- a/docs/_posts/examples/v1.0.0/0100-01-01-swipe-layers.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-swipe-layers.html
@@ -22,10 +22,11 @@ tags:
 <input id='range' class='range' type='range' min='0' max='1.0' step='any' />
 
 <script>
-var map = L.mapbox.map('map');
-L.mapbox.tileLayer('mapbox.outdoors').addTo(map);
+var map = L.mapbox.map('map').setView([49.434,-123.272], 7);
 
+L.mapbox.tileLayer('mapbox.outdoors').addTo(map);
 var overlay = L.mapbox.tileLayer('mapbox.comic').addTo(map);
+
 var range = document.getElementById('range');
 
 function clip() {
@@ -38,7 +39,5 @@ function clip() {
 
 range['oninput' in range ? 'oninput' : 'onchange'] = clip;
 map.on('move', clip);
-map.setView([49.434,-123.272], 7);
-
 clip();
 </script>


### PR DESCRIPTION
The _Swipe between layers_ [example](https://www.mapbox.com/mapbox.js/example/v1.0.0/swipe-layers/) was not loading after the update to v3.0.1. Moving `setView` up to the map initialization appears to fix the issue. 

cc @colleenmcginnis @tmcw 