### PR TITLE
Bump Leaflet Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "corslite": "0.0.6",
     "isarray": "0.0.1",
-    "leaflet": "1.0.2",
+    "leaflet": "1.3.3",
     "mustache": "2.2.1",
     "sanitize-caja": "0.1.4"
   },


### PR DESCRIPTION
Recent Leaflet version bump includes additional ADA compliance coverage

https://leafletjs.com/

Old Version: 1.0.2
New Version: 1.3.3

