### PR TITLE
A banner pointing to Mapbox GL JS

### DIFF
--- a/docs/_layouts/pages.html
+++ b/docs/_layouts/pages.html
@@ -90,9 +90,8 @@ examples:
   <div class="pad2y">
     <div class="margin3 col9 keyline-all round space-bottom contain fill-orange">
       <div class="contain pad2 fill-lighten3">
-        <h3>Looking for Mapbox GL JS?</h3>
-        <p class="prose"><a href="https://docs.mapbox.com/mapbox-gl-js/">Mapbox GL JS</a> is our modern client-side JavaScript library for building web maps and web applications. Read the <a href="https://docs.mapbox.com/mapbox-gl-js/guides/">guide</a>, <a href="https://docs.mapbox.com/mapbox-gl-js/api/">API reference</a>, and <a href="https://docs.mapbox.com/mapbox-gl-js/example/">examples</a>.</p>
-        <p class="prose"><b><em>Continue on this page for documentation on our legacy library, Mapbox.js</em></b></p>
+        <h3>Legacy</h3>
+        <p class="prose">Mapbox.js is no longer in active development. To learn more about our newer mapping tools see <a href="https://docs.mapbox.com/mapbox-gl-js/">Mapbox GL JS.</a></p>
       </div>
     </div>
   </div>

--- a/docs/_layouts/pages.html
+++ b/docs/_layouts/pages.html
@@ -86,6 +86,17 @@ examples:
 </div>
 
 <div class='limiter clearfix'>
+
+  <div class="pad2y">
+    <div class="margin3 col9 keyline-all round space-bottom contain fill-orange">
+      <div class="contain pad2 fill-lighten3">
+        <h3>Looking for Mapbox GL JS?</h3>
+        <p class="prose"><a href="https://docs.mapbox.com/mapbox-gl-js/">Mapbox GL JS</a> is our modern client-side JavaScript library for building web maps and web applications. Read the <a href="https://docs.mapbox.com/mapbox-gl-js/guides/">guide</a>, <a href="https://docs.mapbox.com/mapbox-gl-js/api/">API reference</a>, and <a href="https://docs.mapbox.com/mapbox-gl-js/example/">examples</a>.</p>
+        <p class="prose"><b><em>Continue on this page for documentation on our legacy library, Mapbox.js</em></b></p>
+      </div>
+    </div>
+  </div>
+
   <div class='pad2y'>
     <nav class='contain z10 margin3 col9 fill-green space-bottom round small'>
       <div class='col3 dark round-left keyline-right pad2y pad1x center truncate'>


### PR DESCRIPTION
Customers continue to be confused when they reach our Mapbox.JS documentation (primarily though searches), when their intention was to find our most current library GL JS.

This PR adds a banner to all Mapbox.JS pages

![image](https://user-images.githubusercontent.com/22896/173437765-48a16542-a50b-447a-a212-73fd1d3d1829.png)

@geografa would appreciate input from Support on the best way to frame this, and feedback on whether this is too heavy a touch or an ok presentation.