### PR TITLE
Replace `L.Mixin.events` by `L.Evented.prototype`

### DIFF
--- a/src/feedback.js
+++ b/src/feedback.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var Feedback = L.Class.extend({
-    includes: L.Mixin.Events,
+    includes: L.Evented.prototype || L.Mixin.Events,
     data: {},
     record: function(data) {
         L.extend(this.data, data);

--- a/src/geocoder_control.js
+++ b/src/geocoder_control.js
@@ -4,7 +4,7 @@ var geocoder = require('./geocoder'),
     util = require('./util');
 
 var GeocoderControl = L.Control.extend({
-    includes: L.Mixin.Events,
+    includes: L.Evented.prototype || L.Mixin.Events,
 
     options: {
         proximity: true,


### PR DESCRIPTION
This commits removed the deprecated warnings due to `L.Mixin.events`. Note that Leaflet fixed others deprecated warnings on their `master` branch, but did not push a release yet.