### PR TITLE
[docs] correct api usage of plain-leaflet example

### DIFF
--- a/DOCUMENTING.md
+++ b/DOCUMENTING.md
@@ -27,7 +27,7 @@ make
 jekyll serve -w -p 4000
 ```
 
-Edit the site. Existing examples [are located here](https://github.com/mapbox/mapbox.js/tree/mb-pages/docs/_posts/examples/v1.0.0) -
+Edit the site. Existing examples [are located here](https://github.com/mapbox/mapbox.js/tree/publisher-production/docs/_posts/examples/v1.0.0) -
 copy one to a new file with the same naming convention to start a new example. Test your new example
 by going to http://localhost:4000/mapbox.js/ and finding and using it.
 
@@ -36,7 +36,7 @@ When you're done,
 ```sh
 git add _posts/...newexample
 git commit -m "Added a new example, showing off XYZ"
-git push origin mb-pages
+git push origin publisher-production
 ```
 
 ## API Documentation

--- a/docs/_posts/examples/v1.0.0/0100-01-01-plain-leaflet.html
+++ b/docs/_posts/examples/v1.0.0/0100-01-01-plain-leaflet.html
@@ -12,7 +12,9 @@ tags:
 <script>
     
 var mapboxTiles = L.tileLayer('{{site.tileApi}}/styles/v1/mapbox/streets-v11/tiles/{z}/{x}/{y}?access_token=' + L.mapbox.accessToken, {
-       attribution: '© <a href="https://www.mapbox.com/feedback/">Mapbox</a> © <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+       attribution: '© <a href="https://www.mapbox.com/feedback/">Mapbox</a> © <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+       tileSize: 512,
+       zoomOffset: -1
 });
 
 var map = L.map('map')


### PR DESCRIPTION
Fixes #1320 

Previously, our "plain leaflet" example requested tiles from the Static Tiles API without account for the fact that this API returns 512x512 styles by default, whereas Leaflet.js expects 256x256 tiles by default. This update corrects this example to account for this discrepancy.

(I also updated `DOCUMENTING.md` while I was in there.)

cc/ @mapbox/static-apis @mapbox/docs 