### PR TITLE
Resolve console warnings

### DIFF
--- a/src/format_url.js
+++ b/src/format_url.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var config = require('./config'),
-    warn = require('./util').warn,
     version = require('../package.json').version;
 
 module.exports = function(path, accessToken) {
@@ -36,15 +35,12 @@ module.exports.tileJSON = function(urlOrMapID, accessToken) {
             'L.mapbox.styleLayer, not L.mapbox.tileLayer');
     }
 
-    if (urlOrMapID.indexOf('/') !== -1)
-        return urlOrMapID;
+    if (urlOrMapID.indexOf('/') !== -1) return urlOrMapID;
 
     var url;
     if (urlOrMapID in config.TEMPLATE_STYLES) {
-        url = module.exports('/styles/v1/' + config.TEMPLATE_STYLES[urlOrMapID], accessToken); 
+        url = module.exports('/styles/v1/' + config.TEMPLATE_STYLES[urlOrMapID], accessToken);
     } else {
-        warn('Warning: this implementation is loading a Mapbox Studio Classic style (' + urlOrMapID + '). ' +
-            'Studio Classic styles are scheduled for deprecation: https://blog.mapbox.com/deprecating-studio-classic-styles-c65a744140a6');
         url = module.exports('/v4/' + urlOrMapID + '.json', accessToken);
     }
 

--- a/src/load_tilejson.js
+++ b/src/load_tilejson.js
@@ -7,9 +7,13 @@ var request = require('./request'),
 module.exports = {
     _loadTileJSON: function(_) {
         if (typeof _ === 'string') {
+            var style = _;
             _ = format_url.tileJSON(_, this.options && this.options.accessToken);
             var isGLStyle = _.indexOf('/styles/v1/') !== -1;
-            
+            if (!isGLStyle) {
+                util.warn('Warning: this implementation is loading a Mapbox Studio Classic style (' + style + '). ' +
+                    'Studio Classic styles are scheduled for deprecation: https://blog.mapbox.com/deprecating-studio-classic-styles-c65a744140a6')
+            }
             request(_, L.bind(function(err, json) {
                 if (err) {
                     util.log('could not load TileJSON at ' + _);

--- a/src/map.js
+++ b/src/map.js
@@ -210,7 +210,7 @@ var LMap = L.Map.extend({
         // ensure logo appears even when mapbox layer added after map is initialized
         var mapboxLogoControl = this._mapboxLogoControl.getContainer();
         if (!L.DomUtil.hasClass(mapboxLogoControl, 'mapbox-logo-true')) {
-            var tileJSON = layer.getTileJSON();
+            var tileJSON = layer._tilejson;
             this._mapboxLogoControl._setTileJSON(tileJSON);
         }
 


### PR DESCRIPTION
Fixes #1327 

### Changes
- Only returns console warning about deprecated Studio Classic styles for non-GL styles
- Fixes type error `t.getTileJSON is not a function`. 

Checked all the manual test pages (that are still working), and the console warnings look like what we'd expect.

I think there was also a regression where the mapbox logo was not being added to maps referencing GL style layers. Now the mapbox logo should be added for all mapbox styles. I tried adding a test for this but haven't been successful. Maybe someone more familiar with this codebase has suggestions :)

cc @mapbox/static-apis @katydecorah 