### PR TITLE
Upgrade Leaflet to v1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1748,21 +1748,9 @@
       "dev": true
     },
     "leaflet": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.0.2.tgz",
-      "integrity": "sha1-+k+8t4RJRPwr+wvPnKDeoTRjyiE="
-    },
-    "leaflet-fullscreen": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/leaflet-fullscreen/-/leaflet-fullscreen-0.0.4.tgz",
-      "integrity": "sha1-9mXf1CvbIwaz6JcxFqTo5FrxXdc=",
-      "dev": true
-    },
-    "leaflet-hash": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/leaflet-hash/-/leaflet-hash-0.2.1.tgz",
-      "integrity": "sha1-w2xxg0fFJDAztXy0uuomEZ2CxwE=",
-      "dev": true
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.4.0.tgz",
+      "integrity": "sha512-x9j9tGY1+PDLN9pcWTx9/y6C5nezoTMB8BLK5jTakx+H7bPlnbCHfi9Hjg+Qt36sgDz/cb9lrSpNQXmk45Tvhw=="
     },
     "levn": {
       "version": "0.2.5",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "corslite": "0.0.6",
     "isarray": "0.0.1",
-    "leaflet": "1.3.3",
+    "leaflet": "1.4.0",
     "mustache": "2.2.1",
     "sanitize-caja": "0.1.4"
   },
@@ -27,8 +27,6 @@
     "eslint": "^0.23.0",
     "expect.js": "0.3.1",
     "happen": "0.1.3",
-    "leaflet-fullscreen": "0.0.4",
-    "leaflet-hash": "0.2.1",
     "marked": "~0.3.0",
     "minifyify": "^6.1.0",
     "minimist": "0.0.5",


### PR DESCRIPTION
Also removes plugins from dev deps that were not used anywhere (we use the CDN versions in the examples).