### PR TITLE
Fix links to /tilelayer-setformat/ example

### DIFF
--- a/API.md
+++ b/API.md
@@ -95,7 +95,7 @@ _Example_:
         format: 'jpg70'
     });
 
-[Live example of .setFormat in use](https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/)
+[Live example of .setFormat in use](https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/)
 
 _Returns_: the layer object
 

--- a/docs/_posts/api/0200-01-01-v2.0.0-all.html
+++ b/docs/_posts/api/0200-01-01-v2.0.0-all.html
@@ -123,7 +123,7 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;mapbox.streets&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>
 <h2 id="l-mapbox-gridlayer">L.mapbox.gridLayer(id|url|tilejson, options)</h2>
 <p>An <code><a href="#l-mapbox-gridlayer">L.mapbox.gridLayer</a></code> loads <a href="http://mapbox.com/developers/utfgrid/">UTFGrid</a> tiles of

--- a/docs/_posts/api/0200-01-01-v2.0.1-all.html
+++ b/docs/_posts/api/0200-01-01-v2.0.1-all.html
@@ -123,7 +123,7 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;mapbox.streets&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>
 <h2 id="l-mapbox-gridlayer">L.mapbox.gridLayer(id|url|tilejson, options)</h2>
 <p>An <code><a href="#l-mapbox-gridlayer">L.mapbox.gridLayer</a></code> loads <a href="http://mapbox.com/developers/utfgrid/">UTFGrid</a> tiles of

--- a/docs/_posts/api/0200-01-01-v2.1.0-all.html
+++ b/docs/_posts/api/0200-01-01-v2.1.0-all.html
@@ -123,7 +123,7 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;mapbox.streets&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>
 <h2 id="l-mapbox-gridlayer">L.mapbox.gridLayer(id|url|tilejson, options)</h2>
 <p>An <code><a href="#l-mapbox-gridlayer">L.mapbox.gridLayer</a></code> loads <a href="http://mapbox.com/developers/utfgrid/">UTFGrid</a> tiles of

--- a/docs/_posts/api/0200-01-01-v2.1.1-all.html
+++ b/docs/_posts/api/0200-01-01-v2.1.1-all.html
@@ -123,7 +123,7 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>
 <h2 id="l-mapbox-gridlayer">L.mapbox.gridLayer(id|url|tilejson, options)</h2>
 <p>An <code><a href="#l-mapbox-gridlayer">L.mapbox.gridLayer</a></code> loads <a href="http://mapbox.com/developers/utfgrid/">UTFGrid</a> tiles of

--- a/docs/_posts/api/0200-01-01-v2.1.2-all.html
+++ b/docs/_posts/api/0200-01-01-v2.1.2-all.html
@@ -123,7 +123,7 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>
 <h2 id="l-mapbox-gridlayer">L.mapbox.gridLayer(id|url|tilejson, options)</h2>
 <p>An <code><a href="#l-mapbox-gridlayer">L.mapbox.gridLayer</a></code> loads <a href="http://mapbox.com/developers/utfgrid/">UTFGrid</a> tiles of

--- a/docs/_posts/api/0200-01-01-v2.1.3-all.html
+++ b/docs/_posts/api/0200-01-01-v2.1.3-all.html
@@ -123,7 +123,7 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>
 <h2 id="l-mapbox-gridlayer">L.mapbox.gridLayer(id|url|tilejson, options)</h2>
 <p>An <code><a href="#l-mapbox-gridlayer">L.mapbox.gridLayer</a></code> loads <a href="http://mapbox.com/developers/utfgrid/">UTFGrid</a> tiles of

--- a/docs/_posts/api/0200-01-01-v2.1.4-all.html
+++ b/docs/_posts/api/0200-01-01-v2.1.4-all.html
@@ -123,7 +123,7 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>
 <h2 id="l-mapbox-gridlayer">L.mapbox.gridLayer(id|url|tilejson, options)</h2>
 <p>An <code><a href="#l-mapbox-gridlayer">L.mapbox.gridLayer</a></code> loads <a href="http://mapbox.com/developers/utfgrid/">UTFGrid</a> tiles of

--- a/docs/_posts/api/0200-01-01-v2.1.5-all.html
+++ b/docs/_posts/api/0200-01-01-v2.1.5-all.html
@@ -123,7 +123,7 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>
 <h2 id="l-mapbox-gridlayer">L.mapbox.gridLayer(id|url|tilejson, options)</h2>
 <p>An <code><a href="#l-mapbox-gridlayer">L.mapbox.gridLayer</a></code> loads <a href="http://mapbox.com/developers/utfgrid/">UTFGrid</a> tiles of

--- a/docs/_posts/api/0200-01-01-v2.1.6-all.html
+++ b/docs/_posts/api/0200-01-01-v2.1.6-all.html
@@ -123,7 +123,7 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>
 <h2 id="l-mapbox-gridlayer">L.mapbox.gridLayer(id|url|tilejson, options)</h2>
 <p>An <code><a href="#l-mapbox-gridlayer">L.mapbox.gridLayer</a></code> loads <a href="http://mapbox.com/developers/utfgrid/">UTFGrid</a> tiles of

--- a/docs/_posts/api/0200-01-01-v2.1.7-all.html
+++ b/docs/_posts/api/0200-01-01-v2.1.7-all.html
@@ -123,7 +123,7 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>
 <h2 id="l-mapbox-gridlayer">L.mapbox.gridLayer(id|url|tilejson, options)</h2>
 <p>An <code><a href="#l-mapbox-gridlayer">L.mapbox.gridLayer</a></code> loads <a href="http://mapbox.com/developers/utfgrid/">UTFGrid</a> tiles of

--- a/docs/_posts/api/0200-01-01-v2.1.8-all.html
+++ b/docs/_posts/api/0200-01-01-v2.1.8-all.html
@@ -123,7 +123,7 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>
 <h2 id="l-mapbox-gridlayer">L.mapbox.gridLayer(id|url|tilejson, options)</h2>
 <p>An <code><a href="#l-mapbox-gridlayer">L.mapbox.gridLayer</a></code> loads <a href="http://mapbox.com/developers/utfgrid/">UTFGrid</a> tiles of

--- a/docs/_posts/api/0200-01-01-v2.1.9-all.html
+++ b/docs/_posts/api/0200-01-01-v2.1.9-all.html
@@ -123,7 +123,7 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>
 <h2 id="l-mapbox-gridlayer">L.mapbox.gridLayer(id|url|tilejson, options)</h2>
 <p>An <code><a href="#l-mapbox-gridlayer">L.mapbox.gridLayer</a></code> loads <a href="http://mapbox.com/developers/utfgrid/">UTFGrid</a> tiles of

--- a/docs/_posts/api/0200-01-01-v2.2.0-all.html
+++ b/docs/_posts/api/0200-01-01-v2.2.0-all.html
@@ -123,7 +123,7 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;mapbox.streets&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>
 <h2 id="l-mapbox-gridlayer">L.mapbox.gridLayer(id|url|tilejson, options)</h2>
 <p>An <code><a href="#l-mapbox-gridlayer">L.mapbox.gridLayer</a></code> loads <a href="http://mapbox.com/developers/utfgrid/">UTFGrid</a> tiles of

--- a/docs/_posts/api/0200-01-01-v2.2.1-all.html
+++ b/docs/_posts/api/0200-01-01-v2.2.1-all.html
@@ -123,7 +123,7 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;mapbox.streets&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>
 <h2 id="l-mapbox-gridlayer">L.mapbox.gridLayer(id|url|tilejson, options)</h2>
 <p>An <code><a href="#l-mapbox-gridlayer">L.mapbox.gridLayer</a></code> loads <a href="http://mapbox.com/developers/utfgrid/">UTFGrid</a> tiles of

--- a/docs/_posts/api/0200-01-01-v2.2.2-all.html
+++ b/docs/_posts/api/0200-01-01-v2.2.2-all.html
@@ -123,7 +123,7 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;mapbox.streets&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>
 <h2 id="l-mapbox-gridlayer">L.mapbox.gridLayer(id|url|tilejson, options)</h2>
 <p>An <code><a href="#l-mapbox-gridlayer">L.mapbox.gridLayer</a></code> loads <a href="http://mapbox.com/developers/utfgrid/">UTFGrid</a> tiles of

--- a/docs/_posts/api/0200-01-01-v2.2.3-all.html
+++ b/docs/_posts/api/0200-01-01-v2.2.3-all.html
@@ -123,7 +123,7 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;mapbox.streets&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>
 <h2 id="l-mapbox-gridlayer">L.mapbox.gridLayer(id|url|tilejson, options)</h2>
 <p>An <code><a href="#l-mapbox-gridlayer">L.mapbox.gridLayer</a></code> loads <a href="http://mapbox.com/developers/utfgrid/">UTFGrid</a> tiles of

--- a/docs/_posts/api/0200-01-01-v2.2.4-all.html
+++ b/docs/_posts/api/0200-01-01-v2.2.4-all.html
@@ -123,7 +123,7 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;mapbox.streets&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>
 <h2 id="l-mapbox-gridlayer">L.mapbox.gridLayer(id|url|tilejson, options)</h2>
 <p>An <code><a href="#l-mapbox-gridlayer">L.mapbox.gridLayer</a></code> loads <a href="http://mapbox.com/developers/utfgrid/">UTFGrid</a> tiles of

--- a/docs/_posts/api/0200-01-01-v2.3.0-all.html
+++ b/docs/_posts/api/0200-01-01-v2.3.0-all.html
@@ -123,7 +123,7 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;mapbox.streets&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>
 <h2 id="l-mapbox-gridlayer">L.mapbox.gridLayer(id|url|tilejson, options)</h2>
 <p>An <code><a href="#l-mapbox-gridlayer">L.mapbox.gridLayer</a></code> loads <a href="http://mapbox.com/developers/utfgrid/">UTFGrid</a> tiles of

--- a/docs/_posts/api/0200-01-01-v2.4.0-all.html
+++ b/docs/_posts/api/0200-01-01-v2.4.0-all.html
@@ -123,7 +123,7 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;mapbox.streets&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>
 <h2 id="l-mapbox-gridlayer">L.mapbox.gridLayer(id|url|tilejson, options)</h2>
 <p>An <code><a href="#l-mapbox-gridlayer">L.mapbox.gridLayer</a></code> loads <a href="http://mapbox.com/developers/utfgrid/">UTFGrid</a> tiles of

--- a/docs/_posts/api/0200-01-01-v3.0.0-all.html
+++ b/docs/_posts/api/0200-01-01-v3.0.0-all.html
@@ -123,7 +123,7 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;mapbox.streets&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>
 <h2 id="l-mapbox-gridlayer">L.mapbox.gridLayer(id|url|tilejson, options)</h2>
 <p>An <code><a href="#l-mapbox-gridlayer">L.mapbox.gridLayer</a></code> loads <a href="http://mapbox.com/developers/utfgrid/">UTFGrid</a> tiles of

--- a/docs/_posts/api/0200-01-01-v3.0.1-all.html
+++ b/docs/_posts/api/0200-01-01-v3.0.1-all.html
@@ -123,7 +123,7 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;mapbox.streets&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>
 <h2 id="l-mapbox-gridlayer">L.mapbox.gridLayer(id|url|tilejson, options)</h2>
 <p>An <code><a href="#l-mapbox-gridlayer">L.mapbox.gridLayer</a></code> loads <a href="http://mapbox.com/developers/utfgrid/">UTFGrid</a> tiles of

--- a/docs/_posts/api/0200-01-01-v3.1.0-all.html
+++ b/docs/_posts/api/0200-01-01-v3.1.0-all.html
@@ -123,7 +123,7 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;mapbox.streets&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>
 <h2 id="l-mapbox-gridlayer">L.mapbox.gridLayer(id|url|tilejson, options)</h2>
 <p>An <code><a href="#l-mapbox-gridlayer">L.mapbox.gridLayer</a></code> loads <a href="http://mapbox.com/developers/utfgrid/">UTFGrid</a> tiles of

--- a/docs/_posts/api/0200-01-01-v3.1.1-all.html
+++ b/docs/_posts/api/0200-01-01-v3.1.1-all.html
@@ -123,7 +123,7 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;mapbox.streets&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>
 <h2 id="l-mapbox-gridlayer">L.mapbox.gridLayer(id|url|tilejson, options)</h2>
 <p>An <code><a href="#l-mapbox-gridlayer">L.mapbox.gridLayer</a></code> loads <a href="http://mapbox.com/developers/utfgrid/">UTFGrid</a> tiles of

--- a/docs/_posts/api/0200-01-01-v3.2.0-all.html
+++ b/docs/_posts/api/0200-01-01-v3.2.0-all.html
@@ -123,7 +123,7 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;mapbox.streets&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>
 <h2 id="l-mapbox-gridlayer">L.mapbox.gridLayer(id|url|tilejson, options)</h2>
 <p>An <code><a href="#l-mapbox-gridlayer">L.mapbox.gridLayer</a></code> loads <a href="http://mapbox.com/developers/utfgrid/">UTFGrid</a> tiles of

--- a/docs/_posts/api/0200-01-01-v3.2.1-all.html
+++ b/docs/_posts/api/0200-01-01-v3.2.1-all.html
@@ -113,7 +113,7 @@ in order to load maps faster</p>
 // internet connections
 var layer = L.mapbox.tileLayer(&#39;mapbox.streets&#39;, {
     format: &#39;jpg70&#39;
-});</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+});</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>
 <h2 id="l-mapbox-gridlayer">L.mapbox.gridLayer(id|url|tilejson, options)</h2>
 <p>An <code><a href="#l-mapbox-gridlayer">L.mapbox.gridLayer</a></code> loads <a href="http://mapbox.com/developers/utfgrid/">UTFGrid</a> tiles of

--- a/docs/_posts/api/v2.0.0/0200-01-01-l-mapbox-tilelayer.html
+++ b/docs/_posts/api/v2.0.0/0200-01-01-l-mapbox-tilelayer.html
@@ -76,5 +76,5 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;mapbox.streets&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>

--- a/docs/_posts/api/v2.0.1/0200-01-01-l-mapbox-tilelayer.html
+++ b/docs/_posts/api/v2.0.1/0200-01-01-l-mapbox-tilelayer.html
@@ -76,5 +76,5 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;mapbox.streets&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>

--- a/docs/_posts/api/v2.1.0/0200-01-01-l-mapbox-tilelayer.html
+++ b/docs/_posts/api/v2.1.0/0200-01-01-l-mapbox-tilelayer.html
@@ -76,5 +76,5 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;mapbox.streets&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>

--- a/docs/_posts/api/v2.1.1/0200-01-01-l-mapbox-tilelayer.html
+++ b/docs/_posts/api/v2.1.1/0200-01-01-l-mapbox-tilelayer.html
@@ -76,5 +76,5 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>

--- a/docs/_posts/api/v2.1.2/0200-01-01-l-mapbox-tilelayer.html
+++ b/docs/_posts/api/v2.1.2/0200-01-01-l-mapbox-tilelayer.html
@@ -76,5 +76,5 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>

--- a/docs/_posts/api/v2.1.3/0200-01-01-l-mapbox-tilelayer.html
+++ b/docs/_posts/api/v2.1.3/0200-01-01-l-mapbox-tilelayer.html
@@ -76,5 +76,5 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>

--- a/docs/_posts/api/v2.1.4/0200-01-01-l-mapbox-tilelayer.html
+++ b/docs/_posts/api/v2.1.4/0200-01-01-l-mapbox-tilelayer.html
@@ -76,5 +76,5 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>

--- a/docs/_posts/api/v2.1.5/0200-01-01-l-mapbox-tilelayer.html
+++ b/docs/_posts/api/v2.1.5/0200-01-01-l-mapbox-tilelayer.html
@@ -76,5 +76,5 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>

--- a/docs/_posts/api/v2.1.6/0200-01-01-l-mapbox-tilelayer.html
+++ b/docs/_posts/api/v2.1.6/0200-01-01-l-mapbox-tilelayer.html
@@ -76,5 +76,5 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>

--- a/docs/_posts/api/v2.1.7/0200-01-01-l-mapbox-tilelayer.html
+++ b/docs/_posts/api/v2.1.7/0200-01-01-l-mapbox-tilelayer.html
@@ -76,5 +76,5 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>

--- a/docs/_posts/api/v2.1.8/0200-01-01-l-mapbox-tilelayer.html
+++ b/docs/_posts/api/v2.1.8/0200-01-01-l-mapbox-tilelayer.html
@@ -76,5 +76,5 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>

--- a/docs/_posts/api/v2.1.9/0200-01-01-l-mapbox-tilelayer.html
+++ b/docs/_posts/api/v2.1.9/0200-01-01-l-mapbox-tilelayer.html
@@ -76,5 +76,5 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;examples.map-20v6611k&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>

--- a/docs/_posts/api/v2.2.0/0200-01-01-l-mapbox-tilelayer.html
+++ b/docs/_posts/api/v2.2.0/0200-01-01-l-mapbox-tilelayer.html
@@ -76,5 +76,5 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;mapbox.streets&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>

--- a/docs/_posts/api/v2.2.1/0200-01-01-l-mapbox-tilelayer.html
+++ b/docs/_posts/api/v2.2.1/0200-01-01-l-mapbox-tilelayer.html
@@ -76,5 +76,5 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;mapbox.streets&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>

--- a/docs/_posts/api/v2.2.2/0200-01-01-l-mapbox-tilelayer.html
+++ b/docs/_posts/api/v2.2.2/0200-01-01-l-mapbox-tilelayer.html
@@ -76,5 +76,5 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;mapbox.streets&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>

--- a/docs/_posts/api/v2.2.3/0200-01-01-l-mapbox-tilelayer.html
+++ b/docs/_posts/api/v2.2.3/0200-01-01-l-mapbox-tilelayer.html
@@ -76,5 +76,5 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;mapbox.streets&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>

--- a/docs/_posts/api/v2.2.4/0200-01-01-l-mapbox-tilelayer.html
+++ b/docs/_posts/api/v2.2.4/0200-01-01-l-mapbox-tilelayer.html
@@ -76,5 +76,5 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;mapbox.streets&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>

--- a/docs/_posts/api/v2.3.0/0200-01-01-l-mapbox-tilelayer.html
+++ b/docs/_posts/api/v2.3.0/0200-01-01-l-mapbox-tilelayer.html
@@ -76,5 +76,5 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;mapbox.streets&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>

--- a/docs/_posts/api/v2.4.0/0200-01-01-l-mapbox-tilelayer.html
+++ b/docs/_posts/api/v2.4.0/0200-01-01-l-mapbox-tilelayer.html
@@ -76,5 +76,5 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;mapbox.streets&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>

--- a/docs/_posts/api/v3.0.0/0200-01-01-l-mapbox-tilelayer.html
+++ b/docs/_posts/api/v3.0.0/0200-01-01-l-mapbox-tilelayer.html
@@ -76,5 +76,5 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;mapbox.streets&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>

--- a/docs/_posts/api/v3.0.1/0200-01-01-l-mapbox-tilelayer.html
+++ b/docs/_posts/api/v3.0.1/0200-01-01-l-mapbox-tilelayer.html
@@ -76,5 +76,5 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;mapbox.streets&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>

--- a/docs/_posts/api/v3.1.0/0200-01-01-l-mapbox-tilelayer.html
+++ b/docs/_posts/api/v3.1.0/0200-01-01-l-mapbox-tilelayer.html
@@ -76,5 +76,5 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;mapbox.streets&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>

--- a/docs/_posts/api/v3.1.1/0200-01-01-l-mapbox-tilelayer.html
+++ b/docs/_posts/api/v3.1.1/0200-01-01-l-mapbox-tilelayer.html
@@ -76,5 +76,5 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;mapbox.streets&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>

--- a/docs/_posts/api/v3.2.0/0200-01-01-l-mapbox-tilelayer.html
+++ b/docs/_posts/api/v3.2.0/0200-01-01-l-mapbox-tilelayer.html
@@ -76,5 +76,5 @@ in order to load maps faster</p>
 var layer = L.mapbox.tileLayer(&#39;mapbox.streets&#39;, {
     format: &#39;jpg70&#39;
 });
-</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>

--- a/docs/_posts/api/v3.2.1/0200-01-01-l-mapbox-tilelayer.html
+++ b/docs/_posts/api/v3.2.1/0200-01-01-l-mapbox-tilelayer.html
@@ -69,5 +69,5 @@ in order to load maps faster</p>
 // internet connections
 var layer = L.mapbox.tileLayer(&#39;mapbox.streets&#39;, {
     format: &#39;jpg70&#39;
-});</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/tilelayer-setformat/">Live example of .setFormat in use</a></p>
+});</code></pre><p><a href="https://www.mapbox.com/mapbox.js/example/tilelayer-setformat/">Live example of .setFormat in use</a></p>
 <p><em>Returns</em>: the layer object</p>


### PR DESCRIPTION
This PR updates the link paths to /tilelayer-setformat/ so that it can redirect properly.

Resolves DOCS-SUBDOMAIN-404-2K

Fixes https://github.com/mapbox/mapbox.js/issues/1253