### PR TITLE
[docs] adds jekyll-sitemap plugin to generate a sitemap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org" do
   gem 'jekyll', '3.1.6'
+  gem 'jekyll-sitemap'
 end

--- a/_config.yml
+++ b/_config.yml
@@ -10,3 +10,5 @@ mapboxjs: v3.1.1
 mapboxjsbase: /mapbox.js/dist
 defaultid: 'mapbox.streets'
 future: true
+gems:
+- jekyll-sitemap


### PR DESCRIPTION
We're adding a sitemap to Mapbox.js so we can add it to the search console.

To test this PR:

1. `bundle install`
2. `bundle exec jekyll serve`
3. Navigate to http://127.0.0.1:4000/mapbox.js/sitemap.xml  and you should see an XML document with the files in this site!