### PR TITLE
update default tile/style endpoints for mapbox styles

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -4,5 +4,14 @@ module.exports = {
     HTTP_URL: 'http://api.mapbox.com',
     HTTPS_URL: 'https://api.mapbox.com',
     FORCE_HTTPS: true,
-    REQUIRE_ACCESS_TOKEN: true
+    REQUIRE_ACCESS_TOKEN: true,
+    TEMPLATE_STYLES: {
+        'mapbox.dark': 'mapbox/dark-v10',
+        'mapbox.light': 'mapbox/light-v10',
+        'mapbox.osm-bright': 'mapbox/bright-v9',
+        'mapbox.outdoors': 'mapbox/outdoors-v11', 
+        'mapbox.satellite': 'mapbox/satellite-v9',
+        'mapbox.streets': 'mapbox/streets-v11', 
+        'mapbox.streets-basic': 'mapbox/basic-v9'
+    }
 };

--- a/src/config.js
+++ b/src/config.js
@@ -1,8 +1,8 @@
 'use strict';
 
 module.exports = {
-    HTTP_URL: 'http://a.tiles.mapbox.com/v4',
-    HTTPS_URL: 'https://a.tiles.mapbox.com/v4',
+    HTTP_URL: 'http://api.mapbox.com',
+    HTTPS_URL: 'https://api.mapbox.com',
     FORCE_HTTPS: true,
     REQUIRE_ACCESS_TOKEN: true
 };

--- a/src/config.js
+++ b/src/config.js
@@ -12,6 +12,7 @@ module.exports = {
         'mapbox.outdoors': 'mapbox/outdoors-v11', 
         'mapbox.satellite': 'mapbox/satellite-v9',
         'mapbox.streets': 'mapbox/streets-v11', 
-        'mapbox.streets-basic': 'mapbox/basic-v9'
+        'mapbox.streets-basic': 'mapbox/basic-v9',
+        'mapbox.streets-satellite': 'mapbox/satellite-streets-v11'
     }
 };

--- a/src/format_url.js
+++ b/src/format_url.js
@@ -38,7 +38,13 @@ module.exports.tileJSON = function(urlOrMapID, accessToken) {
     if (urlOrMapID.indexOf('/') !== -1)
         return urlOrMapID;
 
-    var url = module.exports('/v4/' + urlOrMapID + '.json', accessToken);
+    var url;
+    if (urlOrMapID in config.TEMPLATE_STYLES) {
+        url = module.exports('/styles/v1/' + config.TEMPLATE_STYLES[urlOrMapID], accessToken); 
+    } else {
+        // TODO: remove this and throw error around classic style usage instead
+        url = module.exports('/v4/' + urlOrMapID + '.json', accessToken);
+    }
 
     // TileJSON requests need a secure flag appended to their URLs so
     // that the server knows to send SSL-ified resource references.

--- a/src/format_url.js
+++ b/src/format_url.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var config = require('./config'),
+    warn = require('./util').warn,
     version = require('../package.json').version;
 
 module.exports = function(path, accessToken) {
@@ -42,7 +43,8 @@ module.exports.tileJSON = function(urlOrMapID, accessToken) {
     if (urlOrMapID in config.TEMPLATE_STYLES) {
         url = module.exports('/styles/v1/' + config.TEMPLATE_STYLES[urlOrMapID], accessToken); 
     } else {
-        // TODO: remove this and throw error around classic style usage instead
+        warn('Warning: this implementation is loading a Mapbox Studio Classic style (' + urlOrMapID + '). ' +
+            'Studio Classic styles are scheduled for deprecation: https://blog.mapbox.com/deprecating-studio-classic-styles-c65a744140a6');
         url = module.exports('/v4/' + urlOrMapID + '.json', accessToken);
     }
 

--- a/src/load_tilejson.js
+++ b/src/load_tilejson.js
@@ -8,10 +8,18 @@ module.exports = {
     _loadTileJSON: function(_) {
         if (typeof _ === 'string') {
             _ = format_url.tileJSON(_, this.options && this.options.accessToken);
+            var isGLStyle = _.indexOf('/styles/v1/') !== -1;
+            
             request(_, L.bind(function(err, json) {
                 if (err) {
                     util.log('could not load TileJSON at ' + _);
                     this.fire('error', {error: err});
+                } else if (json && isGLStyle) {
+                    // In order to preserve compatibility, 256x256 tiles are requested by default
+                    // If you would like better resolution & fewer network requests, use a styleLayer instead
+                    json.tiles = [ format_url('/styles/v1/' + json.owner + '/' + json.id + '/tiles/256/{z}/{x}/{y}', this.options.accessToken) ];
+                    this._setTileJSON(json);
+                    this.fire('ready');
                 } else if (json) {
                     this._setTileJSON(json);
                     this.fire('ready');

--- a/src/map.js
+++ b/src/map.js
@@ -146,7 +146,8 @@ var LMap = L.Map.extend({
         this._mapboxLogoControl._setTileJSON(json);
 
         if (!this._loaded && json.center) {
-            var zoom = this.getZoom() !== undefined ? this.getZoom() : json.center[2],
+            var defaultZoom = (json.zoom) ? json.zoom : json.center[2];
+            var zoom = this.getZoom() !== undefined ? this.getZoom() : defaultZoom,
                 center = L.latLng(json.center[1], json.center[0]);
 
             this.setView(center, zoom);

--- a/src/tile_layer.js
+++ b/src/tile_layer.js
@@ -79,7 +79,14 @@ var TileLayer = L.TileLayer.extend({
 
         var templated = L.Util.template(url, tilePoint);
         if (!templated || !this.options.format) {
-            return templated;
+            var tileURL;
+            if (L.Browser.retina && url.indexOf('/styles/v1') !== -1) {
+                tileURL = [templated.slice(0, templated.indexOf('?')), '@2x', templated.slice(templated.indexOf('?'))].join('');
+            } else {
+                tileURL = templated;
+            }
+
+            return tileURL
         } else {
             return templated.replace(formatPattern,
                 (L.Browser.retina ? this.scalePrefix : '.') + this.options.format);

--- a/src/tile_layer.js
+++ b/src/tile_layer.js
@@ -81,7 +81,7 @@ var TileLayer = L.TileLayer.extend({
         if (!templated || !this.options.format) {
             var tileURL;
             if (L.Browser.retina && url.indexOf('/styles/v1') !== -1) {
-                tileURL = [templated.slice(0, templated.indexOf('?')), '@2x', templated.slice(templated.indexOf('?'))].join('');
+                tileURL = templated.replace('?', '@2x?');
             } else {
                 tileURL = templated;
             }

--- a/src/util.js
+++ b/src/util.js
@@ -8,6 +8,8 @@ function contains(item, list) {
     return false;
 }
 
+var warnOnceHistory = {};
+
 module.exports = {
     idUrl: function(_, t) {
         if (_.indexOf('/') === -1) t.loadID(_);
@@ -21,8 +23,11 @@ module.exports = {
         }
     },
     warn: function(_) {
+        // avoid cluttering the console with duplicative warnings
+        if (warnOnceHistory[_]) return;
         if (typeof console === 'object' && 
             typeof console.warn === 'function') {
+            warnOnceHistory[_] = true;
             console.warn(_);
         }
         /* eslint-enable no-console */

--- a/src/util.js
+++ b/src/util.js
@@ -19,6 +19,12 @@ module.exports = {
             typeof console.error === 'function') {
             console.error(_);
         }
+    },
+    warn: function(_) {
+        if (typeof console === 'object' && 
+            typeof console.warn === 'function') {
+            console.warn(_);
+        }
         /* eslint-enable no-console */
     },
     strict: function(_, type) {

--- a/test/helper.js
+++ b/test/helper.js
@@ -933,6 +933,31 @@ helpers.tileJSON_noformat = {
     "tiles":["http://domain.example/path/{z}/{x}/{y}"]
 };
 
+helpers.styleJSON = {
+    "version": 8,
+    "name": "Bright",
+    "tiles": ['https://api.mapbox.com/styles/v1/mapbox/bright-v9/tiles/256/{z}/{x}/{y}?access_token=key'],
+    "sources": {
+        "mapbox": {
+            "url": "mapbox://mapbox.mapbox-streets-v7",
+            "type": "vector"
+        }
+    },
+    "center": [
+        -118.2518,
+        34.0442
+    ],
+    "zoom": 15,
+    "sprite": "mapbox://sprites/mapbox/bright-v9",
+    "glyphs": "mapbox://fonts/mapbox/{fontstack}/{range}.pbf",
+    "created": "1970-01-01T00:00:00.000Z",
+    "modified": "1970-01-01T00:00:00.000Z",
+    "owner": "mapbox",
+    "id": "bright-v9",
+    "draft": false,
+    "visibility": "public"
+};
+
 helpers.geoJson = {
     type: 'FeatureCollection',
     features: [{

--- a/test/manual/default-style-retina.html
+++ b/test/manual/default-style-retina.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='UTF-8'/>
+  <link rel="stylesheet" href="../../dist/mapbox.css"/>
+  <meta name='viewport' content='initial-scale=1.0 maximum-scale=1.0'>
+  <link rel="stylesheet" href="embed.css"/>
+  <script src="../../dist/mapbox.js"></script>
+  <script src="access_token.js"></script>
+</head>
+<body>
+<div id='map'></div>
+<script type='text/javascript'>
+L.Browser.retina = true;
+L.mapbox.map('map', 'mapbox.outdoors')
+  .setView([36.1257, -112.0586], 12);
+</script>
+</body>
+</html>

--- a/test/spec/format_url.js
+++ b/test/spec/format_url.js
@@ -10,11 +10,11 @@ describe("format_url", function() {
     });
 
     it('returns a v4 URL with access_token parameter', function() {
-        expect(internals.url('/v4/user.map.json')).to.equal('https://a.tiles.mapbox.com/v4/user.map.json?access_token=key')
+        expect(internals.url('/v4/user.map.json')).to.equal('https://api.mapbox.com/v4/user.map.json?access_token=key')
     });
 
     it('uses provided access token', function() {
-        expect(internals.url('/v4/user.map.json', 'token')).to.equal('https://a.tiles.mapbox.com/v4/user.map.json?access_token=token')
+        expect(internals.url('/v4/user.map.json', 'token')).to.equal('https://api.mapbox.com/v4/user.map.json?access_token=token')
     });
 
     it('throws an error if no access token is provided', function() {
@@ -39,27 +39,27 @@ describe("format_url", function() {
         internals.config.FORCE_HTTPS = true;
         internals.config.HTTPS_URL = 'https://api-maps-staging.tilestream.net/v4';
         expect(internals.url('/v4/ludacris.map.json')).to.equal('https://api-maps-staging.tilestream.net/v4/ludacris.map.json?access_token=key');
-        internals.config.HTTPS_URL = 'https://a.tiles.mapbox.com';
+        internals.config.HTTPS_URL = 'https://api.mapbox.com';
     });
 
     describe('.tileJSON', function() {
         it('returns the input when passed a URL', function() {
-            expect(internals.url.tileJSON('http://a.tiles.mapbox.com/v3/user.map.json')).to.equal('http://a.tiles.mapbox.com/v3/user.map.json')
+            expect(internals.url.tileJSON('http://api.mapbox.com/v3/user.map.json')).to.equal('http://api.mapbox.com/v3/user.map.json')
         });
 
         it('returns a v4 URL with access_token parameter, uses https and appends &secure', function() {
-            expect(internals.url.tileJSON('user.map')).to.equal('https://a.tiles.mapbox.com/v4/user.map.json?access_token=key&secure');
+            expect(internals.url.tileJSON('user.map')).to.equal('https://api.mapbox.com/v4/user.map.json?access_token=key&secure');
         });
 
         it('does not append &secure and uses http when FORCE_HTTPS is set to false', function() {
             internals.config.FORCE_HTTPS = false;
-            expect(internals.url.tileJSON('user.map')).to.equal('http://a.tiles.mapbox.com/v4/user.map.json?access_token=key');
+            expect(internals.url.tileJSON('user.map')).to.equal('http://api.mapbox.com/v4/user.map.json?access_token=key');
         });
     });
 
     describe('.style', function() {
         it('returns a style url with access_token parameter', function() {
-            expect(internals.url.style('mapbox://styles/bobbysud/cifr15emd00007zlzxjew2rar')).to.equal('https://a.tiles.mapbox.com/styles/v1/bobbysud/cifr15emd00007zlzxjew2rar?access_token=key')
+            expect(internals.url.style('mapbox://styles/bobbysud/cifr15emd00007zlzxjew2rar')).to.equal('https://api.mapbox.com/styles/v1/bobbysud/cifr15emd00007zlzxjew2rar?access_token=key')
         });
     });
 });

--- a/test/spec/format_url.js
+++ b/test/spec/format_url.js
@@ -51,6 +51,10 @@ describe("format_url", function() {
             expect(internals.url.tileJSON('user.map')).to.equal('https://api.mapbox.com/v4/user.map.json?access_token=key&secure');
         });
 
+        it('returns a styles/v1 URL for default mapbox style ids', function() {
+            expect(internals.url.tileJSON('mapbox.streets')).to.equal('https://api.mapbox.com/styles/v1/mapbox/streets-v11?access_token=key&secure')
+        });
+
         it('does not append &secure and uses http when FORCE_HTTPS is set to false', function() {
             internals.config.FORCE_HTTPS = false;
             expect(internals.url.tileJSON('user.map')).to.equal('http://api.mapbox.com/v4/user.map.json?access_token=key');

--- a/test/spec/geocoder.js
+++ b/test/spec/geocoder.js
@@ -13,37 +13,37 @@ describe('L.mapbox.geocoder', function() {
         it('supports multiple arguments', function() {
             var g = L.mapbox.geocoder('mapbox.places');
             expect(g.queryURL(['austin', 'houston']))
-                .to.eql('https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/austin;houston.json?access_token=key');
+                .to.eql('https://api.mapbox.com/geocoding/v5/mapbox.places/austin;houston.json?access_token=key');
         });
 
         it('supports proximity', function() {
             var g = L.mapbox.geocoder('mapbox.places');
             expect(g.queryURL({query: ['austin', 'houston'], proximity: [10, 15]}))
-                .to.eql('https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/austin;houston.json?access_token=key&proximity=15,10');
+                .to.eql('https://api.mapbox.com/geocoding/v5/mapbox.places/austin;houston.json?access_token=key&proximity=15,10');
         });
 
         it('supports country option', function() {
             var g = L.mapbox.geocoder('mapbox.places');
             expect(g.queryURL({query: ['austin', 'houston'], country: 'us'}))
-                .to.eql('https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/austin;houston.json?access_token=key&country=us');
+                .to.eql('https://api.mapbox.com/geocoding/v5/mapbox.places/austin;houston.json?access_token=key&country=us');
         });
 
         it('supports bbox option', function() {
             var g = L.mapbox.geocoder('mapbox.places');
             expect(g.queryURL({query: ['austin', 'houston'], bbox: [ -104.0458814, 26.0696823, -93.7347459, 36.4813628 ]}))
-                .to.eql('https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/austin;houston.json?access_token=key&bbox=-104.0458814,26.0696823,-93.7347459,36.4813628');
+                .to.eql('https://api.mapbox.com/geocoding/v5/mapbox.places/austin;houston.json?access_token=key&bbox=-104.0458814,26.0696823,-93.7347459,36.4813628');
         });
 
         it('supports autocomplete option', function() {
             var g = L.mapbox.geocoder('mapbox.places');
             expect(g.queryURL({query: ['austin', 'houston'], country: 'us', autocomplete: false}))
-                .to.eql('https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/austin;houston.json?access_token=key&country=us&autocomplete=false');
+                .to.eql('https://api.mapbox.com/geocoding/v5/mapbox.places/austin;houston.json?access_token=key&country=us&autocomplete=false');
         });
 
         it('rounds proximity params correctly', function() {
             var g = L.mapbox.geocoder('mapbox.places');
             expect(g.queryURL({query: ['austin', 'houston'], proximity: L.latLng(-10.12345, 15.67890)}))
-                .to.eql('https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/austin;houston.json?access_token=key&proximity=15.679,-10.123');
+                .to.eql('https://api.mapbox.com/geocoding/v5/mapbox.places/austin;houston.json?access_token=key&proximity=15.679,-10.123');
         });
 
         it('rounds reverse ')
@@ -51,9 +51,9 @@ describe('L.mapbox.geocoder', function() {
         it('supports types', function() {
             var g = L.mapbox.geocoder('mapbox.places');
             expect(g.queryURL({query: ['austin', 'houston'], types: 'place'}))
-                .to.eql('https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/austin;houston.json?access_token=key&types=place');
+                .to.eql('https://api.mapbox.com/geocoding/v5/mapbox.places/austin;houston.json?access_token=key&types=place');
             expect(g.queryURL({query: ['austin', 'houston'], types: ['place', 'address']}))
-                .to.eql('https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/austin;houston.json?access_token=key&types=place,address');
+                .to.eql('https://api.mapbox.com/geocoding/v5/mapbox.places/austin;houston.json?access_token=key&types=place,address');
         });
     });
 
@@ -62,7 +62,7 @@ describe('L.mapbox.geocoder', function() {
             var g = L.mapbox.geocoder('mapbox.places');
 
             server.respondWith('GET',
-                'https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/austin;houston.json?access_token=key',
+                'https://api.mapbox.com/geocoding/v5/mapbox.places/austin;houston.json?access_token=key',
                 [200, { 'Content-Type': 'application/json' }, JSON.stringify(helpers.geocoderBulk)]);
 
             g.query(['austin', 'houston'], function(err, res) {
@@ -77,7 +77,7 @@ describe('L.mapbox.geocoder', function() {
             var g = L.mapbox.geocoder('mapbox.places');
 
             server.respondWith('GET',
-                'https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/austin.json?access_token=key',
+                'https://api.mapbox.com/geocoding/v5/mapbox.places/austin.json?access_token=key',
                 [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.geocoderAustin)]);
 
             g.query('austin', function(err, res) {
@@ -93,7 +93,7 @@ describe('L.mapbox.geocoder', function() {
             var g = L.mapbox.geocoder('mapbox.places');
 
             server.respondWith('GET',
-                'https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/nonesuch.json?access_token=key',
+                'https://api.mapbox.com/geocoding/v5/mapbox.places/nonesuch.json?access_token=key',
                 [200, { 'Content-Type': 'application/json' }, JSON.stringify({"type":"FeatureCollection","query":["nonesuch"],"features":[]})]);
 
             g.query('nonesuch', function(err, res) {
@@ -110,7 +110,7 @@ describe('L.mapbox.geocoder', function() {
             var g = L.mapbox.geocoder('mapbox.places');
 
             server.respondWith('GET',
-                'https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/-97.7%2C30.3.json?access_token=key',
+                'https://api.mapbox.com/geocoding/v5/mapbox.places/-97.7%2C30.3.json?access_token=key',
                 [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.geocoderReverse)]);
 
             g.reverseQuery({ lat: 30.3, lng: -97.7 }, function(err, res) {
@@ -125,7 +125,7 @@ describe('L.mapbox.geocoder', function() {
             var g = L.mapbox.geocoder('mapbox.places');
 
             server.respondWith('GET',
-                /https:\/\/a\.tiles\.mapbox\.com\/geocoding\/v5\/mapbox.places\/[\-\d\.]+(%2C|,)[\-\d\.]+\.json\?access_token=key/,
+                /https:\/\/api\.mapbox\.com\/geocoding\/v5\/mapbox.places\/[\-\d\.]+(%2C|,)[\-\d\.]+\.json\?access_token=key/,
                 [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.geocoderReverseRounded)]);
 
             g.reverseQuery({ lat: 30.1234567890, lng: -97.0987654321 }, function(err, res) {

--- a/test/spec/geocoder_control.js
+++ b/test/spec/geocoder_control.js
@@ -17,7 +17,7 @@ describe('L.mapbox.geocoderControl', function() {
         expect(control instanceof L.mapbox.GeocoderControl).to.eql(true);
 
         server.respondWith('GET',
-            'https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/austin.json?access_token=key',
+            'https://api.mapbox.com/geocoding/v5/mapbox.places/austin.json?access_token=key',
             [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.geocoderAustin)]);
 
         control._input.value = 'austin';
@@ -32,7 +32,7 @@ describe('L.mapbox.geocoderControl', function() {
             control = L.mapbox.geocoderControl('mapbox.places', { proximity: false }).addTo(map);
 
         server.respondWith('GET',
-            'https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/white%20house.json?access_token=key',
+            'https://api.mapbox.com/geocoding/v5/mapbox.places/white%20house.json?access_token=key',
             [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.geocoderWhiteHouse)]);
 
         control._input.value = 'white house';
@@ -51,7 +51,7 @@ describe('L.mapbox.geocoderControl', function() {
             }).addTo(map);
 
         server.respondWith('GET',
-            'https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/white%20house.json?access_token=key',
+            'https://api.mapbox.com/geocoding/v5/mapbox.places/white%20house.json?access_token=key',
             [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.geocoderWhiteHouse)]);
 
         control._input.value = 'white house';
@@ -74,7 +74,7 @@ describe('L.mapbox.geocoderControl', function() {
             }).addTo(map);
 
         server.respondWith('GET',
-            'https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/white%20house.json?access_token=key&country=us&autocomplete=false',
+            'https://api.mapbox.com/geocoding/v5/mapbox.places/white%20house.json?access_token=key&country=us&autocomplete=false',
             [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.geocoderWhiteHouse)]);
 
         control._input.value = 'white house';
@@ -95,7 +95,7 @@ describe('L.mapbox.geocoderControl', function() {
         map.setView([0, 0], 14);
 
         server.respondWith('GET',
-            'https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/white%20house.json?access_token=key',
+            'https://api.mapbox.com/geocoding/v5/mapbox.places/white%20house.json?access_token=key',
             [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.geocoderWhiteHouse)]);
 
         control._input.value = 'white house';
@@ -108,12 +108,12 @@ describe('L.mapbox.geocoderControl', function() {
 
     it('sets url based on an id', function() {
         var control = L.mapbox.geocoderControl('mapbox.places');
-        expect(control.getURL()).to.equal('https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/{query}.json?access_token=key');
+        expect(control.getURL()).to.equal('https://api.mapbox.com/geocoding/v5/mapbox.places/{query}.json?access_token=key');
     });
 
     it('supports custom access token', function() {
         var control = L.mapbox.geocoderControl('mapbox.places', {accessToken: 'custom'});
-        expect(control.getURL()).to.equal('https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/{query}.json?access_token=custom');
+        expect(control.getURL()).to.equal('https://api.mapbox.com/geocoding/v5/mapbox.places/{query}.json?access_token=custom');
     });
 
     it('#setURL', function() {
@@ -125,7 +125,7 @@ describe('L.mapbox.geocoderControl', function() {
     it('#setID', function() {
         var control = L.mapbox.geocoderControl('mapbox.places');
         expect(control.setID('mapbox.places')).to.eql(control);
-        expect(control.getURL()).to.equal('https://a.tiles.mapbox.com/geocoding/v5/mapbox.places/{query}.json?access_token=key');
+        expect(control.getURL()).to.equal('https://api.mapbox.com/geocoding/v5/mapbox.places/{query}.json?access_token=key');
     });
 
     it('is by default in the top left', function() {

--- a/test/spec/map.js
+++ b/test/spec/map.js
@@ -40,7 +40,7 @@ describe('L.mapbox.map', function() {
             server.respondWith("GET", "https://a.tiles.mapbox.com/v3/mapbox.map-0l53fhk2.json",
                 [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.tileJSON)]);
             server.respondWith("GET", "http://b.tiles.mapbox.com/v3/examples.map-8ced9urs/4/3/6.png",
-                [200, { "Content-Type": "image/png" }, null);
+                [200, { "Content-Type": "image/png" }, '']);
             server.respond();
         });
 
@@ -53,8 +53,22 @@ describe('L.mapbox.map', function() {
                 done();
             });
 
-            server.respondWith("GET", "https://a.tiles.mapbox.com/v4/mapbox.map-0l53fhk2.json?access_token=key",
+            server.respondWith("GET", "https://api.mapbox.com/v4/mapbox.map-0l53fhk2.json?access_token=key&secure",
                 [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.tileJSON)]);
+            server.respond();
+        });
+
+        it('loads styleJSON from a default mapbox ID', function(done) {
+            var map = L.mapbox.map(element, 'mapbox.osm-bright');
+
+            map.on('ready', function() {
+                expect(this).to.equal(map);
+                expect(map.getTileJSON()).to.eql(helpers.styleJSON);
+                done();
+            });
+
+            server.respondWith("GET", "https://api.mapbox.com/styles/v1/mapbox/bright-v9?access_token=key&secure",
+                [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.styleJSON)]);
             server.respond();
         });
 
@@ -83,7 +97,7 @@ describe('L.mapbox.map', function() {
             var map = L.mapbox.map(element, 'mapbox.map-0l53fhk2')
                 .setView([1, 2], 3);
 
-            server.respondWith("GET", "https://a.tiles.mapbox.com/v4/mapbox.map-0l53fhk2.json?access_token=key",
+            server.respondWith("GET", "https://api.mapbox.com/v4/mapbox.map-0l53fhk2.json?access_token=key",
                 [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.tileJSON)]);
             server.respond();
 
@@ -95,7 +109,7 @@ describe('L.mapbox.map', function() {
             var map = L.mapbox.map(element, 'mapbox.map-0l53fhk2')
                 .setZoom(3);
 
-            server.respondWith("GET", "https://a.tiles.mapbox.com/v4/mapbox.map-0l53fhk2.json?access_token=key",
+            server.respondWith("GET", "https://api.mapbox.com/v4/mapbox.map-0l53fhk2.json?access_token=key&secure",
                 [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.tileJSON)]);
             server.respond();
 

--- a/test/spec/map.js
+++ b/test/spec/map.js
@@ -105,6 +105,18 @@ describe('L.mapbox.map', function() {
             expect(map.getZoom()).to.eql(3);
         });
 
+        it('preserves manually-set view for default style ids', function() {
+            var map = L.mapbox.map(element, 'mapbox.osm-bright')
+                .setView([39, -89], 6);
+
+            server.respondWith("GET", "https://api.mapbox.com/styles/v1/mapbox/bright-v9?access_token=key",
+                [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.styleJSON)]);
+            server.respond();
+
+            expect(map.getCenter()).to.eql({ lat: 39, lng: -89});
+            expect(map.getZoom()).to.eql(6);
+        })
+
         it('preserves manually-set zoom', function() {
             var map = L.mapbox.map(element, 'mapbox.map-0l53fhk2')
                 .setZoom(3);
@@ -116,6 +128,18 @@ describe('L.mapbox.map', function() {
             expect(map.getCenter()).to.eql({ lat: 39.386, lng: -98.976 });
             expect(map.getZoom()).to.eql(3);
         });
+
+        it('preserves manually-set zoom for default style ids', function () {
+            var map = L.mapbox.map(element, 'mapbox.osm-bright')
+                .setZoom(3);
+
+            server.respondWith("GET", "https://api.mapbox.com/styles/v1/mapbox/bright-v9?access_token=key&secure",
+                [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.styleJSON)]);
+            server.respond();
+
+            expect(map.getCenter()).to.eql({ lat: 34.0442, lng: -118.2518 });
+            expect(map.getZoom()).to.eql(3);
+        })
 
         it('preserves manually-set marker layer GeoJSON', function() {
             var map = L.mapbox.map(element, 'https://a.tiles.mapbox.com/v3/mapbox.map-0l53fhk2.json');

--- a/test/spec/mapbox_logo.js
+++ b/test/spec/mapbox_logo.js
@@ -43,7 +43,7 @@ describe('mapbox_logo', function() {
             done();
         });
 
-        server.respondWith("GET", "https://a.tiles.mapbox.com/v4/mapbox.map-0l53fhk2.json?access_token=key&secure",
+        server.respondWith("GET", "https://api.mapbox.com/v4/mapbox.map-0l53fhk2.json?access_token=key&secure",
             [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.tileJSON_mapboxlogo)]);
         server.respond();
     });
@@ -56,7 +56,7 @@ describe('mapbox_logo', function() {
             done();
         });
 
-        server.respondWith("GET", "https://a.tiles.mapbox.com/v4/mapbox.map-0l53fhk2.json?access_token=key&secure",
+        server.respondWith("GET", "https://api.mapbox.com/v4/mapbox.map-0l53fhk2.json?access_token=key&secure",
             [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.tileJSON_mapboxlogoFalse)]);
         server.respond();
     });

--- a/test/spec/share_control.js
+++ b/test/spec/share_control.js
@@ -55,7 +55,7 @@ describe('L.mapbox.shareControl', function() {
 
         expect(element
             .getElementsByClassName('mapbox-embed')[0].value)
-            .to.eql('<iframe width="100%" height="500px" frameBorder="0" src="https://a.tiles.mapbox.com/v4/mapid.html?access_token=key"></iframe>');
+            .to.eql('<iframe width="100%" height="500px" frameBorder="0" src="https://api.mapbox.com/v4/mapid.html?access_token=key"></iframe>');
     });
 
     it('can accept a custom url', function() {

--- a/test/spec/style_layer.js
+++ b/test/spec/style_layer.js
@@ -18,11 +18,11 @@ describe('L.mapbox.styleLayer', function() {
                 done();
             });
 
-            server.respondWith('GET', 'https://a.tiles.mapbox.com/styles/v1/mapbox/streets-v8?access_token=key',
+            server.respondWith('GET', 'https://api.mapbox.com/styles/v1/mapbox/streets-v8?access_token=key',
                 [200, { "Content-Type": "application/json" }, JSON.stringify({"sources":{"composite":{"url":"mapbox://mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v6","type":"vector"}}})]);
             server.respond();
 
-            server.respondWith('GET', 'https://a.tiles.mapbox.com/v4/mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v6.json?access_token=key&secure',
+            server.respondWith('GET', 'https://api.mapbox.com/v4/mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v6.json?access_token=key&secure',
                 [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.tileJSON_street_terrain)]);
             server.respond();
         });
@@ -34,11 +34,11 @@ describe('L.mapbox.styleLayer', function() {
                 done();
             });
 
-            server.respondWith('GET', 'https://a.tiles.mapbox.com/styles/v1/mapbox/satellite-hybrid-v8?access_token=key',
+            server.respondWith('GET', 'https://api.mapbox.com/styles/v1/mapbox/satellite-hybrid-v8?access_token=key',
                 [200, { "Content-Type": "application/json" }, JSON.stringify({"sources":{"mapbox":{"url":"mapbox://mapbox.mapbox-streets-v6","type":"vector"},"satellite":{"url":"mapbox://mapbox.satellite","type":"raster","tileSize":256}}})]);
             server.respond();
 
-            server.respondWith('GET', 'https://a.tiles.mapbox.com/v4/mapbox.mapbox-streets-v6,mapbox.satellite.json?access_token=key&secure',
+            server.respondWith('GET', 'https://api.mapbox.com/v4/mapbox.mapbox-streets-v6,mapbox.satellite.json?access_token=key&secure',
                 [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.tileJSON_satellite_streets)]);
             server.respond();
         });

--- a/test/spec/tile_layer.js
+++ b/test/spec/tile_layer.js
@@ -131,6 +131,21 @@ describe("L.mapbox.tileLayer", function() {
             expect(layer.getTileUrl({x: 4, y: 0, z: 0})).to.equal('http://a.tiles.mapbox.com/v3/examples.map-8ced9urs/0/4/0.jpg70');
         });
 
+        it("does not change format of styleJSON tilelayers", function () {
+            var layer = L.mapbox.tileLayer(helpers.styleJSON).setFormat('jpg70');
+            expect(layer.getTileUrl({ x: 0, y: 0, z: 0 })).to.equal('https://api.mapbox.com/styles/v1/mapbox/bright-v9/tiles/256/0/0/0?access_token=key');
+            expect(layer.getTileUrl({ x: 1, y: 0, z: 0 })).to.equal('https://api.mapbox.com/styles/v1/mapbox/bright-v9/tiles/256/0/1/0?access_token=key');
+            expect(layer.getTileUrl({ x: 2, y: 0, z: 0 })).to.equal('https://api.mapbox.com/styles/v1/mapbox/bright-v9/tiles/256/0/2/0?access_token=key');
+            expect(layer.getTileUrl({ x: 4, y: 0, z: 0 })).to.equal('https://api.mapbox.com/styles/v1/mapbox/bright-v9/tiles/256/0/4/0?access_token=key');
+            expect(layer.getTileUrl({ x: 3, y: 0, z: 0 })).to.equal('https://api.mapbox.com/styles/v1/mapbox/bright-v9/tiles/256/0/3/0?access_token=key');
+        });
+
+        it("requests @2x tiles on retina (default id)", function () {
+            L.Browser.retina = true;
+            var layer = L.mapbox.tileLayer(helpers.styleJSON);
+            expect(layer.getTileUrl({ x: 0, y: 0, z: 0 })).to.equal('https://api.mapbox.com/styles/v1/mapbox/bright-v9/tiles/256/0/0/0@2x?access_token=key');
+        });
+
         it("requests @2x tiles on retina", function() {
             L.Browser.retina = true;
             var layer = L.mapbox.tileLayer(helpers.tileJSON);


### PR DESCRIPTION
Resolves #1316 

Up until now, Mapbox.js defaults have relied heavily on the Mapbox Legacy Static Tiles endpoints.

I'll mark this PR as ready for review when the following are implemented:
- [x] Updates initialization code so that passing in a template `mapID` will automatically load the equivalent style from the modern Static Tiles API.
- [x] Set console warning when automatic support for classic style IDs (e.g. `riastrad.{class style id}`) is passed to `map` objects and `tileLayer` objects.
- [x] ~Logs a console warning about dropping support for the outdated `tileLayer.setFormat()` method with default `mapIDs`.~  Given that the url pattern for legacy & modern APIs is different, this appears to be unnecessary.
- [x] All previous tests are updated and passing
- [x] new tests for changes to default behavior

If I identify any other usage of legacy APIs within the defaults, I will flag it and incorporate it within this PR before the review.

cc @mapbox/static-apis 