### PR TITLE
Force HTTPS by default

### DIFF
--- a/API.md
+++ b/API.md
@@ -649,16 +649,16 @@ in [API access tokens](../api-access-tokens).
 
 ## L.mapbox.config.FORCE_HTTPS
 
-By default, this is `false`. Mapbox.js auto-detects whether the page your map
+By default, this is `true`. Mapbox.js always requires HTTPS resources,
+regardless of the host page's scheme.
+
+Setting `FORCE_HTTPS` to `false` makes Mapbox.js auto-detect whether the page your map
 is embedded in is using HTTPS or SSL, and matches: if you use HTTPS on your site,
 it uses HTTPS resources.
 
-Setting `FORCE_HTTPS` to `true` makes Mapbox.js always require HTTPS resources,
-regardless of the host page's scheme.
-
 _Example_:
 
-    L.mapbox.config.FORCE_HTTPS = true;
+    L.mapbox.config.FORCE_HTTPS = false;
 
 ## L.mapbox.config.HTTP_URL
 

--- a/src/config.js
+++ b/src/config.js
@@ -3,6 +3,6 @@
 module.exports = {
     HTTP_URL: 'http://a.tiles.mapbox.com/v4',
     HTTPS_URL: 'https://a.tiles.mapbox.com/v4',
-    FORCE_HTTPS: false,
+    FORCE_HTTPS: true,
     REQUIRE_ACCESS_TOKEN: true
 };

--- a/test/spec/feature_layer.js
+++ b/test/spec/feature_layer.js
@@ -20,7 +20,7 @@ describe('L.mapbox.featureLayer', function() {
     });
 
     it('loads data from a GeoJSON URL', function() {
-        var url = 'http://api.tiles.mapbox.com/v4/examples.map-zr0njcqy/features.json',
+        var url = 'https://api.tiles.mapbox.com/v4/examples.map-zr0njcqy/features.json',
             layer = L.mapbox.featureLayer(url);
 
         server.respondWith("GET", url,
@@ -57,11 +57,6 @@ describe('L.mapbox.featureLayer', function() {
     });
 
     describe("#loadURL", function() {
-        it('returns self', function() {
-            var layer = L.mapbox.featureLayer();
-            expect(layer.loadURL('http://a.tiles.mapbox.com/v3/mapbox.map-0l53fhk2.json')).to.eql(layer);
-        });
-
         it('emits a ready event', function(done) {
             var layer = L.mapbox.featureLayer();
 
@@ -69,9 +64,9 @@ describe('L.mapbox.featureLayer', function() {
                 done();
             });
 
-            layer.loadURL('http://a.tiles.mapbox.com/v3/mapbox.map-0l53fhk2.json');
+            layer.loadURL('https://a.tiles.mapbox.com/v3/mapbox.map-0l53fhk2.json');
 
-            server.respondWith("GET", "http://a.tiles.mapbox.com/v3/mapbox.map-0l53fhk2.json",
+            server.respondWith("GET", "https://a.tiles.mapbox.com/v3/mapbox.map-0l53fhk2.json",
                 [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.geoJson)]);
             server.respond();
         });
@@ -85,9 +80,9 @@ describe('L.mapbox.featureLayer', function() {
                 done();
             });
 
-            layer.loadURL('http://a.tiles.mapbox.com/v3/mapbox.map-0l53fhk2.json');
+            layer.loadURL('https://a.tiles.mapbox.com/v3/mapbox.map-0l53fhk2.json');
 
-            server.respondWith("GET", "http://a.tiles.mapbox.com/v3/mapbox.map-0l53fhk2.json",
+            server.respondWith("GET", "https://a.tiles.mapbox.com/v3/mapbox.map-0l53fhk2.json",
                 [400, { "Content-Type": "application/json" }, JSON.stringify({error: 'error'})]);
             server.respond();
         });

--- a/test/spec/format_url.js
+++ b/test/spec/format_url.js
@@ -10,11 +10,11 @@ describe("format_url", function() {
     });
 
     it('returns a v4 URL with access_token parameter', function() {
-        expect(internals.url('/v4/user.map.json')).to.equal('http://a.tiles.mapbox.com/v4/user.map.json?access_token=key')
+        expect(internals.url('/v4/user.map.json')).to.equal('https://a.tiles.mapbox.com/v4/user.map.json?access_token=key')
     });
 
     it('uses provided access token', function() {
-        expect(internals.url('/v4/user.map.json', 'token')).to.equal('http://a.tiles.mapbox.com/v4/user.map.json?access_token=token')
+        expect(internals.url('/v4/user.map.json', 'token')).to.equal('https://a.tiles.mapbox.com/v4/user.map.json?access_token=token')
     });
 
     it('throws an error if no access token is provided', function() {
@@ -47,13 +47,13 @@ describe("format_url", function() {
             expect(internals.url.tileJSON('http://a.tiles.mapbox.com/v3/user.map.json')).to.equal('http://a.tiles.mapbox.com/v3/user.map.json')
         });
 
-        it('returns a v4 URL with access_token parameter', function() {
-            expect(internals.url.tileJSON('user.map')).to.equal('http://a.tiles.mapbox.com/v4/user.map.json?access_token=key')
+        it('returns a v4 URL with access_token parameter, uses https and appends &secure', function() {
+            expect(internals.url.tileJSON('user.map')).to.equal('https://a.tiles.mapbox.com/v4/user.map.json?access_token=key&secure');
         });
 
-        it('appends &secure and uses https when FORCE_HTTPS is set', function() {
-            internals.config.FORCE_HTTPS = true;
-            expect(internals.url.tileJSON('user.map')).to.equal('https://a.tiles.mapbox.com/v4/user.map.json?access_token=key&secure');
+        it('does not append &secure and uses http when FORCE_HTTPS is set to false', function() {
+            internals.config.FORCE_HTTPS = false;
+            expect(internals.url.tileJSON('user.map')).to.equal('http://a.tiles.mapbox.com/v4/user.map.json?access_token=key');
         });
     });
 

--- a/test/spec/geocoder.js
+++ b/test/spec/geocoder.js
@@ -13,38 +13,37 @@ describe('L.mapbox.geocoder', function() {
         it('supports multiple arguments', function() {
             var g = L.mapbox.geocoder('mapbox.places');
             expect(g.queryURL(['austin', 'houston']))
-                .to.eql('http://a.tiles.mapbox.com/geocoding/v5/mapbox.places/austin;houston.json?access_token=key');
+                .to.eql('https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/austin;houston.json?access_token=key');
         });
 
         it('supports proximity', function() {
             var g = L.mapbox.geocoder('mapbox.places');
             expect(g.queryURL({query: ['austin', 'houston'], proximity: [10, 15]}))
-                .to.eql('http://a.tiles.mapbox.com/geocoding/v5/mapbox.places/austin;houston.json?access_token=key&proximity=15,10');
+                .to.eql('https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/austin;houston.json?access_token=key&proximity=15,10');
         });
 
         it('supports country option', function() {
             var g = L.mapbox.geocoder('mapbox.places');
             expect(g.queryURL({query: ['austin', 'houston'], country: 'us'}))
-                .to.eql('http://a.tiles.mapbox.com/geocoding/v5/mapbox.places/austin;houston.json?access_token=key&country=us');
+                .to.eql('https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/austin;houston.json?access_token=key&country=us');
         });
 
         it('supports bbox option', function() {
             var g = L.mapbox.geocoder('mapbox.places');
             expect(g.queryURL({query: ['austin', 'houston'], bbox: [ -104.0458814, 26.0696823, -93.7347459, 36.4813628 ]}))
-                .to.eql('http://a.tiles.mapbox.com/geocoding/v5/mapbox.places/
-                    austin;houston.json?access_token=key&bbox='-104.0458814,26.0696823,-93.7347459,36.4813628');
+                .to.eql('https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/austin;houston.json?access_token=key&bbox=-104.0458814,26.0696823,-93.7347459,36.4813628');
         });
 
         it('supports autocomplete option', function() {
             var g = L.mapbox.geocoder('mapbox.places');
             expect(g.queryURL({query: ['austin', 'houston'], country: 'us', autocomplete: false}))
-                .to.eql('http://a.tiles.mapbox.com/geocoding/v5/mapbox.places/austin;houston.json?access_token=key&country=us&autocomplete=false');
+                .to.eql('https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/austin;houston.json?access_token=key&country=us&autocomplete=false');
         });
 
         it('rounds proximity params correctly', function() {
             var g = L.mapbox.geocoder('mapbox.places');
             expect(g.queryURL({query: ['austin', 'houston'], proximity: L.latLng(-10.12345, 15.67890)}))
-                .to.eql('http://a.tiles.mapbox.com/geocoding/v5/mapbox.places/austin;houston.json?access_token=key&proximity=15.679,-10.123');
+                .to.eql('https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/austin;houston.json?access_token=key&proximity=15.679,-10.123');
         });
 
         it('rounds reverse ')
@@ -52,9 +51,9 @@ describe('L.mapbox.geocoder', function() {
         it('supports types', function() {
             var g = L.mapbox.geocoder('mapbox.places');
             expect(g.queryURL({query: ['austin', 'houston'], types: 'place'}))
-                .to.eql('http://a.tiles.mapbox.com/geocoding/v5/mapbox.places/austin;houston.json?access_token=key&types=place');
+                .to.eql('https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/austin;houston.json?access_token=key&types=place');
             expect(g.queryURL({query: ['austin', 'houston'], types: ['place', 'address']}))
-                .to.eql('http://a.tiles.mapbox.com/geocoding/v5/mapbox.places/austin;houston.json?access_token=key&types=place,address');
+                .to.eql('https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/austin;houston.json?access_token=key&types=place,address');
         });
     });
 
@@ -63,7 +62,7 @@ describe('L.mapbox.geocoder', function() {
             var g = L.mapbox.geocoder('mapbox.places');
 
             server.respondWith('GET',
-                'http://a.tiles.mapbox.com/geocoding/v5/mapbox.places/austin;houston.json?access_token=key',
+                'https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/austin;houston.json?access_token=key',
                 [200, { 'Content-Type': 'application/json' }, JSON.stringify(helpers.geocoderBulk)]);
 
             g.query(['austin', 'houston'], function(err, res) {
@@ -78,7 +77,7 @@ describe('L.mapbox.geocoder', function() {
             var g = L.mapbox.geocoder('mapbox.places');
 
             server.respondWith('GET',
-                'http://a.tiles.mapbox.com/geocoding/v5/mapbox.places/austin.json?access_token=key',
+                'https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/austin.json?access_token=key',
                 [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.geocoderAustin)]);
 
             g.query('austin', function(err, res) {
@@ -94,7 +93,7 @@ describe('L.mapbox.geocoder', function() {
             var g = L.mapbox.geocoder('mapbox.places');
 
             server.respondWith('GET',
-                'http://a.tiles.mapbox.com/geocoding/v5/mapbox.places/nonesuch.json?access_token=key',
+                'https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/nonesuch.json?access_token=key',
                 [200, { 'Content-Type': 'application/json' }, JSON.stringify({"type":"FeatureCollection","query":["nonesuch"],"features":[]})]);
 
             g.query('nonesuch', function(err, res) {
@@ -111,7 +110,7 @@ describe('L.mapbox.geocoder', function() {
             var g = L.mapbox.geocoder('mapbox.places');
 
             server.respondWith('GET',
-                'http://a.tiles.mapbox.com/geocoding/v5/mapbox.places/-97.7%2C30.3.json?access_token=key',
+                'https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/-97.7%2C30.3.json?access_token=key',
                 [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.geocoderReverse)]);
 
             g.reverseQuery({ lat: 30.3, lng: -97.7 }, function(err, res) {
@@ -126,7 +125,7 @@ describe('L.mapbox.geocoder', function() {
             var g = L.mapbox.geocoder('mapbox.places');
 
             server.respondWith('GET',
-                /http:\/\/a\.tiles\.mapbox\.com\/geocoding\/v5\/mapbox.places\/[\-\d\.]+(%2C|,)[\-\d\.]+\.json\?access_token=key/,
+                /https:\/\/a\.tiles\.mapbox\.com\/geocoding\/v5\/mapbox.places\/[\-\d\.]+(%2C|,)[\-\d\.]+\.json\?access_token=key/,
                 [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.geocoderReverseRounded)]);
 
             g.reverseQuery({ lat: 30.1234567890, lng: -97.0987654321 }, function(err, res) {

--- a/test/spec/geocoder_control.js
+++ b/test/spec/geocoder_control.js
@@ -17,7 +17,7 @@ describe('L.mapbox.geocoderControl', function() {
         expect(control instanceof L.mapbox.GeocoderControl).to.eql(true);
 
         server.respondWith('GET',
-            'http://a.tiles.mapbox.com/geocoding/v5/mapbox.places/austin.json?access_token=key',
+            'https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/austin.json?access_token=key',
             [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.geocoderAustin)]);
 
         control._input.value = 'austin';
@@ -32,7 +32,7 @@ describe('L.mapbox.geocoderControl', function() {
             control = L.mapbox.geocoderControl('mapbox.places', { proximity: false }).addTo(map);
 
         server.respondWith('GET',
-            'http://a.tiles.mapbox.com/geocoding/v5/mapbox.places/white%20house.json?access_token=key',
+            'https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/white%20house.json?access_token=key',
             [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.geocoderWhiteHouse)]);
 
         control._input.value = 'white house';
@@ -51,7 +51,7 @@ describe('L.mapbox.geocoderControl', function() {
             }).addTo(map);
 
         server.respondWith('GET',
-            'http://a.tiles.mapbox.com/geocoding/v5/mapbox.places/white%20house.json?access_token=key',
+            'https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/white%20house.json?access_token=key',
             [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.geocoderWhiteHouse)]);
 
         control._input.value = 'white house';
@@ -74,7 +74,7 @@ describe('L.mapbox.geocoderControl', function() {
             }).addTo(map);
 
         server.respondWith('GET',
-            'http://a.tiles.mapbox.com/geocoding/v5/mapbox.places/white%20house.json?access_token=key&country=us&autocomplete=false',
+            'https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/white%20house.json?access_token=key&country=us&autocomplete=false',
             [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.geocoderWhiteHouse)]);
 
         control._input.value = 'white house';
@@ -95,7 +95,7 @@ describe('L.mapbox.geocoderControl', function() {
         map.setView([0, 0], 14);
 
         server.respondWith('GET',
-            'http://a.tiles.mapbox.com/geocoding/v5/mapbox.places/white%20house.json?access_token=key',
+            'https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/white%20house.json?access_token=key',
             [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.geocoderWhiteHouse)]);
 
         control._input.value = 'white house';
@@ -108,12 +108,12 @@ describe('L.mapbox.geocoderControl', function() {
 
     it('sets url based on an id', function() {
         var control = L.mapbox.geocoderControl('mapbox.places');
-        expect(control.getURL()).to.equal('http://a.tiles.mapbox.com/geocoding/v5/mapbox.places/{query}.json?access_token=key');
+        expect(control.getURL()).to.equal('https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/{query}.json?access_token=key');
     });
 
     it('supports custom access token', function() {
         var control = L.mapbox.geocoderControl('mapbox.places', {accessToken: 'custom'});
-        expect(control.getURL()).to.equal('http://a.tiles.mapbox.com/geocoding/v5/mapbox.places/{query}.json?access_token=custom');
+        expect(control.getURL()).to.equal('https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/{query}.json?access_token=custom');
     });
 
     it('#setURL', function() {
@@ -125,7 +125,7 @@ describe('L.mapbox.geocoderControl', function() {
     it('#setID', function() {
         var control = L.mapbox.geocoderControl('mapbox.places');
         expect(control.setID('mapbox.places')).to.eql(control);
-        expect(control.getURL()).to.equal('http://a.tiles.mapbox.com/geocoding/v5/mapbox.places/{query}.json?access_token=key');
+        expect(control.getURL()).to.equal('https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/{query}.json?access_token=key');
     });
 
     it('is by default in the top left', function() {
@@ -143,14 +143,14 @@ describe('L.mapbox.geocoderControl', function() {
     describe('#keepOpen', function(done) {
         it('true', function() {
             var map = new L.Map(document.createElement('div'));
-            var control = L.mapbox.geocoderControl('http://example.com/{query}.json', {
+            var control = L.mapbox.geocoderControl('https://example.com/{query}.json', {
                 keepOpen: true
             }).addTo(map);
             expect(control._container.className).to.eql('leaflet-control-mapbox-geocoder leaflet-bar leaflet-control active');
         });
         it('false', function() {
             var map = new L.Map(document.createElement('div'));
-            var control = L.mapbox.geocoderControl('http://example.com/{query}.json').addTo(map);
+            var control = L.mapbox.geocoderControl('https://example.com/{query}.json').addTo(map);
             expect(control._container.className).to.eql('leaflet-control-mapbox-geocoder leaflet-bar leaflet-control');
         });
     });
@@ -160,7 +160,7 @@ describe('L.mapbox.geocoderControl', function() {
 
         beforeEach(function() {
             map = new L.Map(document.createElement('div'));
-            control = L.mapbox.geocoderControl('http://example.com/{query}.json', {
+            control = L.mapbox.geocoderControl('https://example.com/{query}.json', {
                 proximity: false
             }).addTo(map);
         });
@@ -175,7 +175,7 @@ describe('L.mapbox.geocoderControl', function() {
             control._input.value = 'austin';
             happen.once(control._form, { type: 'submit' });
 
-            server.respondWith('GET', 'http://example.com/austin.json',
+            server.respondWith('GET', 'https://example.com/austin.json',
                 [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.geocoderAustin)]);
             server.respond();
         });
@@ -188,7 +188,7 @@ describe('L.mapbox.geocoderControl', function() {
             control._input.value = 'unfindable';
             happen.once(control._form, { type: 'submit' });
 
-            server.respondWith('GET', 'http://example.com/unfindable.json',
+            server.respondWith('GET', 'https://example.com/unfindable.json',
                 [200, { "Content-Type": "application/json" }, JSON.stringify({features:[]})]);
             server.respond();
         });
@@ -202,7 +202,7 @@ describe('L.mapbox.geocoderControl', function() {
             control._input.value = 'austin';
             happen.once(control._form, { type: 'submit' });
 
-            server.respondWith('GET', 'http://example.com/austin.json',
+            server.respondWith('GET', 'https://example.com/austin.json',
                 [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.geocoderAustin)]);
             server.respond();
         });
@@ -211,7 +211,7 @@ describe('L.mapbox.geocoderControl', function() {
             control._input.value = 'chester';
             happen.once(control._form, { type: 'submit' });
 
-            server.respondWith('GET', 'http://example.com/chester.json',
+            server.respondWith('GET', 'https://example.com/chester.json',
                 [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.geocoderMulti)]);
             server.respond();
 
@@ -233,7 +233,7 @@ describe('L.mapbox.geocoderControl', function() {
             control._input.value = 'austin';
             happen.once(control._form, { type: 'submit' });
 
-            server.respondWith('GET', 'http://example.com/austin.json',
+            server.respondWith('GET', 'https://example.com/austin.json',
                 [400, { "Content-Type": "application/json" }, JSON.stringify(helpers.geocoderAustin)]);
             server.respond();
         });
@@ -244,7 +244,7 @@ describe('L.mapbox.geocoderControl', function() {
 
         beforeEach(function() {
             map = new L.Map(document.createElement('div'));
-            control = L.mapbox.geocoderControl('http://example.com/{query}.json', {
+            control = L.mapbox.geocoderControl('https://example.com/{query}.json', {
                 autocomplete: true,
                 proximity: false
             }).addTo(map);
@@ -259,7 +259,7 @@ describe('L.mapbox.geocoderControl', function() {
             control._input.value = 'austin';
             happen.once(control._form, { type: 'submit' });
 
-            server.respondWith('GET', 'http://example.com/austin.json',
+            server.respondWith('GET', 'https://example.com/austin.json',
                 [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.geocoderAustin)]);
             server.respond();
         });
@@ -270,7 +270,7 @@ describe('L.mapbox.geocoderControl', function() {
 
         beforeEach(function() {
             map = new L.Map(document.createElement('div'), { center: [0,0], zoom: 0});
-            control = L.mapbox.geocoderControl('http://example.com/{query}.json', {
+            control = L.mapbox.geocoderControl('https://example.com/{query}.json', {
                 autocomplete: true,
                 proximity: true
             }).addTo(map);
@@ -285,7 +285,7 @@ describe('L.mapbox.geocoderControl', function() {
             control._input.value = 'austin';
             happen.once(control._form, { type: 'submit' });
 
-            server.respondWith('GET', 'http://example.com/austin.json&proximity=0,0',
+            server.respondWith('GET', 'https://example.com/austin.json&proximity=0,0',
                 [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.geocoderAustin)]);
             server.respond();
         });

--- a/test/spec/grid_layer.js
+++ b/test/spec/grid_layer.js
@@ -45,7 +45,7 @@ describe('L.mapbox.gridLayer', function() {
         });
 
         it('loads TileJSON from a URL', function(done) {
-            var layer = L.mapbox.gridLayer('http://a.tiles.mapbox.com/v3/mapbox.map-0l53fhk2.json');
+            var layer = L.mapbox.gridLayer('https://a.tiles.mapbox.com/v3/mapbox.map-0l53fhk2.json');
 
             layer.on('ready', function() {
                 expect(this).to.equal(layer);
@@ -53,7 +53,7 @@ describe('L.mapbox.gridLayer', function() {
                 done();
             });
 
-            server.respondWith("GET", "http://a.tiles.mapbox.com/v3/mapbox.map-0l53fhk2.json",
+            server.respondWith("GET", "https://a.tiles.mapbox.com/v3/mapbox.map-0l53fhk2.json",
                 [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.tileJSON)]);
             server.respond();
         });

--- a/test/spec/map.js
+++ b/test/spec/map.js
@@ -29,7 +29,7 @@ describe('L.mapbox.map', function() {
 
     describe('constructor', function() {
         it('loads TileJSON from a URL', function(done) {
-            var map = L.mapbox.map(element, 'http://a.tiles.mapbox.com/v3/mapbox.map-0l53fhk2.json');
+            var map = L.mapbox.map(element, 'https://a.tiles.mapbox.com/v3/mapbox.map-0l53fhk2.json');
 
             map.on('ready', function() {
                 expect(this).to.equal(map);
@@ -37,8 +37,10 @@ describe('L.mapbox.map', function() {
                 done();
             });
 
-            server.respondWith("GET", "http://a.tiles.mapbox.com/v3/mapbox.map-0l53fhk2.json",
+            server.respondWith("GET", "https://a.tiles.mapbox.com/v3/mapbox.map-0l53fhk2.json",
                 [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.tileJSON)]);
+            server.respondWith("GET", "http://b.tiles.mapbox.com/v3/examples.map-8ced9urs/4/3/6.png",
+                [200, { "Content-Type": "image/png" }, null);
             server.respond();
         });
 
@@ -51,13 +53,13 @@ describe('L.mapbox.map', function() {
                 done();
             });
 
-            server.respondWith("GET", "http://a.tiles.mapbox.com/v4/mapbox.map-0l53fhk2.json?access_token=key",
+            server.respondWith("GET", "https://a.tiles.mapbox.com/v4/mapbox.map-0l53fhk2.json?access_token=key",
                 [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.tileJSON)]);
             server.respond();
         });
 
         it('emits an error event', function(done) {
-            var map = L.mapbox.map(element, 'http://a.tiles.mapbox.com/v3/mapbox.map-0l53fhk2.json');
+            var map = L.mapbox.map(element, 'https://a.tiles.mapbox.com/v3/mapbox.map-0l53fhk2.json');
 
             map.on('error', function(e) {
                 expect(this).to.equal(map);
@@ -65,13 +67,13 @@ describe('L.mapbox.map', function() {
                 done();
             });
 
-            server.respondWith("GET", "http://a.tiles.mapbox.com/v3/mapbox.map-0l53fhk2.json",
+            server.respondWith("GET", "https://a.tiles.mapbox.com/v3/mapbox.map-0l53fhk2.json",
                 [400, { "Content-Type": "application/json" }, JSON.stringify({error: 'error'})]);
             server.respond();
         });
 
         it('can deactivate featureLayer', function() {
-            var map = L.mapbox.map(element, 'http://a.tiles.mapbox.com/v3/mapbox.map-0l53fhk2.json', {
+            var map = L.mapbox.map(element, 'https://a.tiles.mapbox.com/v3/mapbox.map-0l53fhk2.json', {
                 featureLayer: false
             });
             expect(map.featureLayer).to.eql(undefined);
@@ -81,7 +83,7 @@ describe('L.mapbox.map', function() {
             var map = L.mapbox.map(element, 'mapbox.map-0l53fhk2')
                 .setView([1, 2], 3);
 
-            server.respondWith("GET", "http://a.tiles.mapbox.com/v4/mapbox.map-0l53fhk2.json?access_token=key",
+            server.respondWith("GET", "https://a.tiles.mapbox.com/v4/mapbox.map-0l53fhk2.json?access_token=key",
                 [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.tileJSON)]);
             server.respond();
 
@@ -93,7 +95,7 @@ describe('L.mapbox.map', function() {
             var map = L.mapbox.map(element, 'mapbox.map-0l53fhk2')
                 .setZoom(3);
 
-            server.respondWith("GET", "http://a.tiles.mapbox.com/v4/mapbox.map-0l53fhk2.json?access_token=key",
+            server.respondWith("GET", "https://a.tiles.mapbox.com/v4/mapbox.map-0l53fhk2.json?access_token=key",
                 [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.tileJSON)]);
             server.respond();
 
@@ -102,8 +104,10 @@ describe('L.mapbox.map', function() {
         });
 
         it('preserves manually-set marker layer GeoJSON', function() {
-            var map = L.mapbox.map(element, 'http://a.tiles.mapbox.com/v3/mapbox.map-0l53fhk2.json');
+            var map = L.mapbox.map(element, 'https://a.tiles.mapbox.com/v3/mapbox.map-0l53fhk2.json');
             map.featureLayer.setGeoJSON(helpers.geoJson);
+
+            console.log(server.requests);
 
             server.respondWith("GET", "http://a.tiles.mapbox.com/v3/mapbox.map-0l53fhk2.json",
                 [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.tileJSON)]);

--- a/test/spec/mapbox_logo.js
+++ b/test/spec/mapbox_logo.js
@@ -43,7 +43,7 @@ describe('mapbox_logo', function() {
             done();
         });
 
-        server.respondWith("GET", "http://a.tiles.mapbox.com/v4/mapbox.map-0l53fhk2.json?access_token=key",
+        server.respondWith("GET", "https://a.tiles.mapbox.com/v4/mapbox.map-0l53fhk2.json?access_token=key&secure",
             [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.tileJSON_mapboxlogo)]);
         server.respond();
     });
@@ -56,7 +56,7 @@ describe('mapbox_logo', function() {
             done();
         });
 
-        server.respondWith("GET", "http://a.tiles.mapbox.com/v4/mapbox.map-0l53fhk2.json?access_token=key",
+        server.respondWith("GET", "https://a.tiles.mapbox.com/v4/mapbox.map-0l53fhk2.json?access_token=key&secure",
             [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.tileJSON_mapboxlogoFalse)]);
         server.respond();
     });

--- a/test/spec/share_control.js
+++ b/test/spec/share_control.js
@@ -55,7 +55,7 @@ describe('L.mapbox.shareControl', function() {
 
         expect(element
             .getElementsByClassName('mapbox-embed')[0].value)
-            .to.eql('<iframe width="100%" height="500px" frameBorder="0" src="http://a.tiles.mapbox.com/v4/mapid.html?access_token=key"></iframe>');
+            .to.eql('<iframe width="100%" height="500px" frameBorder="0" src="https://a.tiles.mapbox.com/v4/mapid.html?access_token=key"></iframe>');
     });
 
     it('can accept a custom url', function() {

--- a/test/spec/style_layer.js
+++ b/test/spec/style_layer.js
@@ -22,7 +22,7 @@ describe('L.mapbox.styleLayer', function() {
                 [200, { "Content-Type": "application/json" }, JSON.stringify({"sources":{"composite":{"url":"mapbox://mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v6","type":"vector"}}})]);
             server.respond();
 
-            server.respondWith('GET', 'http://a.tiles.mapbox.com/v4/mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v6.json?access_token=key',
+            server.respondWith('GET', 'https://a.tiles.mapbox.com/v4/mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v6.json?access_token=key&secure',
                 [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.tileJSON_street_terrain)]);
             server.respond();
         });
@@ -38,7 +38,7 @@ describe('L.mapbox.styleLayer', function() {
                 [200, { "Content-Type": "application/json" }, JSON.stringify({"sources":{"mapbox":{"url":"mapbox://mapbox.mapbox-streets-v6","type":"vector"},"satellite":{"url":"mapbox://mapbox.satellite","type":"raster","tileSize":256}}})]);
             server.respond();
 
-            server.respondWith('GET', 'http://a.tiles.mapbox.com/v4/mapbox.mapbox-streets-v6,mapbox.satellite.json?access_token=key',
+            server.respondWith('GET', 'https://a.tiles.mapbox.com/v4/mapbox.mapbox-streets-v6,mapbox.satellite.json?access_token=key&secure',
                 [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.tileJSON_satellite_streets)]);
             server.respond();
         });

--- a/test/spec/tile_layer.js
+++ b/test/spec/tile_layer.js
@@ -38,7 +38,7 @@ describe("L.mapbox.tileLayer", function() {
         });
 
         it('loads TileJSON from a URL', function(done) {
-            var layer = L.mapbox.tileLayer('http://a.tiles.mapbox.com/v3/mapbox.map-0l53fhk2.json');
+            var layer = L.mapbox.tileLayer('https://a.tiles.mapbox.com/v3/mapbox.map-0l53fhk2.json');
 
             layer.on('ready', function() {
                 expect(this).to.equal(layer);
@@ -46,7 +46,7 @@ describe("L.mapbox.tileLayer", function() {
                 done();
             });
 
-            server.respondWith("GET", "http://a.tiles.mapbox.com/v3/mapbox.map-0l53fhk2.json",
+            server.respondWith("GET", "https://a.tiles.mapbox.com/v3/mapbox.map-0l53fhk2.json",
                 [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.tileJSON)]);
             server.respond();
         });


### PR DESCRIPTION
Always requesting HTTPS assets from HTTP pages is considered safe, so it makes sense to turn it on by default. The change should be backwards-compatible.