### PR TITLE
fix bug where logo did not appear if layer added after map init

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -209,7 +209,7 @@ var LMap = L.Map.extend({
 
         // ensure logo appears even when mapbox layer added after map is initialized
         var mapboxLogoControl = this._mapboxLogoControl.getContainer();
-        if (!L.DomUtil.hasClass(mapboxLogoControl)) {
+        if (!L.DomUtil.hasClass(mapboxLogoControl, 'mapbox-logo-true')) {
             var tileJSON = layer.getTileJSON();
             this._mapboxLogoControl._setTileJSON(tileJSON);
         }

--- a/src/map.js
+++ b/src/map.js
@@ -209,15 +209,9 @@ var LMap = L.Map.extend({
 
         // ensure logo appears even when mapbox layer added after map is initialized
         var mapboxLogoControl = this._mapboxLogoControl.getContainer();
-        if (
-            (layer.options.tiles) &&
-            (layer.options.tiles[0].indexOf('mapbox.com') !== -1) &&
-            !(L.DomUtil.hasClass(mapboxLogoControl))
-        ) {
+        if (!L.DomUtil.hasClass(mapboxLogoControl)) {
             var tileJSON = layer.getTileJSON();
-            if (!(tileJSON.mapbox_logo) || (tileJSON.mapbox_logo === true)) {
-                this._mapboxLogoControl._setTileJSON(tileJSON);
-            }
+            this._mapboxLogoControl._setTileJSON(tileJSON);
         }
 
         this._updateMapFeedbackLink();

--- a/src/map.js
+++ b/src/map.js
@@ -209,8 +209,15 @@ var LMap = L.Map.extend({
 
         // ensure logo appears even when mapbox layer added after map is initialized
         var mapboxLogoControl = this._mapboxLogoControl.getContainer();
-        if ((layer._tilejson.attribution.indexOf('mapbox') !== -1) && !(L.DomUtil.hasClass(mapboxLogoControl))) {
-            this._mapboxLogoControl._setTileJSON({ mapbox_logo : true });
+        if (
+            (layer.options.tiles) &&
+            (layer.options.tiles[0].indexOf('mapbox.com') !== -1) &&
+            !(L.DomUtil.hasClass(mapboxLogoControl))
+        ) {
+            var tileJSON = layer.getTileJSON();
+            if (!(tileJSON.mapbox_logo) || (tileJSON.mapbox_logo === true)) {
+                this._mapboxLogoControl._setTileJSON(tileJSON);
+            }
         }
 
         this._updateMapFeedbackLink();

--- a/src/map.js
+++ b/src/map.js
@@ -207,6 +207,12 @@ var LMap = L.Map.extend({
             this._zoomBoundLayers[L.stamp(layer)] = layer;
         }
 
+        // ensure logo appears even when mapbox layer added after map is initialized
+        var mapboxLogoControl = this._mapboxLogoControl.getContainer();
+        if ((layer._tilejson.attribution.indexOf('mapbox') !== -1) && !(L.DomUtil.hasClass(mapboxLogoControl))) {
+            this._mapboxLogoControl._setTileJSON({ mapbox_logo : true });
+        }
+
         this._updateMapFeedbackLink();
         this._updateZoomLevels();
     }

--- a/src/mapbox_logo.js
+++ b/src/mapbox_logo.js
@@ -24,7 +24,7 @@ var MapboxLogoControl = L.Control.extend({
         }
 
         // account for usage of styleJSON as functional tileJSON for defaults
-        if (!json.tilejson && (json.owner && json.owner === 'mapbox')) {
+        if (!json.tilejson && json.owner === 'mapbox') {
             L.DomUtil.addClass(this._container, 'mapbox-logo-true');
         }
     }

--- a/src/mapbox_logo.js
+++ b/src/mapbox_logo.js
@@ -22,6 +22,11 @@ var MapboxLogoControl = L.Control.extend({
         if (json.mapbox_logo) {
             L.DomUtil.addClass(this._container, 'mapbox-logo-true');
         }
+
+        // account for usage of styleJSON as functional tileJSON for defaults
+        if (!json.tilejson && (json.owner && json.owner === 'mapbox')) {
+            L.DomUtil.addClass(this._container, 'mapbox-logo-true');
+        }
     }
 });
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -869,6 +869,23 @@ helpers.tileJSON_malicious = {
     "webpage":"http://tiles.mapbox.com/examples/map/map-8ced9urs"
 }
 
+helpers.tileJSON_mapboxlogoMissing = {
+    "attribution": "<a href='https://www.mapbox.com/about/maps/' target='_blank'>&copy; Mapbox &copy; OpenStreetMap</a> <a class='mapbox-improve-map' href='https://www.mapbox.com/feedback/' target='_blank'>Improve this map</a>",
+    "autoscale": true,
+    "bounds": [-180, -85.0511, 180, 85.0511],
+    "data": ["http://a.tiles.mapbox.com/v3/examples.h8e9h88l/markers.geojsonp"],
+    "geocoder": "http://a.tiles.mapbox.com/v3/examples.h8e9h88l/geocode/{query}.jsonp",
+    "id": "examples.h8e9h88l",
+    "maxzoom": 22,
+    "minzoom": 0,
+    "name": "My Mapbox Streets Map",
+    "private": true,
+    "scheme": "xyz",
+    "tilejson": "2.0.0",
+    "tiles": ["http://some.external.source.com/v3/examples.h8e9h88l/{z}/{x}/{y}.png"],
+    "webpage": "http://a.tiles.mapbox.com/v3/examples.h8e9h88l/page.html",
+};
+
 helpers.tileJSON_mapboxlogoFalse = {
     "attribution": "<a href='https://www.mapbox.com/about/maps/' target='_blank'>&copy; Mapbox &copy; OpenStreetMap</a> <a class='mapbox-improve-map' href='https://www.mapbox.com/feedback/' target='_blank'>Improve this map</a>",
     "autoscale": true,
@@ -955,7 +972,8 @@ helpers.styleJSON = {
     "owner": "mapbox",
     "id": "bright-v9",
     "draft": false,
-    "visibility": "public"
+    "visibility": "public",
+    "mapbox_logo": true
 };
 
 helpers.geoJson = {

--- a/test/helper.js
+++ b/test/helper.js
@@ -972,8 +972,7 @@ helpers.styleJSON = {
     "owner": "mapbox",
     "id": "bright-v9",
     "draft": false,
-    "visibility": "public",
-    "mapbox_logo": true
+    "visibility": "public"
 };
 
 helpers.geoJson = {

--- a/test/manual/later-layer-logo.html
+++ b/test/manual/later-layer-logo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset='UTF-8' />
+  <link rel="stylesheet" href="../../dist/mapbox.css" />
+  <meta name='viewport' content='initial-scale=1.0 maximum-scale=1.0'>
+  <link rel="stylesheet" href="embed.css" />
+  <script src="../../dist/mapbox.js"></script>
+  <script src="access_token.js"></script>
+  <style>
+    body {
+      margin: 0;
+      padding: 0;
+    }
+
+    #map {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      width: 100%;
+    }
+  </style>
+</head>
+
+<body>
+
+  <div id='map'></div>
+
+  <script>
+    var map = L.mapbox.map('map', null, {
+      maxZoom: 18
+    }).setView([22.76, -25.84], 3);
+
+    L.mapbox.tileLayer('mapbox.streets').addTo(map);
+  </script>
+
+</body>
+
+</html>

--- a/test/manual/tooltips-on-hover.html
+++ b/test/manual/tooltips-on-hover.html
@@ -24,7 +24,7 @@
     // Hide popup when user's cursor leaves marker.
     // We add a timeout to make it a little more visually graceful
     // in case of rapid cursor movement.
-    mapfeatureLayerr.on('mouseout', function(e) {
+    map.featureLayer.on('mouseout', function(e) {
         e.layer._closeTimeout = window.setTimeout(function() {
             e.layer.closePopup();
         }, 300);

--- a/test/spec/mapbox_logo.js
+++ b/test/spec/mapbox_logo.js
@@ -22,6 +22,12 @@ describe('mapbox_logo', function() {
         expect(L.DomUtil.hasClass(mapboxLogoControl, 'mapbox-logo-true')).to.be(false);
     });
 
+    it('is on map when tilejson is mapbox styleJSON without mapbox_logo flag', function() {
+        var map = L.mapbox.map(element, helpers.styleJSON);
+        var mapboxLogoControl = map._mapboxLogoControl.getContainer();
+        expect(L.DomUtil.hasClass(mapboxLogoControl, 'mapbox-logo-true')).to.be(true);
+    });
+
     it('is on tilejson map with mapbox_logo === true', function() {
         var map = L.mapbox.map(element, helpers.tileJSON_mapboxlogo);
         var mapboxLogoControl = map._mapboxLogoControl.getContainer();
@@ -58,6 +64,23 @@ describe('mapbox_logo', function() {
 
         server.respondWith("GET", "https://api.mapbox.com/v4/mapbox.map-0l53fhk2.json?access_token=key&secure",
             [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.tileJSON_mapboxlogoFalse)]);
+        server.respond();
+    });
+
+    it('is on mapid map when layer added after map initialization', function (done) {
+        var layer = L.mapbox.tileLayer('mapbox.map-0l53fhk2');
+        var map = L.mapbox.map(element)
+            .setView([0, 0], 3)
+            .addLayer(layer);
+
+        layer.on('ready', function() {
+            var mapboxLogoControl = map._mapboxLogoControl.getContainer();
+            expect(L.DomUtil.hasClass(mapboxLogoControl, 'mapbox-logo-true')).to.be(true);
+            done();
+        });
+
+        server.respondWith("GET", "https://api.mapbox.com/v4/mapbox.map-0l53fhk2.json?access_token=key&secure",
+            [200, { "Content-Type": "application/json" }, JSON.stringify(helpers.tileJSON_mapboxlogo)]);
         server.respond();
     });
 });

--- a/test/spec/mapbox_logo.js
+++ b/test/spec/mapbox_logo.js
@@ -17,7 +17,7 @@ describe('mapbox_logo', function() {
     });
 
     it('is not on tilejson map without mapbox_logo flag', function() {
-        var map = L.mapbox.map(element, tileJSON);
+        var map = L.mapbox.map(element, helpers.tileJSON_mapboxlogoMissing);
         var mapboxLogoControl = map._mapboxLogoControl.getContainer();
         expect(L.DomUtil.hasClass(mapboxLogoControl, 'mapbox-logo-true')).to.be(false);
     });


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox.js/issues/1314, where the mapbox logo would not be added to maps when they added the mapbox tilelayer's after initialization of `L.mapbox.map`. 

However, note that it does not correct the behavior noted in https://github.com/mapbox/mapbox.js/issues/1227, as there are still problems with the logo appearing when a `styleLayer` is added to the map after the map object's initialization. 

cc/ @mapbox/static-apis 