### PR TITLE
create redirect for leaflet-image plugin

### DIFF
--- a/docs/_posts/examples/redirects/0100-01-01-leaflet-image.html
+++ b/docs/_posts/examples/redirects/0100-01-01-leaflet-image.html
@@ -1,0 +1,6 @@
+---
+layout: redirect
+redirect: /example/v1.0.0/
+categories: example
+permalink: /example/v1.0.0/leaflet-image/
+---

--- a/docs/_posts/plugins/0100-01-01-leaflet-image.html
+++ b/docs/_posts/plugins/0100-01-01-leaflet-image.html
@@ -8,5 +8,6 @@ tag:
     -bsd
 license: BSD 2-Clause
 code: https://github.com/mapbox/leaflet-image
+example: false
 ---
 <script src='{{site.tileApi}}/mapbox.js/plugins/leaflet-image/v0.0.4/leaflet-image.js'></script>

--- a/docs/plugins/index.html
+++ b/docs/plugins/index.html
@@ -9,7 +9,7 @@ title: Plugins
     <div class='col9'>
       <a class='doc-section' id='{{plugin.prefix}}'></a>
       <h3>{{plugin.title | markdownify | strip_html }} <a href='{{plugin.code}}' title='Project page' class='icon github'></a></h3>
-      <p class='prose'>{{plugin.description}} {% if plugin.license %}<em class='quiet'>&#8211; {{plugin.license}} licensed. </em>{% endif %}<a href='{{site.baseurl}}/example/v1.0.0/{% if plugin.example %}{{plugin.example}}{% else %}{{plugin.prefix}}{% endif %}' class='rcon next'>View example</a></p>
+      <p class='prose'>{{plugin.description}} {% if plugin.license %}<em class='quiet'>&#8211; {{plugin.license}} licensed. </em>{% endif %}{% if plugin.example != false %}<a href='{{site.baseurl}}/example/v1.0.0/{% if plugin.example %}{{plugin.example}}{% else %}{{plugin.prefix}}{% endif %}' class='rcon next'>View example</a>{% endif %}</p>
     </div>
     <div class='pin-right pad2'>
       <a href='#' title='Copy plugin to clipboard' data-clipboard-target='snippet-{{forloop.index}}' class='button icon clipboard js-clipboard'>Copy</a>


### PR DESCRIPTION
This PR creates a redirect for /mapbox.js/example/v1.0.0/leaflet-image/ (back to main examples page) and removes the "View example" from the plugins page for the Leaflet Image plugin:

![image](https://user-images.githubusercontent.com/2180540/66210770-974f2d00-e688-11e9-8200-fbe801dc4fb3.png)


Fixes https://github.com/mapbox/subdomain-docs/issues/49

🐌 