### PR TITLE
remove L.mapbox.template from v3.3.1 nav

### DIFF
--- a/docs/_posts/api/0200-01-01-v3.3.1-all.html
+++ b/docs/_posts/api/0200-01-01-v3.3.1-all.html
@@ -817,30 +817,7 @@ options object formatted to be used as <a href="http://leafletjs.com/reference.h
 <td>String of content you wish to sanitize.</td>
 </tr>
 </tbody></table>
-<h2 id="l-mapbox-template">L.mapbox.template(template, data)</h2>
-<p>A <a href="http://mustache.github.io/">mustache</a> template rendering function, as used by the templating feature provided by <code><a href="#l-mapbox-gridcontrol">L.mapbox.gridControl</a></code>.</p>
-<table>
-<thead>
-<tr>
-<th>Options</th>
-<th>Value</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody><tr>
-<td>template</td>
-<td>string</td>
-<td>The template string</td>
-</tr>
-<tr>
-<td>data</td>
-<td>object</td>
-<td>Data you wish to pass into the template string</td>
-</tr>
-</tbody></table>
-<p><em>Example</em>:</p>
-<pre><code>var output = L.mapbox.template(&#39;Name: {% raw %}{{name}}{% endraw %}&#39;, {name: &#39;John&#39;});
-// output is &quot;Name: John&quot;</code></pre><h1 id="configuration">Configuration</h1>
+<h1 id="configuration">Configuration</h1>
 <h2 id="l-mapbox-accesstoken">L.mapbox.accessToken</h2>
 <p>The API access token to be used by Mapbox.js. You must set this value as described
 in <a href="../api-access-tokens">API access tokens</a>.</p>

--- a/docs/_posts/api/0200-01-01-v3.3.1.html
+++ b/docs/_posts/api/0200-01-01-v3.3.1.html
@@ -116,9 +116,6 @@ navigation:
     - title: "L.mapbox.sanitize"
       id: l-mapbox-sanitize
       nav:
-    - title: "L.mapbox.template"
-      id: l-mapbox-template
-      nav:
   - title: "Configuration"
     id: configuration
     nav:


### PR DESCRIPTION
We recently did a sweep and removed any deprecated API usage from the API documentation (ref. https://github.com/mapbox/mapbox.js/pull/1346). However, in that sweep we missed removing references to `L.mapbox.template` from the main navigation menu.

Resolves #1347

cc/ @danswick @mapbox/static-apis﻿
