### PR TITLE
assert documentation exists when mapboxjs version is bumped

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "sanitize-caja": "0.1.4"
   },
   "scripts": {
-    "test": "eslint src && phantomjs node_modules/mocha-phantomjs-core/mocha-phantomjs-core.js test/index.html",
+    "test": "eslint src && phantomjs node_modules/mocha-phantomjs-core/mocha-phantomjs-core.js test/index.html && mocha test/docs.js",
     "prepublishOnly": "npm run build",
     "build": "make"
   },

--- a/test/docs.js
+++ b/test/docs.js
@@ -1,0 +1,15 @@
+// makes sure documentation is generated when `mapboxjs: v#.#.#` is updated in _config.publisher-production.yml
+var fs = require('fs');
+var jsyaml = require('js-yaml');
+var assert = require('assert');
+
+// get mapbox.js version from config
+var config = fs.readFileSync('./_config.publisher-production.yml');
+var yaml = jsyaml.load(config);
+var mapboxjs = yaml.mapboxjs;
+// assert that that docs/_posts/api/v#.#.# exists
+describe('Documentation is generated', function() {
+  it('Documentation for ' + mapboxjs + ' exists', function() {
+    assert.equal(fs.existsSync('./docs/_posts/api/' + mapboxjs), true);
+  });
+});


### PR DESCRIPTION
When `mapboxjs` is updated in _config.publisher-production.yml the documentation for that version must exist, otherwise, the production site will redirect to the 404 page. This is because the Mapbox.js landing page redirects to the latest version of the documentation.

This PR adds a test to verify that the documentation folder exists for the current `mapboxjs` version in _config.publisher-production.yml. If the folder does not exist, the tests will fail. 

cc @whyvez @alulsh 