### PR TITLE
Bumps version in package-lock.json to prepare for v3.2.1 npm publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mapbox.js",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Small and quick PR to prepare for the upcoming v3.2.1 release publishing process. 

I ran through the steps in the [deployment guide](https://github.com/mapbox/mapbox.js/blob/publisher-production/DEPLOYING.md). I ran `make` locally in preparation for `npm publish`. @whyvez already updated the changelog in https://github.com/mapbox/mapbox.js/commit/25de92d149271dd5342323899f8ab09642b6df8c and create a new tag in https://github.com/mapbox/mapbox.js/releases/tag/v3.2.1 so I didn't need to do those steps.

After running `make` I ran `git status` and saw that it bumped the semver from v3.2.0 to v3.2.1 in the `package-lock.json` file. I saw in the last v3.2.0 release in https://github.com/mapbox/mapbox.js/commit/d786baa3975b7f889f5ef59eecd392d4e4211123 that the semver was bumped in both the `package.json` and `package-lock.json` files. This PR updates the `package-lock.json` file for good release hygiene.

Per Slack with @whyvez, we may want to move/update the v3.2.1 tag for this gitsha once it's merged. 

cc @whyvez to review