### PR TITLE
Update Leaflet.draw plugin to v0.4.10

### DIFF
--- a/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-draw.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-draw.html
@@ -7,8 +7,8 @@ description: Add drawing tools for users to author shapes using the Leaflet Draw
 tags:
   - plugins
 ---
-<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-draw/v0.2.3/leaflet.draw.css' rel='stylesheet' />
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-draw/v0.2.3/leaflet.draw.js'></script>
+<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-draw/v0.4.10/leaflet.draw.css' rel='stylesheet' />
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-draw/v0.4.10/leaflet.draw.js'></script>
 
 <div id='map'></div>
 

--- a/docs/_posts/examples/v1.0.0/0100-01-01-show-polygon-area.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-show-polygon-area.html
@@ -10,8 +10,8 @@ tags:
   - plugins
 ---
 
-<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-draw/v0.2.3/leaflet.draw.css' rel='stylesheet' />
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-draw/v0.2.3/leaflet.draw.js'></script>
+<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-draw/v0.4.10/leaflet.draw.css' rel='stylesheet' />
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-draw/v0.4.10/leaflet.draw.js'></script>
 <script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-geodesy/v0.1.0/leaflet-geodesy.js'></script>
 
 <div id='map'></div>

--- a/docs/_posts/plugins/0100-01-01-leaflet-draw.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-draw.html
@@ -9,5 +9,5 @@ tags:
 code: https://github.com/Leaflet/Leaflet.draw
 license: BSD
 ---
-<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-draw/v0.2.3/leaflet.draw.js'></script>
-<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-draw/v0.2.3/leaflet.draw.css' rel='stylesheet' />
+<script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-draw/v0.4.10/leaflet.draw.js'></script>
+<link href='{{site.tileApi}}/mapbox.js/plugins/leaflet-draw/v0.4.10/leaflet.draw.css' rel='stylesheet' />


### PR DESCRIPTION
Updates the Leaflet plugins page and both the "Leaflet draw" and "Show drawn polygon area" examples to use the most recent version of the Leaflet.draw plugin.