### PR TITLE
Fix broken paths to assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,13 @@ Requirements:
 1. Make edits to `theme/images/icons.svg`.
 2. Run `./theme/images/render.sh` to update sprites from your edits.
 3. Add a CSS reference with the appropriate pixel coordinate if adding a new icon.
+
+### Running docuemntation locally
+
+Documentation is powered by [Jekyll](http://jekyllrb.com/). Running using the
+following command:
+
+
+``` sh
+./jekyll.sh
+```

--- a/_config.yml
+++ b/_config.yml
@@ -9,5 +9,4 @@ baseurl: /mapbox.js
 mapboxjs: v3.0.1
 mapboxjsbase: /mapbox.js/dist
 defaultid: 'mapbox.streets'
-exclude: [dist]
 future: true

--- a/jekyll.sh
+++ b/jekyll.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+JEKYLL_ENV=production jekyll serve --watch


### PR DESCRIPTION
The nature of `{{site.url}}` [changed as of Jekyll v3.3](http://jekyllrb.com/news/#3-siteurl-is-set-by-the-development-server). This commit accounts for that by passing a `JEKYLL_ENV=production` variable in a wrapped `jekyll.sh` executable.