### PR TITLE
Run make to create built release before NPM publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+node_modules
+_site
+tmp

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "sanitize-caja": "0.1.4"
   },
   "scripts": {
-    "test": "eslint --no-eslintrc -c .eslintrc src && phantomjs node_modules/mocha-phantomjs-core/mocha-phantomjs-core.js test/index.html"
+    "test": "eslint --no-eslintrc -c .eslintrc src && phantomjs node_modules/mocha-phantomjs-core/mocha-phantomjs-core.js test/index.html",
+    "prepublishOnly": "npm run build",
+    "build": "make"
   },
   "license": "BSD-3-Clause",
   "devDependencies": {


### PR DESCRIPTION
At the moment each project depending on mapbox.js has to create the built release files on their own. With that we bring the built releases directly to these projects by putting them inside the package before publish, so they are available for everyone directly when the package is installed via npm.

The git repository instead is still clean and will not contain them.