### PR TITLE
Change feedback app URL

### DIFF
--- a/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-studio-style.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-leaflet-studio-style.html
@@ -19,6 +19,6 @@ L.tileLayer(
     'https://api.mapbox.com/styles/v1/mapbox/emerald-v8/tiles/{z}/{x}/{y}?access_token=' + L.mapbox.accessToken, {
         tileSize: 512,
         zoomOffset: -1,
-        attribution: '© <a href="https://www.mapbox.com/feedback/">Mapbox</a> © <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+        attribution: '© <a href="https://apps.mapbox.com/feedback/">Mapbox</a> © <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
     }).addTo(map);
 </script>


### PR DESCRIPTION
We are transitioning the feedback app to a new subdomain: `apps.mapbox.com/feedback/`. 