### PR TITLE
Updates featureLayer to be interactive only if there is popup content

### DIFF
--- a/src/feature_layer.js
+++ b/src/feature_layer.js
@@ -91,10 +91,11 @@ var FeatureLayer = L.FeatureGroup.extend({
                 pointToLayer = this.options.pointToLayer || function(feature, latlon) {
                   return marker.style(feature, latlon, opts);
                 },
-                layer = L.GeoJSON.geometryToLayer(json, {
-                    pointToLayer: pointToLayer
-                }),
                 popupHtml = marker.createPopup(json, this.options.sanitizer),
+                layer = L.GeoJSON.geometryToLayer(json, {
+                    pointToLayer: pointToLayer,
+                    interactive: !!popupHtml
+                }),
                 style = this.options.style,
                 defaultStyle = style === simplestyle.style;
 


### PR DESCRIPTION
This patch suggests that **a feature layer should be considered interactive only if there is a popup attached to it.**

By default a vector layer is considered [interactive by default](https://github.com/Leaflet/Leaflet/blob/master/src/layer/vector/Path.js#L70). When a layer is "interactive", leaflet [adds a class to the DOM](https://github.com/Leaflet/Leaflet/blob/14c5f1602cdd337df14c37ea8df777578219f744/src/layer/vector/SVG.js#L113-L115) that makes the DOM look clickable (by applying the CSS property `cursor: pointer;` ).
Our users have complained about the poor user experience resulting from this: they see a pointer cursor, they try to click on the layer, but nothing happens.