### PR TITLE
update leaflet marker cluster version in examples addresses #1201

### DIFF
--- a/docs/_posts/examples/v1.0.0/0100-01-01-filtering-marker-clusters.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-filtering-marker-clusters.html
@@ -7,9 +7,9 @@ description: Show only filtered markers in marker clusters
 tags:
   - cluster
 ---
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/leaflet.markercluster.js'></script>
-<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.css' rel='stylesheet' />
-<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.Default.css' rel='stylesheet' />
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v1.0.0/leaflet.markercluster.js'></script>
+<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v1.0.0/MarkerCluster.css' rel='stylesheet' />
+<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v1.0.0/MarkerCluster.Default.css' rel='stylesheet' />
 
 <style>
 #colors {

--- a/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-markercluster.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-markercluster.html
@@ -8,9 +8,9 @@ tags:
   - cluster
 ---
 
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/leaflet.markercluster.js'></script>
-<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.css' rel='stylesheet' />
-<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.Default.css' rel='stylesheet' />
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v1.0.0/leaflet.markercluster.js'></script>
+<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v1.0.0/MarkerCluster.css' rel='stylesheet' />
+<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v1.0.0/MarkerCluster.Default.css' rel='stylesheet' />
 
 <!-- Example data. -->
 <script src="{{site.baseurl}}/assets/data/realworld.388.js"></script>

--- a/docs/_posts/examples/v1.0.0/0100-01-01-listing-marker-clusters.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-listing-marker-clusters.html
@@ -7,9 +7,9 @@ description: Show a list of clustered markers by their coordinates on a map with
 tags:
   - cluster
 ---
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/leaflet.markercluster.js'></script>
-<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.css' rel='stylesheet' />
-<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.Default.css' rel='stylesheet' />
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v1.0.0/leaflet.markercluster.js'></script>
+<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v1.0.0/MarkerCluster.css' rel='stylesheet' />
+<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v1.0.0/MarkerCluster.Default.css' rel='stylesheet' />
 
 <style>
 pre.ui-coordinates {

--- a/docs/_posts/examples/v1.0.0/0100-01-01-markercluster-custom-marker-icons.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-markercluster-custom-marker-icons.html
@@ -7,9 +7,9 @@ description: Show the number of markers in a cluster with custom simplestyle mar
 tags:
   - cluster
 ---
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/leaflet.markercluster.js'></script>
-<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.css' rel='stylesheet' />
-<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.Default.css' rel='stylesheet' />
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v1.0.0/leaflet.markercluster.js'></script>
+<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v1.0.0/MarkerCluster.css' rel='stylesheet' />
+<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v1.0.0/MarkerCluster.Default.css' rel='stylesheet' />
 
 <div id='map'></div>
 

--- a/docs/_posts/examples/v1.0.0/0100-01-01-markercluster-custom-polygon-appearance.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-markercluster-custom-polygon-appearance.html
@@ -7,9 +7,9 @@ description: Show a custom styled polygon for the extent of clustered markers
 tags:
   - cluster
 ---
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/leaflet.markercluster.js'></script>
-<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.css' rel='stylesheet' />
-<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.Default.css' rel='stylesheet' />
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v1.0.0/leaflet.markercluster.js'></script>
+<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v1.0.0/MarkerCluster.css' rel='stylesheet' />
+<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v1.0.0/MarkerCluster.Default.css' rel='stylesheet' />
 
 <div id='map'></div>
 

--- a/docs/_posts/examples/v1.0.0/0100-01-01-markercluster-multiple-groups.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-markercluster-multiple-groups.html
@@ -7,9 +7,9 @@ description: Show different types of markers in their own cluster types
 tags:
   - cluster
 ---
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/leaflet.markercluster.js'></script>
-<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.css' rel='stylesheet' />
-<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.Default.css' rel='stylesheet' />
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v1.0.0/leaflet.markercluster.js'></script>
+<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v1.0.0/MarkerCluster.css' rel='stylesheet' />
+<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v1.0.0/MarkerCluster.Default.css' rel='stylesheet' />
 
 <div id='map'></div>
 

--- a/docs/_posts/examples/v1.0.0/0100-01-01-markercluster-with-mapbox-data.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-markercluster-with-mapbox-data.html
@@ -7,9 +7,9 @@ description: Cluster markers from a Mapbox featureLayer using MarkerClusterGroup
 tags:
   - cluster
 ---
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/leaflet.markercluster.js'></script>
-<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.css' rel='stylesheet' />
-<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.Default.css' rel='stylesheet' />
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v1.0.0/leaflet.markercluster.js'></script>
+<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v1.0.0/MarkerCluster.css' rel='stylesheet' />
+<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v1.0.0/MarkerCluster.Default.css' rel='stylesheet' />
 
 <div id='map'></div>
 

--- a/docs/_posts/plugins/0100-01-01-leaflet-markercluster.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-markercluster.html
@@ -9,6 +9,6 @@ tags:
 code: https://github.com/Leaflet/Leaflet.markercluster
 license: MIT
 ---
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/leaflet.markercluster.js'></script>
-<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.css' rel='stylesheet' />
-<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v0.4.0/MarkerCluster.Default.css' rel='stylesheet' />
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v1.0.0/leaflet.markercluster.js'></script>
+<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v1.0.0/MarkerCluster.css' rel='stylesheet' />
+<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-markercluster/v1.0.0/MarkerCluster.Default.css' rel='stylesheet' />


### PR DESCRIPTION
Depends on https://github.com/mapbox/mapbox.js-plugins/pull/35. 

Updates leaflet markercluster version. 