### PR TITLE
Update dependencies to to @mapbox namespace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,16 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@mapbox/corslite": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@mapbox/corslite/-/corslite-0.0.7.tgz",
+      "integrity": "sha1-KfW2oYi6lG5RS98LZAHtT74To54="
+    },
+    "@mapbox/sanitize-caja": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@mapbox/sanitize-caja/-/sanitize-caja-0.1.4.tgz",
+      "integrity": "sha1-GzyoIg0TK3axIZtl+acZ++/jWDc="
+    },
     "@sinonjs/commons": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
@@ -929,11 +939,6 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
-    },
-    "corslite": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/corslite/-/corslite-0.0.7.tgz",
-      "integrity": "sha1-jkUdtTIKdVbeHveNm9NWY0MHdyE="
     },
     "create-ecdh": {
       "version": "4.0.3",
@@ -3705,11 +3710,6 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
-    },
-    "sanitize-caja": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/sanitize-caja/-/sanitize-caja-0.1.4.tgz",
-      "integrity": "sha1-eAPo5FK447rLNC29k624hazQeK8="
     },
     "semver": {
       "version": "5.6.0",

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
     "*.md"
   ],
   "dependencies": {
-    "corslite": "0.0.7",
+    "@mapbox/corslite": "0.0.7",
+    "@mapbox/sanitize-caja": "^0.1.4",
     "leaflet": "1.4.0",
-    "mustache": "3.0.1",
-    "sanitize-caja": "0.1.4"
+    "mustache": "3.0.1"
   },
   "scripts": {
     "test": "eslint src && phantomjs node_modules/mocha-phantomjs-core/mocha-phantomjs-core.js test/index.html && mocha test/docs.js",

--- a/src/feature_layer.js
+++ b/src/feature_layer.js
@@ -13,7 +13,7 @@ var util = require('./util'),
 var FeatureLayer = L.FeatureGroup.extend({
     options: {
         filter: function() { return true; },
-        sanitizer: require('sanitize-caja'),
+        sanitizer: require('@mapbox/sanitize-caja'),
         style: simplestyle.style,
         popupOptions: { closeButton: false }
     },

--- a/src/grid_control.js
+++ b/src/grid_control.js
@@ -8,7 +8,7 @@ var GridControl = L.Control.extend({
     options: {
         pinnable: true,
         follow: false,
-        sanitizer: require('sanitize-caja'),
+        sanitizer: require('@mapbox/sanitize-caja'),
         touchTeaser: true,
         location: true
     },

--- a/src/legend_control.js
+++ b/src/legend_control.js
@@ -4,7 +4,7 @@ var LegendControl = L.Control.extend({
 
     options: {
         position: 'bottomright',
-        sanitizer: require('sanitize-caja')
+        sanitizer: require('@mapbox/sanitize-caja')
     },
 
     initialize: function(options) {

--- a/src/map.js
+++ b/src/map.js
@@ -25,7 +25,7 @@ var LMap = L.Map.extend({
         legendControl: {},
         gridControl: {},
         shareControl: false,
-        sanitizer: require('sanitize-caja')
+        sanitizer: require('@mapbox/sanitize-caja')
     },
 
     _tilejson: {},

--- a/src/mapbox.js
+++ b/src/mapbox.js
@@ -34,7 +34,7 @@ L.mapbox = module.exports = {
     map: map.map,
     Map: map.Map,
     config: require('./config'),
-    sanitize: require('sanitize-caja'),
+    sanitize: require('@mapbox/sanitize-caja'),
     template: require('mustache').to_html,
     feedback: require('./feedback')
 };

--- a/src/marker.js
+++ b/src/marker.js
@@ -2,7 +2,7 @@
 
 var format_url = require('./format_url'),
     util = require('./util'),
-    sanitize = require('sanitize-caja');
+    sanitize = require('@mapbox/sanitize-caja');
 
 // mapbox-related markers functionality
 // provide an icon from mapbox's simple-style spec and hosted markers

--- a/src/request.js
+++ b/src/request.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var corslite = require('corslite'),
+var corslite = require('@mapbox/corslite'),
     strict = require('./util').strict,
     config = require('./config');
 

--- a/src/style_layer.js
+++ b/src/style_layer.js
@@ -7,7 +7,7 @@ var request = require('./request');
 var StyleLayer = L.TileLayer.extend({
 
     options: {
-        sanitizer: require('sanitize-caja')
+        sanitizer: require('@mapbox/sanitize-caja')
     },
 
     initialize: function(_, options) {

--- a/src/tile_layer.js
+++ b/src/tile_layer.js
@@ -7,7 +7,7 @@ var TileLayer = L.TileLayer.extend({
     includes: [require('./load_tilejson')],
 
     options: {
-        sanitizer: require('sanitize-caja')
+        sanitizer: require('@mapbox/sanitize-caja')
     },
 
     // http://mapbox.com/developers/api/#image_quality


### PR DESCRIPTION
Closes #1241 

This is a tiny change that will install the Mapbox dependencies through the `@mapbox` namespace. Mapbox.js has very few dependencies, and there have been no new versions of the two affected by this change, so this is a purely cosmetic change.

cc/ @mapbox/static-apis 