### PR TITLE
Migrate to Travis CI .com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mapbox.js
 
-[![Build Status](https://travis-ci.org/mapbox/mapbox.js.svg?branch=publisher-production)](https://travis-ci.org/mapbox/mapbox.js)
+[![Build Status](https://travis-ci.com/mapbox/mapbox.js.svg?branch=publisher-production)](https://travis-ci.com/mapbox/mapbox.js)
 
 A Mapbox plugin for [Leaflet](http://leafletjs.com/), a lightweight JavaScript library for traditional raster maps.
 


### PR DESCRIPTION
I've been working through the list of docs sites that are still on Travis org and this site is one of them. I migrated this repo to Travis CI .com and as a last step, this PR updates the badge in the README.