### PR TITLE
docs: Fix simple typo, asscociated -> associated

### DIFF
--- a/src/mapbox_logo.js
+++ b/src/mapbox_logo.js
@@ -17,7 +17,7 @@ var MapboxLogoControl = L.Control.extend({
 
     _setTileJSON: function(json) {
         // Check if account referenced by the accessToken
-        // is asscociated with the Mapbox Logo
+        // is associated with the Mapbox Logo
         // as determined by mapbox-maps.
         if (json.mapbox_logo) {
             L.DomUtil.addClass(this._container, 'mapbox-logo-true');


### PR DESCRIPTION
There is a small typo in src/mapbox_logo.js.

Should read `associated` rather than `asscociated`.

