### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,11 @@ Require mapbox in your script:
 ```js
 // main.js
 
-require('mapbox.js'); // <-- auto-attaches to window.L
+// node.js
+let L = require('mapbox.js') // <-- auto-attaches to window.L
+
+// es6
+import L from 'matchbox.js';
 ```
 
 Browserify it:


### PR DESCRIPTION
Make clearer where `L` comes from in README.md. Possible since the following commit was merged:

https://github.com/mapbox/mapbox.js/commit/4a390b1251f3bbea0713a0a894580f244b17fdf4