### PR TITLE
Fix Overzoom issues with tile layers

### DIFF
--- a/src/tile_layer.js
+++ b/src/tile_layer.js
@@ -52,11 +52,14 @@ var TileLayer = L.TileLayer.extend({
           }
         }
 
+        var minZoom = this.options.minZoom || json.minzoom || 0;
+		var maxZoom = this.options.maxZoom || json.maxzoom || 18;
+
         L.extend(this.options, {
             tiles: json.tiles,
             attribution: this.options.sanitizer(json.attribution),
-            minZoom: json.minzoom || 0,
-            maxZoom: json.maxzoom || 18,
+            minZoom: minZoom,
+            maxZoom: maxZoom,
             tms: json.scheme === 'tms',
             bounds: json.bounds && util.lbounds(json.bounds)
         });
@@ -76,6 +79,7 @@ var TileLayer = L.TileLayer.extend({
         var tiles = this.options.tiles,
             index = Math.floor(Math.abs(tilePoint.x + tilePoint.y) % tiles.length),
             url = tiles[index];
+        tilePoint.z = this._getZoomForUrl();
 
         var templated = L.Util.template(url, tilePoint);
         if (!templated || !this.options.format) {

--- a/src/tile_layer.js
+++ b/src/tile_layer.js
@@ -52,8 +52,8 @@ var TileLayer = L.TileLayer.extend({
           }
         }
 
-        var minZoom = this.options.minZoom || json.minzoom || 0;
-		var maxZoom = this.options.maxZoom || json.maxzoom || 18;
+        var minZoom = this.options.minZoom !== 0 ? this.options.minZoom : json.minzoom || 0;
+		var maxZoom = this.options.maxZoom !== 18 ? this.options.maxZoom : json.maxzoom || 18;
 
         L.extend(this.options, {
             tiles: json.tiles,
@@ -79,7 +79,7 @@ var TileLayer = L.TileLayer.extend({
         var tiles = this.options.tiles,
             index = Math.floor(Math.abs(tilePoint.x + tilePoint.y) % tiles.length),
             url = tiles[index];
-        tilePoint.z = this._getZoomForUrl();
+        tilePoint.z = this._getZoomForUrl() || 0;
 
         var templated = L.Util.template(url, tilePoint);
         if (!templated || !this.options.format) {

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,7 +1,7 @@
 var helpers = {};
 
 beforeEach(function() {
-    L.mapbox.accessToken = 'key';
+    L.mapbox.accessToken = 'pk.eyJ1IjoidHZibG9tYmVyZyIsImEiOiJjaXZsZmpsMWwwNXBuMnRudmJqNGQyMjJwIn0.842ovgKydac51tg6b9qKbg';
 });
 
 // permissive test of leaflet-like location objects
@@ -200,6 +200,30 @@ helpers.tileJSON = {
     "id":"examples.map-8ced9urs",
     "maxzoom":17,
     "minzoom":0,
+    "name":"Bird species",
+    "private":true,
+    "scheme":"xyz",
+    "template":"{{#__l0__}}{{#__location__}}{{/__location__}}{{#__teaser__}}<div class='birds-tooltip'>\n  <strong>{{name}}</strong>\n  <strong>{{count}} species</strong>\n  <small>{{species}}</small>\n  <div class='carmen-fields' style='display:none'>\n  {{search}} {{lon}} {{lat}} {{bounds}}\n  </div>\n</div>\n<style type='text/css'>\n.birds-tooltip strong { display:block; font-size:16px; }\n.birds-tooltip small { font-size:10px; display:block; overflow:hidden; max-height:90px; line-height:15px; }\n</style>{{/__teaser__}}{{#__full__}}{{/__full__}}{{/__l0__}}",
+    "tilejson":"2.0.0",
+    "tiles":["http://a.tiles.mapbox.com/v3/examples.map-8ced9urs/{z}/{x}/{y}.png",
+        "http://b.tiles.mapbox.com/v3/examples.map-8ced9urs/{z}/{x}/{y}.png",
+        "http://c.tiles.mapbox.com/v3/examples.map-8ced9urs/{z}/{x}/{y}.png",
+        "http://d.tiles.mapbox.com/v3/examples.map-8ced9urs/{z}/{x}/{y}.png"],
+    "webpage":"http://tiles.mapbox.com/examples/map/map-8ced9urs"
+};
+
+helpers.tileJSONNoMinMax = {
+    "attribution":"Data provided by NatureServe in collaboration with Robert Ridgely",
+    "bounds":[-180,-85.0511,180,85.0511],
+    "center":[-98.976,39.386,4],
+    "data":["http://a.tiles.mapbox.com/v3/examples.map-8ced9urs/markers.geojsonp"],
+    "description":"Bird species of North America, gridded by species count.",
+    "geocoder":"http://a.tiles.mapbox.com/v3/examples.map-8ced9urs/geocode/{query}.jsonp",
+    "grids":["http://a.tiles.mapbox.com/v3/examples.map-8ced9urs/{z}/{x}/{y}.grid.json",
+        "http://b.tiles.mapbox.com/v3/examples.map-8ced9urs/{z}/{x}/{y}.grid.json",
+        "http://c.tiles.mapbox.com/v3/examples.map-8ced9urs/{z}/{x}/{y}.grid.json",
+        "http://d.tiles.mapbox.com/v3/examples.map-8ced9urs/{z}/{x}/{y}.grid.json"],
+    "id":"examples.map-8ced9urs",
     "name":"Bird species",
     "private":true,
     "scheme":"xyz",

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,7 +1,7 @@
 var helpers = {};
 
 beforeEach(function() {
-    L.mapbox.accessToken = 'pk.eyJ1IjoidHZibG9tYmVyZyIsImEiOiJjaXZsZmpsMWwwNXBuMnRudmJqNGQyMjJwIn0.842ovgKydac51tg6b9qKbg';
+    L.mapbox.accessToken = 'key';
 });
 
 // permissive test of leaflet-like location objects

--- a/test/spec/tile_layer.js
+++ b/test/spec/tile_layer.js
@@ -10,10 +10,24 @@ describe("L.mapbox.tileLayer", function() {
     });
 
     describe("constructor", function() {
-        it("sets min and max zoom", function() {
+        it("sets min and max zoom based on tileJSON", function() {
             var layer = L.mapbox.tileLayer(helpers.tileJSON);
             expect(layer.options.minZoom).to.equal(0);
             expect(layer.options.maxZoom).to.equal(17);
+            expect(layer instanceof L.mapbox.TileLayer).to.eql(true);
+        });
+
+        it("sets min and max zoom based on default", function() {
+            var layer = L.mapbox.tileLayer(helpers.tileJSONNoMinMax);
+            expect(layer.options.minZoom).to.equal(0);
+            expect(layer.options.maxZoom).to.equal(18);
+            expect(layer instanceof L.mapbox.TileLayer).to.eql(true);
+        });
+
+        it("sets min and max zoom based on user input", function() {
+            var layer = L.mapbox.tileLayer(helpers.tileJSON, { minZoom: 5, maxZoom: 15});
+            expect(layer.options.minZoom).to.equal(5);
+            expect(layer.options.maxZoom).to.equal(15);
             expect(layer instanceof L.mapbox.TileLayer).to.eql(true);
         });
 


### PR DESCRIPTION
This pull request should fix issues with calculating zoom for maxNativeZoom and calculating tilesize.
Right now the maxNativeZoom option does not do anything for tileLayers.  This worked correctly in version 2.1.5. Currently users will get white tiles when overzooming. This is my first pull request so please let me know if I am doing something wrong. This should fix issue #1250 

Here is the example of the two versions:
2.1.5: https://jsfiddle.net/jfwkq0s4/4/
3.1.1: http://jsfiddle.net/dbpfcoqo/6/