### PR TITLE
Use leaflet caret version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "corslite": "0.0.6",
     "isarray": "0.0.1",
-    "leaflet": "1.0.2",
+    "leaflet": "^1.0.2",
     "mustache": "2.2.1",
     "sanitize-caja": "0.1.4"
   },


### PR DESCRIPTION
I'd like to have only a single copy of leaflet in my webpack output, but since mapbox.js forces 1.0.2 exactly I can't do that.

Changelog looks pretty safe: https://github.com/Leaflet/Leaflet/releases