### PR TITLE
[docs] remove search bar

### DIFF
--- a/docs/_layouts/pages.html
+++ b/docs/_layouts/pages.html
@@ -91,16 +91,10 @@ examples:
       <div class='col3 dark round-left keyline-right pad2y pad1x center truncate'>
         <strong class='icon brackets'>Mapbox.js</strong>
       </div>
-      <div class='col6 dark tabs mobile-cols pad1'><!--
+      <div class='col9 dark tabs mobile-cols pad1'><!--
         --><a href='{{site.baseurl}}/api' class='col4 {% if page.categories contains "api" %}active{% endif %}'>API</a><!--
         --><a href='{{site.baseurl}}/examples' class='col4 {% if page.url contains "example" %}active{% endif %}'>Examples</a><!--
         --><a href='{{site.baseurl}}/plugins' class='col4 {% if page.url contains "plugins" %}active{% endif %}'>Plugins</a>
-      </div>
-      <div id='docs-search' class='col3 pad1 keyline-left'>
-        <fieldset class='col12 with-icon dark'>
-          <span class='icon search'></span>
-          <input type='text' class='col12 round clean' />
-        </fieldset>
       </div>
     </nav>
   </div>

--- a/docs/assets/js/site.js
+++ b/docs/assets/js/site.js
@@ -39,16 +39,6 @@ function load() {
         return false;
     });
 
-    $('#docs-search input').swiftype({
-        autocompleteContainingElement: $('#docs-search'),
-        filters: {
-          page: {
-            type: ['mapboxjs'],
-            info: ['{{site.mapboxjs}}', 'latest']
-          }
-        }
-    });
-
     $('.js-signup').on('click',function() {
         $('a.action.signup').trigger('click');
         return false;


### PR DESCRIPTION
The search bar on this site hasn't been working properly for sometime. Now that we've launched docs-wide search, I think we should remove this particular search bar. (I don't think using our new search engine here is an option because we filter out Mapbox.js API docs.)

I pushed these changes to staging for faster review.