### PR TITLE
regular case `section` for search

### DIFF
--- a/docs/_layouts/pages.html
+++ b/docs/_layouts/pages.html
@@ -2,7 +2,7 @@
 layout: default
 class: fill-light
 options: full
-section: mapboxjs
+section: Mapbox.js
 hasdocnav: true
 examples:
   - id: animation


### PR DESCRIPTION
Small update to regular case the section name - this value (will be used) in Swiftype/search results to help categorize these pages as being part of the “Mapbox.js” site

cc @geografa 