### PR TITLE
[WIP] Add check for logo in tileJson when adding a tilelayer

### DIFF
--- a/src/tile_layer.js
+++ b/src/tile_layer.js
@@ -61,6 +61,10 @@ var TileLayer = L.TileLayer.extend({
             bounds: json.bounds && util.lbounds(json.bounds)
         });
 
+        if (map._mapboxLogoControl && json.mapbox_logo) {
+            L.DomUtil.addClass(map._mapboxLogoControl._container, 'mapbox-logo-true');
+        }
+
         this._tilejson = json;
         this.redraw();
         return this;


### PR DESCRIPTION
Per https://github.com/mapbox/mapbox.js/issues/1227, a few examples ([example](https://www.mapbox.com/mapbox.js/example/v1.0.0/toggle-baselayers/)) don't show the Mapbox logo because the map doesn't initialize with any tileJSON to check (tileLayers are added after the map has finished initializing). This PR only adds a check to `tileLayer`, but it may be worth adding a check to the other [layer types](https://github.com/mapbox/mapbox.js/blob/eb5eab2a128e4ed10b241f88c535a96c2e984b40/src/map.js#L123-L154). I'm sure there is a better way to target the `mapboxLogoControl` container or to avoid duplicating this check across all of the layer types, so please comment with suggestions! 

Need: 
- [ ] Do something other than referencing `map` 

Tested locally and the above [example](https://www.mapbox.com/mapbox.js/example/v1.0.0/toggle-baselayers/) works as expected. 

cc @geografa @lizziegooding 